### PR TITLE
Bump version of oidc-login to v1.10.0

### DIFF
--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -23,10 +23,10 @@ spec:
     See https://github.com/int128/kubelogin for more.
 
   homepage: https://github.com/int128/kubelogin
-  version: v1.9.1
+  version: v1.10.0
   platforms:
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.9.1/kubelogin_linux_amd64.zip
-      sha256: "634b5bfcd72b11f0c70a13ab4064b91b68d9079b2f23b1279520d79d8225b51e"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.10.0/kubelogin_linux_amd64.zip
+      sha256: "6cd42c549a516043bca95a1def20ea37bc4fce11acda1a1c598e08d3c62e1482"
       bin: kubelogin
       files:
         - from: "kubelogin"
@@ -35,8 +35,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.9.1/kubelogin_darwin_amd64.zip
-      sha256: "757c6bcc997fb3146b40de8b3633e51a78dd42c45f6242e0f5bae488e16fee2f"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.10.0/kubelogin_darwin_amd64.zip
+      sha256: "3ef8999504007b4bba93c69b548b83fa44f2151078ead8242be6a6fcdc7b916b"
       bin: kubelogin
       files:
         - from: "kubelogin"
@@ -45,8 +45,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.9.1/kubelogin_windows_amd64.zip
-      sha256: "01ee7c8ed08d513bdab127c72968af4f64d107bc98b3cccc87669b0bb46b099d"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.10.0/kubelogin_windows_amd64.zip
+      sha256: "6f0c316f639625521ff3a6a134ceded583579699c00fc7f54ce04aad527a3134"
       bin: kubelogin.exe
       files:
         - from: "kubelogin.exe"


### PR DESCRIPTION
This updates the version of [oidc-login](https://github.com/int128/kubelogin) to v1.10.0.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
