### PR TITLE
Add config-merge plugin

### DIFF
--- a/plugins/config-merge.yaml
+++ b/plugins/config-merge.yaml
@@ -14,7 +14,7 @@ spec:
   description: This plugin helps you to merge multiple kubeconfig files. Run `kubectl config-merge` for usage.
   platforms:
   - uri: https://github.com/kairen/kubectl-config-merge/releases/download/v0.1.0/kubectl-config_merge-darwin-amd64.tar.gz
-    sha256: e765e5ec650b28808e7d9b35da8316574181bf7c8655ec67f660935335c2468d
+    sha256: 1e6815d09898e77ac49e96169f1f142c087e977c71ea7085fb25c6d367a72202
     bin: config-merge
     files:
     - from: "*"
@@ -24,7 +24,7 @@ spec:
         os: darwin
         arch: amd64
   - uri: https://github.com/kairen/kubectl-config-merge/releases/download/v0.1.0/kubectl-config_merge-linux-amd64.tar.gz
-    sha256: bb205341b4a2ea28e3eed9430033c8c99b64fbf438266cb78593ed65ec00c1df
+    sha256: 0f7851eb5e5b7d72f6a2bc23e96dd6c5439b7475873aed7d55106cb388aded57
     bin: config-merge
     files:
     - from: "*"
@@ -34,7 +34,7 @@ spec:
         os: linux
         arch: amd64
   - uri: https://github.com/kairen/kubectl-config-merge/releases/download/v0.1.0/kubectl-config_merge-windows-amd64.tar.gz
-    sha256: 8a32aa19317f6b2b5fa360d4762ee0f3cadada1072af7c7f4444f51cb377b05c
+    sha256: 9484af211d4ab7b1136cd178dda835dbe0781bf8199447918eae24f9d3953fb6
     bin: config-merge.exe
     files:
     - from: "*"

--- a/plugins/config-merge.yaml
+++ b/plugins/config-merge.yaml
@@ -1,0 +1,45 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: config-merge
+spec:
+  version: v0.1.0
+  caveats: |
+    Usage:
+      kubectl config-merge KUBECONFIG1 KUBECONFIG2 ... [flags]
+    
+    Read the documentation at:
+      https://github.com/kairen/kubectl-config-merge
+  shortDescription: Merge two or more kubeconfig files.
+  description: This plugin helps you to merge multiple kubeconfig files. Run `kubectl config-merge` for usage.
+  platforms:
+  - uri: https://github.com/kairen/kubectl-config-merge/releases/download/v0.1.0/kubectl-config_merge-darwin-amd64.tar.gz
+    sha256: e765e5ec650b28808e7d9b35da8316574181bf7c8655ec67f660935335c2468d
+    bin: config-merge
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/kairen/kubectl-config-merge/releases/download/v0.1.0/kubectl-config_merge-linux-amd64.tar.gz
+    sha256: bb205341b4a2ea28e3eed9430033c8c99b64fbf438266cb78593ed65ec00c1df
+    bin: config-merge
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - uri: https://github.com/kairen/kubectl-config-merge/releases/download/v0.1.0/kubectl-config_merge-windows-amd64.tar.gz
+    sha256: 8a32aa19317f6b2b5fa360d4762ee0f3cadada1072af7c7f4444f51cb377b05c
+    bin: config-merge.exe
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64


### PR DESCRIPTION
Adds the config-merge plugin seen [here](https://github.com/kairen/kubectl-config-merge#kubectl-config-merge). Its usage as below:

```
$ k config-merge -h
Merge two or more kubeconfig files

Usage:
  config-merge [kubeconfig] [flags]

Examples:

	# Merge your kubeconfig and save it as "merge-config" in the current directory
	kubectl config-merge kubeconfig1 kubeconfig2 ...

	# Merge your kubeconfig and save it as "config" in "test" directory
	kubectl config-merge kubeconfig1 kubeconfig2 ... --path test/config

	# Merge your kubeconfig with $HOME/.kube/config as "$HOME/.kube/config"
	kubectl config-merge kubeconfig1 ... --home

	# To view merged kubeconfig result
	kubectl config-merge kubeconfig1 kubeconfig2 ... --view


Flags:
      --backup          If true, backup $HOME/.kube/config file to $HOME/.kube/config.bk (default true)
  -h, --help            help for config-merge
      --home            If true, merge with $HOME/.kube/config to $HOME/.kube/config
  -o, --output string   Merged kubeconfig output type(json or yaml) (default "yaml")
      --overwrite       If true, force merge kubeconfig
      --path string     Merged kubeconfig output name and path (default "merge-config")
      --version         Show config-merge version
      --view            View merged kubeconfig result 
```

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
