### PR TITLE
Update plugin "access-matrix" to v0.2.1

### DIFF
--- a/plugins/access-matrix.yaml
+++ b/plugins/access-matrix.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: access-matrix
 spec:
-  version: "v0.2.0"
+  version: "v0.2.1"
   platforms:
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.2.0/bundle.tar.gz
-      sha256: 649d830449ad958b86e701f6375aad88a96e184d12d252bf2a38f29dfcbe1a57
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.2.1/bundle.tar.gz
+      sha256: a09c0597c96e008147ae1a120b16690a1401dfd243c6c5629ba396a34797d1f0
       bin: rakkess-linux-amd64
       files:
         - from: ./rakkess-linux-amd64
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.2.0/bundle.tar.gz
-      sha256: 649d830449ad958b86e701f6375aad88a96e184d12d252bf2a38f29dfcbe1a57
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.2.1/bundle.tar.gz
+      sha256: a09c0597c96e008147ae1a120b16690a1401dfd243c6c5629ba396a34797d1f0
       bin: rakkess-darwin-amd64
       files:
         - from: ./rakkess-darwin-amd64
@@ -25,8 +25,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.2.0/bundle.tar.gz
-      sha256: 649d830449ad958b86e701f6375aad88a96e184d12d252bf2a38f29dfcbe1a57
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.2.1/bundle.tar.gz
+      sha256: a09c0597c96e008147ae1a120b16690a1401dfd243c6c5629ba396a34797d1f0
       bin: rakkess-windows-amd64.exe
       files:
         - from: ./rakkess-windows-amd64
@@ -42,7 +42,7 @@ spec:
         kubectl access-matrix
 
       Documentation:
-        https://github.com/corneliusweig/rakkess/blob/v0.2.0/doc/USAGE.md#usage
+        https://github.com/corneliusweig/rakkess/blob/v0.2.1/doc/USAGE.md#usage
   description: |+2
 
       Show an access matrix for all server resources
@@ -52,4 +52,4 @@ spec:
       This complements the usual "kubectl auth can-i" command, which works for
       a single resource and a single verb.
 
-      More on https://github.com/corneliusweig/rakkess/blob/v0.2.0/doc/USAGE.md#usage
+      More on https://github.com/corneliusweig/rakkess/blob/v0.2.1/doc/USAGE.md#usage


### PR DESCRIPTION
Release notes https://github.com/corneliusweig/rakkess/releases/tag/v0.2.1

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
