### PR TITLE
Krew plugin criteria

### DIFF
--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -125,9 +125,10 @@ In order of decreasing usage frequency:
 
 Usability
 ---
-Further required acceptance criteria:
+Plugins should be as user-friendly as possible.
+Please follow the following guidelines:
 
-1. Standard look & feel: Adheres to standard kubectl best practices and in particular uses consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
-2. A plugin needs to be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.
+1. Standard look & feel: The plugin should adhere to standard kubectl best practices and have consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
+2. A plugin should be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.
 3. If the plugin has dependencies, try to limit those to fundamental UNIX tools (like bash, sed, grep, awk) or popular tools (like jq, yq) as this makes it easier to get started.
 4. Make sure the plugin fails with a user-friendly error when a required dependency is missing.

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -129,6 +129,7 @@ Plugins should be as user-friendly as possible.
 Please follow the following guidelines:
 
 1. Standard look & feel: The plugin should adhere to standard kubectl best practices and have consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
+    - when writing a plugin in go, consider using the official `k8s.io/cli-runtime/pkg/genericclioptions`
 2. A plugin should be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.
 3. If the plugin has dependencies, try to limit those to fundamental UNIX tools (like bash, sed, grep, awk) or popular tools (like jq, yq) as this makes it easier to get started.
 4. Make sure the plugin fails with a user-friendly error when a required dependency is missing.

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -37,9 +37,9 @@ This task should be classified in one of the categories:
           Mere command wrappers are not acceptable, as those are better coveredby shell aliases.
           However, convenience and productivity improvements are welcome. Examples:
            <ul>
-             <li>`konfig` is a convencience script to aid with merging of kubeconfig files, similar to `kubectl config view`.</li>
-             <li>`change-ns` is a utility easily switch between namespaces, similar to `kubectl config set-context --curent -n`</li>
-             <li>`view-secret` retrieves and decodes secrets, similar to `kubectl get secret -o jsonpath=... | base64 -d`</li>
+             <li><code>konfig</code> is a convencience script to aid with merging of kubeconfig files, similar to <code>kubectl config view</code>.</li>
+             <li><code>change-ns</code> is a utility easily switch between namespaces, similar to <code>kubectl config set-context --curent -n</code></li>
+             <li><code>view-secret</code> retrieves and decodes secrets, similar to <code>kubectl get secret -o jsonpath=... | base64 -d</code></li>
            </ul>
         </td>
     </tr>
@@ -53,17 +53,17 @@ This task should be classified in one of the categories:
           In general welcome unless it overlaps significantly with other plugins or has a bad usability.
           Examples:
           <ul>
-            <li>`get-all` plugin is a replacement for `kubectl get all` command which actually fetches only a subset of API resource types.</li>
-            <li>`access-matrix` gives an overview of authorities, whereas `kubectl auth can-i` only applies to single resource/verb pairs</li>
-            <li>`tail` plugin allows tailing logs from pods from a label selector, a namespace or all namespaces at once, whereas `kubectl logs` command has more limited functionality.</li>
-            <li>`mtail` plugin allows tailing logs from pods from a label selector, similar to `kubectl logs -l` but labels log lines.</li>
+            <li><code>get-all</code> plugin is a replacement for <code>kubectl get all</code> command which actually fetches only a subset of API resource types.</li>
+            <li><code>access-matrix</code> gives an overview of authorities, whereas <code>kubectl auth can-i</code> only applies to single resource/verb pairs</li>
+            <li><code>tail</code> plugin allows tailing logs from pods from a label selector, a namespace or all namespaces at once, whereas <code>kubectl logs</code> command has more limited functionality.</li>
+            <li><code>mtail</code> plugin allows tailing logs from pods from a label selector, similar to <code>kubectl logs -l</code> but labels log lines.</li>
           </ul>
         </td>
     </tr>
     <tr>
         <td>3.</td>
         <td>The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.</td>
-        <td>Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug-pod`).</td>
+        <td>Gray area. If the task fits well into <code>kubectl</code>, it may be accepted (for example <code>kubectl debug-pod</code>).</td>
     </tr>
     <tr>
         <td>4.</td>
@@ -100,14 +100,14 @@ In order of decreasing usage frequency:
     <tbody>
     <tr>
         <td>1.</td>
-        <td>Recurring task on the same cluster. For example: `mtail`</td>
+        <td>Recurring task on the same cluster. For example: <code>mtail</code></td>
         <td>Favors acceptance as plugin.</td>
     </tr>
     <tr>
         <td>2.</td>
         <td>
           Recurring task on different cluster instances, but one-time task on the same cluster instance.
-          For example: `init-tiller`
+          For example: <code>init-tiller</code>
         </td>
         <td>Gray area. Usually this is not acceptable.</td>
     </tr>

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -21,25 +21,90 @@ Purpose
 
 This task should be classified in one of the categories:
 
-| #  | Classification                                                                                                                                                                                                                 | Recommendation                                                                                                                                                                                            |
-|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| 1. |  The task is already solved by kubectl.                                                                                                                                                                                        |  Mere command wrappers are not acceptable, as those are better covered by shell aliases.  However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`) |
-| 2. | The task provides a different solution to a problem which is also solved by kubectl. However, the task would be impossible or very hard to reproduce with kubectl alone. Examples: `access-matrix`, `get-all`, `mtail`, `tail` |  In general welcome unless it overlaps significantly with other plugins or has a bad usability.                                                                                                           |
-| 3. | The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.                                                                                                          |  Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug-pod`).                                                                                                       |
-| 4. | The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s. However, it can be useful in the k8s ecosystem.                                                                                       | Not acceptable.                                                                                                                                                                                           |
-| 5. | The task is very dissimilar to common kubectl tasks and is not focused on k8s. Its general usefulness in the k8s ecosystem is questionable.                                                                                    | Not acceptable.                                                                                                                                                                                           |
+<table>
+    <thead>
+    <tr>
+        <th>#</th>
+        <th>Classification</th>
+        <th>Recommendation</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>1.</td>
+        <td>The task is already solved by kubectl.</td>
+        <td>
+          Mere command wrappers are not acceptable, as those are better coveredby shell aliases.
+          However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`)
+        </td>
+    </tr>
+    <tr>
+        <td>2.</td>
+        <td>
+          The task provides a different solution to a problem which is also solved by kubectl.
+          However, the task would be impossible or very hard to reproduce with kubectl alone.
+          Examples: `access-matrix`, `get-all`, `mtail`, `tail`
+        </td>
+        <td>In general welcome unless it overlaps significantly with other plugins or has a bad usability.</td>
+    </tr>
+    <tr>
+        <td>3.</td>
+        <td>The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.</td>
+        <td>Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug-pod`).</td>
+    </tr>
+    <tr>
+        <td>4.</td>
+        <td>
+          The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s.
+          However, it can be useful in the k8s ecosystem.
+        </td>
+        <td>Not acceptable.</td>
+    </tr>
+    <tr>
+        <td>5.</td>
+        <td>
+          The task is very dissimilar to common kubectl tasks and is not focused on k8s.
+          Its general usefulness in the k8s ecosystem is questionable.
+        </td>
+        <td>Not acceptable.</td>
+    </tr>
+    </tbody>
+</table>
 
 Category
 ---
 
 In order of decreasing usage frequency:
 
-
-| #  | Classification                                                                                                            | Recommendation                             |
-|----|---------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
-| 1. | Recurring task on the same cluster. For example: `mtail`                                                                  | Favors acceptance as plugin.               |
-| 2. | Recurring task on different cluster instances, but one-time task on the same cluster instance. For example: `init-tiller` | Gray area. Usually this is not acceptable. |
-| 3. | One-time task per machine.                                                                                                | In general not acceptable as plugin.       |
+<table>
+    <thead>
+    <tr>
+        <th>#</th>
+        <th>Classification</th>
+        <th>Recommendation</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>1.</td>
+        <td>Recurring task on the same cluster. For example: `mtail`</td>
+        <td>Favors acceptance as plugin.</td>
+    </tr>
+    <tr>
+        <td>2.</td>
+        <td>
+          Recurring task on different cluster instances, but one-time task on the same cluster instance.
+          For example: `init-tiller`
+        </td>
+        <td>Gray area. Usually this is not acceptable.</td>
+    </tr>
+    <tr>
+        <td>3.</td>
+        <td>One-time task per machine.</td>
+        <td>In general not acceptable as plugin.</td>
+    </tr>
+    </tbody>
+</table>
 
 Usability
 ---

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -21,47 +21,31 @@ Purpose
 
 This task should be classified in one of the categories:
 
-1. The task is already solved by kubectl.
-2. The task provides a different solution to a problem which is also solved by kubectl. However, the task would be impossible or very hard to reproduce with kubectl alone. Examples: `access-matrix`, `get-all`, `mtail`, `tail`
-3. The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.
-4. The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s. However, it can be useful in the k8s ecosystem.
-5. The task is very dissimilar to common kubectl tasks and is not focused on k8s. Its general usefulness in the k8s ecosystem is questionable.
-
-
-#### Guideline
-
-- 1: Mere command wrappers are not acceptable, as those are better covered by shell aliases.
-  However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`)
-- 2: In general welcome unless it overlaps significantly with other plugins or has a bad usability.
-- 3: Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug`).
-- 4: Not acceptable.
-- 5: Not acceptable.
+| #  | Classification                                                                                                                                                                                                                 | Recommendation                                                                                                                                                                                            |
+|----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 1. |  The task is already solved by kubectl.                                                                                                                                                                                        |  Mere command wrappers are not acceptable, as those are better covered by shell aliases.  However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`) |
+| 2. | The task provides a different solution to a problem which is also solved by kubectl. However, the task would be impossible or very hard to reproduce with kubectl alone. Examples: `access-matrix`, `get-all`, `mtail`, `tail` |  In general welcome unless it overlaps significantly with other plugins or has a bad usability.                                                                                                           |
+| 3. | The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.                                                                                                          |  Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug`).                                                                                                       |
+| 4. | The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s. However, it can be useful in the k8s ecosystem.                                                                                       | Not acceptable.                                                                                                                                                                                           |
+| 5. | The task is very dissimilar to common kubectl tasks and is not focused on k8s. Its general usefulness in the k8s ecosystem is questionable.                                                                                    | Not acceptable.                                                                                                                                                                                           |
 
 Category
 ---
 
-In order of decreasing frequency:
+In order of decreasing usage frequency:
 
-1. Recurring task on the same cluster. For example: `mtail`
-2. Recurring task on different cluster instances, but one-time task on the same cluster instance. For example: `init-tiller`
-3. One-time task per machine.
 
-#### Guideline
-
-- 1: Favors acceptance as plugin.
-- 2: Gray area. Usually this is not acceptable.
-- 3: In general not acceptable as plugin.
-
+| #  | Classification                                                                                                            | Recommendation                             |
+|----|---------------------------------------------------------------------------------------------------------------------------|--------------------------------------------|
+| 1. | Recurring task on the same cluster. For example: `mtail`                                                                  | Favors acceptance as plugin.               |
+| 2. | Recurring task on different cluster instances, but one-time task on the same cluster instance. For example: `init-tiller` | Gray area. Usually this is not acceptable. |
+| 3. | One-time task per machine.                                                                                                | In general not acceptable as plugin.       |
 
 Usability
 ---
+Furter required acceptance criteria:
 
 1. Standard look & feel: Adheres to standard kubectl best practices and in particular uses consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
 2. A plugin needs to be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.
 3. Plugins may not depend on additional non-standard third-party tools which are not part of the plugin installation. Acceptable: jq, standard unix CLI tools (awk, sed, grep).
 <!-- 4. Ready to use: Unless absolutely required, a plugin should not need extra configuration. -->
-
-
-#### Guideline
-
-- 1,2,3: Required for acceptance.

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -35,7 +35,12 @@ This task should be classified in one of the categories:
         <td>The task is already solved by kubectl.</td>
         <td>
           Mere command wrappers are not acceptable, as those are better coveredby shell aliases.
-          However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`)
+          However, convenience and productivity improvements are welcome. Examples:
+           <ul>
+             <li>`konfig` is a convencience script to aid with merging of kubeconfig files, similar to `kubectl config view`.</li>
+             <li>`change-ns` is a utility easily switch between namespaces, similar to `kubectl config set-context --curent -n`</li>
+             <li>`view-secret` retrieves and decodes secrets, similar to `kubectl get secret -o jsonpath=... | base64 -d`</li>
+           </ul>
         </td>
     </tr>
     <tr>
@@ -43,9 +48,17 @@ This task should be classified in one of the categories:
         <td>
           The task provides a different solution to a problem which is also solved by kubectl.
           However, the task would be impossible or very hard to reproduce with kubectl alone.
-          Examples: `access-matrix`, `get-all`, `mtail`, `tail`
         </td>
-        <td>In general welcome unless it overlaps significantly with other plugins or has a bad usability.</td>
+        <td>
+          In general welcome unless it overlaps significantly with other plugins or has a bad usability.
+          Examples:
+          <ul>
+            <li>`get-all` plugin is a replacement for `kubectl get all` command which actually fetches only a subset of API resource types.</li>
+            <li>`access-matrix` gives an overview of authorities, whereas `kubectl auth can-i` only applies to single resource/verb pairs</li>
+            <li>`tail` plugin allows tailing logs from pods from a label selector, a namespace or all namespaces at once, whereas `kubectl logs` command has more limited functionality.</li>
+            <li>`mtail` plugin allows tailing logs from pods from a label selector, similar to `kubectl logs -l` but labels log lines.</li>
+          </ul>
+        </td>
     </tr>
     <tr>
         <td>3.</td>

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -63,7 +63,11 @@ This task should be classified in one of the categories:
     <tr>
         <td>3.</td>
         <td>The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.</td>
-        <td>Gray area. If the task fits well into <code>kubectl</code>, it may be accepted (for example <code>kubectl debug-pod</code>).</td>
+        <td>
+          Gray area. If most users would use tool as a <code>kubectl</code> plugin, it may be accepted.
+          For example, <code>kubectl debug-pod</code> would be acceptable.
+          On the other hand, <code>helm</code> as <code>kubectl helm</code> would not be acceptable, because it is independent.
+        </td>
     </tr>
     <tr>
         <td>4.</td>
@@ -71,7 +75,7 @@ This task should be classified in one of the categories:
           The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s.
           However, it can be useful in the k8s ecosystem.
         </td>
-        <td>Not acceptable.</td>
+        <td>Not acceptable. Consider distributing as a separate tool instead of making it a kubectl plugin.</td>
     </tr>
     <tr>
         <td>5.</td>
@@ -125,5 +129,5 @@ Further required acceptance criteria:
 
 1. Standard look & feel: Adheres to standard kubectl best practices and in particular uses consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
 2. A plugin needs to be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.
-3. Plugins may not depend on additional non-standard third-party tools which are not part of the plugin installation. Acceptable: jq, standard unix CLI tools (awk, sed, grep).
-<!-- 4. Ready to use: Unless absolutely required, a plugin should not need extra configuration. -->
+3. If the plugin has dependencies, try to limit those to fundamental UNIX tools (like bash, sed, grep, awk) or popular tools (like jq, yq) as this makes it easier to get started.
+4. Make sure the plugin fails with a user-friendly error when a required dependency is missing.

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -6,9 +6,9 @@ Rationale
 
 Krew is a `kubectl` plugin manager.
 
-A plugin provides a technical solution to at least one _task_ concerning a problem around kubernetes.
-As plugins are invoked via `kubectl <plugin-name>`, they should feel like natural extensions of the `kubectl` command in a way that some kubectl task is extended.
-Stated reversely: without the plugin, users would typically try to solve the plugin task mainly with kubectl.
+The centralized Krew plugin index (`sigs.k8s.io/krew-index` repository) holds plugins that are applicable to a broad set of kubectl users.
+
+A plugin in the Krew plugin index must add new functionality or enhance the existing functionality in `kubectl`, or encapsulate a common operator/developer workflow for higher productivity.
 
 A plugin should be classified in the following categories:
 
@@ -25,7 +25,7 @@ This task should be classified in one of the categories:
 |----|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | 1. |  The task is already solved by kubectl.                                                                                                                                                                                        |  Mere command wrappers are not acceptable, as those are better covered by shell aliases.  However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`) |
 | 2. | The task provides a different solution to a problem which is also solved by kubectl. However, the task would be impossible or very hard to reproduce with kubectl alone. Examples: `access-matrix`, `get-all`, `mtail`, `tail` |  In general welcome unless it overlaps significantly with other plugins or has a bad usability.                                                                                                           |
-| 3. | The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.                                                                                                          |  Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug`).                                                                                                       |
+| 3. | The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.                                                                                                          |  Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug-pod`).                                                                                                       |
 | 4. | The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s. However, it can be useful in the k8s ecosystem.                                                                                       | Not acceptable.                                                                                                                                                                                           |
 | 5. | The task is very dissimilar to common kubectl tasks and is not focused on k8s. Its general usefulness in the k8s ecosystem is questionable.                                                                                    | Not acceptable.                                                                                                                                                                                           |
 
@@ -43,7 +43,7 @@ In order of decreasing usage frequency:
 
 Usability
 ---
-Furter required acceptance criteria:
+Further required acceptance criteria:
 
 1. Standard look & feel: Adheres to standard kubectl best practices and in particular uses consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
 2. A plugin needs to be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.

--- a/doc/plugin-criteria.md
+++ b/doc/plugin-criteria.md
@@ -1,0 +1,67 @@
+Krew plugin criteria
+===
+
+Rationale
+---
+
+Krew is a `kubectl` plugin manager.
+
+A plugin provides a technical solution to at least one _task_ concerning a problem around kubernetes.
+As plugins are invoked via `kubectl <plugin-name>`, they should feel like natural extensions of the `kubectl` command in a way that some kubectl task is extended.
+Stated reversely: without the plugin, users would typically try to solve the plugin task mainly with kubectl.
+
+A plugin should be classified in the following categories:
+
+- Purpose
+- Category
+- Usability
+
+Purpose
+---
+
+This task should be classified in one of the categories:
+
+1. The task is already solved by kubectl.
+2. The task provides a different solution to a problem which is also solved by kubectl. However, the task would be impossible or very hard to reproduce with kubectl alone. Examples: `access-matrix`, `get-all`, `mtail`, `tail`
+3. The task addresses a completely different problem than any of the kubectl subcommands, but is clearly focused on k8s.
+4. The task is very dissimilar to common kubectl tasks and is not primarily focused on k8s. However, it can be useful in the k8s ecosystem.
+5. The task is very dissimilar to common kubectl tasks and is not focused on k8s. Its general usefulness in the k8s ecosystem is questionable.
+
+
+#### Guideline
+
+- 1: Mere command wrappers are not acceptable, as those are better covered by shell aliases.
+  However, convenience and productivity improvements are welcome (examples: `konfig`, `change-ns`, `view-secret`)
+- 2: In general welcome unless it overlaps significantly with other plugins or has a bad usability.
+- 3: Gray area. If the task fits well into `kubectl`, it may be accepted (for example `kubectl debug`).
+- 4: Not acceptable.
+- 5: Not acceptable.
+
+Category
+---
+
+In order of decreasing frequency:
+
+1. Recurring task on the same cluster. For example: `mtail`
+2. Recurring task on different cluster instances, but one-time task on the same cluster instance. For example: `init-tiller`
+3. One-time task per machine.
+
+#### Guideline
+
+- 1: Favors acceptance as plugin.
+- 2: Gray area. Usually this is not acceptable.
+- 3: In general not acceptable as plugin.
+
+
+Usability
+---
+
+1. Standard look & feel: Adheres to standard kubectl best practices and in particular uses consistent (abbreviated) flag names. For example: bad `--ns`, good `--namespace` + `-n`.
+2. A plugin needs to be documented in such a way, that a proficient `kubectl` user immediately understands its purpose and how to use it.
+3. Plugins may not depend on additional non-standard third-party tools which are not part of the plugin installation. Acceptable: jq, standard unix CLI tools (awk, sed, grep).
+<!-- 4. Ready to use: Unless absolutely required, a plugin should not need extra configuration. -->
+
+
+#### Guideline
+
+- 1,2,3: Required for acceptance.


### PR DESCRIPTION
Hi @ahmetb @juanvallejo,

as you all know, krew-index currently has no criteria to apply for accepting or rejecting plugins. This creates friction for both contributors and maintainers:
- plugin contributors, because they have no idea whether their idea might be accepted.
- krew-index maintainers, because they need to do subjective case-by-case decisions whether a plugin actually "fits".

So I put up this draft for plugin criteria to get the discussion going. It is an opinionated crude first draft and probably misses a lot of things. But maybe it helps nevertheless. Let me know what you think.

cc @garethr because you wanted to tune in