### PR TITLE
New plugin: gke-exec-credential

### DIFF
--- a/plugins/tmp/gke-exec-credential.yaml
+++ b/plugins/tmp/gke-exec-credential.yaml
@@ -1,0 +1,37 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gke-exec-credential
+spec:
+  version: v1.0.0
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+          - linux
+          - darwin
+    uri: https://github.com/jglick/gke-exec-credential/archive/v1.0.0.zip
+    sha256: 6f01ddae4476c915b33c54f0642d8c9d0ff7b6b4cca0a19562bbb015b5b6a7ee
+    files:
+    - from: /*/run.sh
+      to: .
+    bin: run.sh
+  shortDescription: Allows the ExecCredential system to be used to authenticate to Google Kubernetes Engine.
+  homepage: https://github.com/jglick/gke-exec-credential
+  caveats: |-
+    This plugin needs the following programs:
+    * gcloud
+    * jq
+    See: https://github.com/jglick/gke-exec-credential
+  description: |-
+    Can authenticate to GKE in your ~/.kube/config:
+    users:
+    - name: gke
+      user:
+        exec:
+          apiVersion: client.authentication.k8s.io/v1beta1
+          command: kubectl
+          args:
+          - gke-exec-credential


### PR DESCRIPTION
https://github.com/jglick/gke-exec-credential/blob/master/README.md#gke-exec-credential and see https://github.com/kubernetes/kubernetes/issues/62185

-----

**Checklist for plugin developers:**

- [X] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [X] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
