### PR TITLE
Add sort-manifests plugin

### DIFF
--- a/plugins/sort-manifests.yaml
+++ b/plugins/sort-manifests.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: sort-manifests
+spec:
+  version: v0.1.0
+  shortDescription: Sort manfest files in a proper order by Kind
+  description: |
+    When installing manifests, they should be sorted in a proper order by Kind.
+    For example, Namespace object must be in the first place when installing
+    them.
+
+    ksort sorts manifest files in a proper order by Kind, which is implementd by
+    using tiller.SortByKind() in Kubernetes Helm.
+  homepage: https://github.com/superbrothers/ksort
+  platforms:
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.1.0/ksort-darwin-amd64.zip
+    sha256: 4d7ab60c6e2aadcdc968e7bf9d383015cd8ff6ff6eca727b2475f5b0b336628d
+    bin: ksort
+    files:
+    - from: ksort
+      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.1.0/ksort-linux-amd64.zip
+    sha256: 52413ad1f8e1a92871afe376c888b8aa3ec534651fc4d6c90efb3c2fbeec03a7
+    bin: ksort
+    files:
+    - from: ksort
+      to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64


### PR DESCRIPTION
This PR adds a new plugin manifest "sort-by-kind".

When installing manifests, they should be sorted in a proper order by Kind. For example, Namespace object must be in the first place when installing them.

"sort-by-kind" plugin sorts manfest files in a proper order by Kind, which is implementd by using tiller.SortByKind() in Kubernetes Helm.

```
$ ls ./manifests
deployment.yaml  ingress.yaml  namespace.yaml  service.yaml
$ kubectl sort-by-kind ./manifests | kubectl apply -f -
```

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
