### PR TITLE
Add oidc-login plugin

### DIFF
--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -1,0 +1,57 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: oidc-login
+spec:
+  shortDescription: Login for OpenID Connect authentication
+  description: |
+    This plugin gets a token from the OIDC provider and writes it to the kubeconfig.
+
+    Just run:
+      % kubectl oidc-login
+
+    It opens the browser and you can log in to the provider.
+    After authentication, it gets an ID token and refresh token and writes them to the kubeconfig.
+
+  caveats: |
+    You need to setup the following components:
+      * OIDC provider
+      * Kubernetes API server
+      * Role for your group or user
+      * kubectl authentication
+
+    See https://github.com/int128/kubelogin for more.
+
+  homepage: https://github.com/int128/kubelogin
+  version: v1.9.1
+  platforms:
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.9.1/kubelogin_linux_amd64.zip
+      sha256: "634b5bfcd72b11f0c70a13ab4064b91b68d9079b2f23b1279520d79d8225b51e"
+      bin: kubelogin
+      files:
+        - from: "kubelogin"
+          to: "."
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.9.1/kubelogin_darwin_amd64.zip
+      sha256: "757c6bcc997fb3146b40de8b3633e51a78dd42c45f6242e0f5bae488e16fee2f"
+      bin: kubelogin
+      files:
+        - from: "kubelogin"
+          to: "."
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.9.1/kubelogin_windows_amd64.zip
+      sha256: "01ee7c8ed08d513bdab127c72968af4f64d107bc98b3cccc87669b0bb46b099d"
+      bin: kubelogin.exe
+      files:
+        - from: "kubelogin.exe"
+          to: "."
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64


### PR DESCRIPTION
This adds the [oidc-login](https://github.com/int128/kubelogin) plugin.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
