### PR TITLE
Add kubectl-grep

### DIFF
--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -36,15 +36,57 @@ spec:
         arch: amd64
   version: v1.1.0
   homepage: https://github.com/guessi/kubectl-grep
-  caveats: This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
+  caveats: |
+    This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
+
+    Usage:
+
+      $ kubectl grep # output help messages
+      $ kubectl grep pods keyword
+      $ kubectl grep deployments keyword
+      $ kubectl grep pods keyword -n namespace
+      $ kubectl grep pods keyword --all-namespaces
+
+    More Info:
+    - https://github.com/guessi/kubectl-grep
+    Bug report:
+    - https://github.com/guessi/kubectl-grep/issues
+    Changelog:
+    - https://github.com/guessi/kubectl-grep/blob/master/CHANGELOG.md
   shortDescription: Search Kubernetes resources with keyword
   description: |
-    Search Kubernetes resources with keyword
+    Search Kubernetes resources with keyword, and namespace supported
 
     From ...
-    * kubectl get -n namespace [deployments|pods|...] | grep "keyword" # no Header output
+    $ kubectl get -n namespace [resourceType] | grep 'keyword'
 
     To ...
-    * kubectl grep -n namespace [deployments|pods|...] keyword
+    $ kubectl grep [resourceType] [keyword]
+
+    Supported Resource Types:
+    - daemonset
+    - deployment
+    - hpa
+    - node
+    - pod
+
+    For example, to list all pods in all namespaces,
+
+    $ kubectl grep pods --all-namespaces
+
+    NAMESPACE     NAME                           READY   STATUS     RESTART   AGE
+    star-lab      the-flash-1563321660-bm225     1/1     Running    0         2d13h
+    marvel        spider-man-564d97dc9c-65mvw    1/1     Running    0         7d22h
+    dc            super-man-bb58c6784-26bmr      1/1     Running    0         1d3h
+
+    Or list all pods with specific keyword, under specific namespace,
+
+    $ kubectl grep pods -n star-lab flash
+
+    NAMESPACE     NAME                           READY   STATUS     RESTART   AGE
+    star-lab      the-flash-1563321660-bm225     1/1     Running    0         2d13h
+
+    To support more type of resources, it is always welcome to open a pull-request
+    - https://github.com/guessi/kubectl-grep/pulls
 
     No more pipe, built-in grep :-)

--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -69,11 +69,9 @@ spec:
     Examples:
 
     List all pods in all namespaces
-
     $ kubectl grep pods --all-namespaces
 
-    Shows all pods in namespace "star-lab" which contain the keyword "flash"
-
+    List all pods in namespace "star-lab" which contain the keyword "flash"
     $ kubectl grep pods -n star-lab flash
 
     No more pipe, built-in grep :-)

--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -49,13 +49,9 @@ spec:
 
     More Info:
     - https://github.com/guessi/kubectl-grep
-    Bug report:
-    - https://github.com/guessi/kubectl-grep/issues
-    Changelog:
-    - https://github.com/guessi/kubectl-grep/blob/master/CHANGELOG.md
-  shortDescription: Search Kubernetes resources with keyword
+  shortDescription: Filter Kubernetes resources by matching their names
   description: |
-    Search Kubernetes resources with keyword, and namespace supported
+    Filter Kubernetes resources by matching their names
 
     From ...
     $ kubectl get -n namespace [resourceType] | grep 'keyword'
@@ -70,23 +66,14 @@ spec:
     - node
     - pod
 
-    For example, to list all pods in all namespaces,
+    Examples:
+
+    List all pods in all namespaces
 
     $ kubectl grep pods --all-namespaces
 
-    NAMESPACE     NAME                           READY   STATUS     RESTART   AGE
-    star-lab      the-flash-1563321660-bm225     1/1     Running    0         2d13h
-    marvel        spider-man-564d97dc9c-65mvw    1/1     Running    0         7d22h
-    dc            super-man-bb58c6784-26bmr      1/1     Running    0         1d3h
-
-    Or list all pods with specific keyword, under specific namespace,
+    Shows all pods in namespace "star-lab" which contain the keyword "flash"
 
     $ kubectl grep pods -n star-lab flash
-
-    NAMESPACE     NAME                           READY   STATUS     RESTART   AGE
-    star-lab      the-flash-1563321660-bm225     1/1     Running    0         2d13h
-
-    To support more type of resources, it is always welcome to open a pull-request
-    - https://github.com/guessi/kubectl-grep/pulls
 
     No more pipe, built-in grep :-)

--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -1,12 +1,12 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: search
+  name: grep
 spec:
   platforms:
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.5/kubectl-search-Darwin-x86_64.tar.gz
-    sha256: feeb95a51cb2696757977f14da24d3d8a3a28a60b15ae5e15b87bba31a2c0fa1
-    bin: kubectl-search
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.1.0/kubectl-grep-Darwin-x86_64.tar.gz
+    sha256: 2348dd6484903bfc394cfd9714e5bb66aa101c81e1f48227d819f726f89fbf96
+    bin: kubectl-grep
     files:
     - from: "*"
       to: "."
@@ -14,9 +14,9 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.5/kubectl-search-Linux-x86_64.tar.gz
-    sha256: ebdfd270a60e161c047ffcf1acfa4b341c7118af9849f9795f4ec80b6b7f289f
-    bin: kubectl-search
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.1.0/kubectl-grep-Linux-x86_64.tar.gz
+    sha256: 1362e8a77bed882b5973ab7418c8e82d3aa46fdd1eced36d9c684a055f4cea02
+    bin: kubectl-grep
     files:
     - from: "*"
       to: "."
@@ -24,9 +24,9 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.5/kubectl-search-Windows-x86_64.tar.gz
-    sha256: af2396749a96678500431b317a6166ad2a91f1e202e85ae0ffcd0ba6d55bdeac
-    bin: kubectl-search.exe
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.1.0/kubectl-grep-Windows-x86_64.tar.gz
+    sha256: d45edf88d0840057d38349ef3b8d6ea1246cc31ec94a6656cbbb758eb1c3d597
+    bin: kubectl-grep.exe
     files:
     - from: "*"
       to: "."
@@ -34,7 +34,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: v1.0.5
+  version: v1.1.0
   homepage: https://github.com/guessi/kubectl-search
   caveats: This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
   shortDescription: Search Kubernetes resources with keyword
@@ -45,6 +45,6 @@ spec:
     * kubectl get -n namespace [deployments|pods|...] | grep "keyword" # no Header output
 
     To ...
-    * kubectl search -n namespace [deployments|pods|...] keyword
+    * kubectl grep -n namespace [deployments|pods|...] keyword
 
-    No more pipe, no more grep :-)
+    No more pipe, built-in grep :-)

--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -4,7 +4,7 @@ metadata:
   name: grep
 spec:
   platforms:
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.1.0/kubectl-grep-Darwin-x86_64.tar.gz
+  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.1.0/kubectl-grep-Darwin-x86_64.tar.gz
     sha256: 2348dd6484903bfc394cfd9714e5bb66aa101c81e1f48227d819f726f89fbf96
     bin: kubectl-grep
     files:
@@ -14,7 +14,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.1.0/kubectl-grep-Linux-x86_64.tar.gz
+  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.1.0/kubectl-grep-Linux-x86_64.tar.gz
     sha256: 1362e8a77bed882b5973ab7418c8e82d3aa46fdd1eced36d9c684a055f4cea02
     bin: kubectl-grep
     files:
@@ -24,7 +24,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.1.0/kubectl-grep-Windows-x86_64.tar.gz
+  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.1.0/kubectl-grep-Windows-x86_64.tar.gz
     sha256: d45edf88d0840057d38349ef3b8d6ea1246cc31ec94a6656cbbb758eb1c3d597
     bin: kubectl-grep.exe
     files:
@@ -35,7 +35,7 @@ spec:
         os: windows
         arch: amd64
   version: v1.1.0
-  homepage: https://github.com/guessi/kubectl-search
+  homepage: https://github.com/guessi/kubectl-grep
   caveats: This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
   shortDescription: Search Kubernetes resources with keyword
   description: |

--- a/plugins/search.yaml
+++ b/plugins/search.yaml
@@ -1,0 +1,50 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: search
+spec:
+  platforms:
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.4/kubectl-search-Darwin-x86_64.tar.gz
+    sha256: 0e0cc4443484a1835204cda8632803755c1760a9760e7661e445b101a1054606
+    bin: kubectl-search
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.4/kubectl-search-Linux-x86_64.tar.gz
+    sha256: 9e774344edccfd70ee23f08d5f5a7a25b8fcb1c042f6635f806ae921f8f15211
+    bin: kubectl-search
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.4/kubectl-search-Windows-x86_64.tar.gz
+    sha256: 39a3193c42d4f48c9c959d6a26bdce12c4a684a8eb4840cd35afabc31dda649f
+    bin: kubectl-search.exe
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+  version: v1.0.4
+  homepage: https://github.com/guessi/kubectl-search
+  caveats: This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
+  shortDescription: Search Kubernetes resources with keyword
+  description: |
+    Search Kubernetes resources with keyword
+
+    From ...
+    * kubectl get -n namespace [deployments|pods|...] | grep "keyword" # no Header output
+
+    To ...
+    * kubectl search -n namespace [deployments|pods|...] keyword
+
+    No more pipe, no more grep :-)

--- a/plugins/search.yaml
+++ b/plugins/search.yaml
@@ -4,8 +4,8 @@ metadata:
   name: search
 spec:
   platforms:
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.4/kubectl-search-Darwin-x86_64.tar.gz
-    sha256: 0e0cc4443484a1835204cda8632803755c1760a9760e7661e445b101a1054606
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.5/kubectl-search-Darwin-x86_64.tar.gz
+    sha256: feeb95a51cb2696757977f14da24d3d8a3a28a60b15ae5e15b87bba31a2c0fa1
     bin: kubectl-search
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.4/kubectl-search-Linux-x86_64.tar.gz
-    sha256: 9e774344edccfd70ee23f08d5f5a7a25b8fcb1c042f6635f806ae921f8f15211
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.5/kubectl-search-Linux-x86_64.tar.gz
+    sha256: ebdfd270a60e161c047ffcf1acfa4b341c7118af9849f9795f4ec80b6b7f289f
     bin: kubectl-search
     files:
     - from: "*"
@@ -24,8 +24,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.4/kubectl-search-Windows-x86_64.tar.gz
-    sha256: 39a3193c42d4f48c9c959d6a26bdce12c4a684a8eb4840cd35afabc31dda649f
+  - uri: https://github.com/guessi/kubectl-search/releases/download/v1.0.5/kubectl-search-Windows-x86_64.tar.gz
+    sha256: af2396749a96678500431b317a6166ad2a91f1e202e85ae0ffcd0ba6d55bdeac
     bin: kubectl-search.exe
     files:
     - from: "*"
@@ -34,7 +34,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: v1.0.4
+  version: v1.0.5
   homepage: https://github.com/guessi/kubectl-search
   caveats: This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
   shortDescription: Search Kubernetes resources with keyword


### PR DESCRIPTION
### Description:

Search Kubernetes resources with keyword, and namespace supported

### Basic Usage:

From ...

    $ kubectl get -n namespace [resourceType] | grep 'keyword'

To ...

    $ kubectl grep [resourceType] [keyword]

Supported Resource Types:
- daemonset
- deployment
- hpa
- node
- pod

### Examples:

List all pods in all namespaces

    $ kubectl grep pods --all-namespaces

Shows all pods in namespace "star-lab" which contain the keyword "flash"

    $ kubectl grep pods -n star-lab flash
---

**Checklist for plugin developers:**

- [X] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [X] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
