### PR TITLE
Update exec-as plugin

### DIFF
--- a/plugins/exec-as.yaml
+++ b/plugins/exec-as.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   platforms:
   - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
-    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
-    sha256: efa1c2122ecaeb0a43ba1ed9e54c1ff1274d20de76934f7bb91dd154f2327aa1
+    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.1-krew.zip
+    sha256: f6dc82bc8c00d31e4a08a82513d83ff1cb0f21323f8ab1011b2031863603183f
     bin: kubectl-exec-as
     files:
     - from: "**/kubectl-exec-as"
@@ -14,7 +14,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "v1.0.0-krew"
+  version: "v1.0.1-krew"
   caveats: The node which the pod is running on cannot have more than one taint.
   homepage: https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-exec-as
   shortDescription: Like kubectl exec, but offers a `user` flag to exec as root or any other user.


### PR DESCRIPTION
Updates the exec-as plugin:

Removes the namespace lookup in the exec-as-plugin. Because the plugin does not currently allow traversing namespaces, this is unnecessary and has resulted in an error in some edge-case scenarios.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
