### PR TITLE
Add instructions to list all plugins in krew caveat section

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,5 @@
 
 **Checklist for plugin developers:**
 
-- [ ] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
+- [ ] Read the [Plugin Naming Guide](https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md) (for new plugins)
 - [ ] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)

--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -17,7 +17,11 @@ spec:
 
       * Windows: Add %USERPROFILE%\.krew\bin to your PATH environment variable
 
-    Run "kubectl krew" to list krew commands and get help.
+    To list krew commands and to get help run
+      $ kubectl krew
+    For a full list of available plugins run
+      $ kubectl krew search
+
     You can find documentation at https://sigs.k8s.io/krew.
 
   platforms:

--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -17,9 +17,9 @@ spec:
 
       * Windows: Add %USERPROFILE%\.krew\bin to your PATH environment variable
 
-    To list krew commands and to get help run
+    To list krew commands and to get help, run:
       $ kubectl krew
-    For a full list of available plugins run
+    For a full list of available plugins, run:
       $ kubectl krew search
 
     You can find documentation at https://sigs.k8s.io/krew.

--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -4,7 +4,7 @@ metadata:
   name: krew
 spec:
   version: "v0.2.1"
-  homepage: https://github.com/GoogleContainerTools/krew
+  homepage: https://sigs.k8s.io/krew
   shortDescription: Package manager for kubectl plugins.
   caveats: |
     krew is now installed! To start using kubectl plugins, you need to add
@@ -18,7 +18,7 @@ spec:
       * Windows: Add %USERPROFILE%\.krew\bin to your PATH environment variable
 
     Run "kubectl krew" to list krew commands and get help.
-    You can find documentation at https://github.com/GoogleContainerTools/krew.
+    You can find documentation at https://sigs.k8s.io/krew.
 
   platforms:
   - uri: https://storage.googleapis.com/krew/v0.2.1/krew.tar.gz


### PR DESCRIPTION
-----

**Checklist for plugin developers:**

- [ ] Read the [Plugin Naming Guide](https://github.com/GoogleContainerTools/krew/tree/master/docs/NAMING_GUIDE.md) (for new plugins)
- [ ] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
