### PR TITLE
Unify license headers

### DIFF
--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -1,17 +1,3 @@
-# Copyright © 2018 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:

--- a/plugins/rbac-view.yaml
+++ b/plugins/rbac-view.yaml
@@ -1,17 +1,3 @@
-# Copyright © 2018 Google Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:

--- a/plugins/sudo.yaml
+++ b/plugins/sudo.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:


### PR DESCRIPTION
The new copyright header is "# Copyright © 2019 The Kubernetes Authors" for
plugin manifests, although I'm not sure if manifest files are treated as code
in this case.

At any rate, I'm still figuring out how to actually test for presence and
correctness of the license headers as part of CI.

/assign @nikhita