### PR TITLE
Bump version of oidc-login to v1.11.0

### DIFF
--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -23,10 +23,10 @@ spec:
     See https://github.com/int128/kubelogin for more.
 
   homepage: https://github.com/int128/kubelogin
-  version: v1.10.0
+  version: v1.11.0
   platforms:
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.10.0/kubelogin_linux_amd64.zip
-      sha256: "6cd42c549a516043bca95a1def20ea37bc4fce11acda1a1c598e08d3c62e1482"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.11.0/kubelogin_linux_amd64.zip
+      sha256: "66bc30af9d82d47c716e2b371c125070285769499cbe6f35dfd2171b3647d0ac"
       bin: kubelogin
       files:
         - from: "kubelogin"
@@ -35,8 +35,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.10.0/kubelogin_darwin_amd64.zip
-      sha256: "3ef8999504007b4bba93c69b548b83fa44f2151078ead8242be6a6fcdc7b916b"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.11.0/kubelogin_darwin_amd64.zip
+      sha256: "589286396206d5d4faf6301f0df74837ac3b342ec693ae9c970428a4858a70e0"
       bin: kubelogin
       files:
         - from: "kubelogin"
@@ -45,8 +45,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.10.0/kubelogin_windows_amd64.zip
-      sha256: "6f0c316f639625521ff3a6a134ceded583579699c00fc7f54ce04aad527a3134"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.11.0/kubelogin_windows_amd64.zip
+      sha256: "95aabfd2d32a76b9140e0edd9c672516fef61e3563b3e3d5b748a4a351ca5071"
       bin: kubelogin.exe
       files:
         - from: "kubelogin.exe"


### PR DESCRIPTION
This updates oidc-login to [v1.11.0](https://github.com/int128/kubelogin/releases/tag/v1.11.0).

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
