### PR TITLE
Bump oidc-login to v1.12.0

### DIFF
--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -23,10 +23,10 @@ spec:
     See https://github.com/int128/kubelogin for more.
 
   homepage: https://github.com/int128/kubelogin
-  version: v1.11.0
+  version: v1.12.0
   platforms:
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.11.0/kubelogin_linux_amd64.zip
-      sha256: "66bc30af9d82d47c716e2b371c125070285769499cbe6f35dfd2171b3647d0ac"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.12.0/kubelogin_linux_amd64.zip
+      sha256: "5a4c02dc2527f20ba55f7a0751628d009d5e9a3a5e0efd1d01096ec32869b493"
       bin: kubelogin
       files:
         - from: "kubelogin"
@@ -35,8 +35,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.11.0/kubelogin_darwin_amd64.zip
-      sha256: "589286396206d5d4faf6301f0df74837ac3b342ec693ae9c970428a4858a70e0"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.12.0/kubelogin_darwin_amd64.zip
+      sha256: "e61f6f662b15b2a223a4fba4dae0d4c7ea5b50e36029badb90cbab364d4775b6"
       bin: kubelogin
       files:
         - from: "kubelogin"
@@ -45,8 +45,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.11.0/kubelogin_windows_amd64.zip
-      sha256: "95aabfd2d32a76b9140e0edd9c672516fef61e3563b3e3d5b748a4a351ca5071"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.12.0/kubelogin_windows_amd64.zip
+      sha256: "2e8be24ef70bfe96345fc8e36720e7d5ca5b0c711e5fe6f0ee8a2a7567ee6305"
       bin: kubelogin.exe
       files:
         - from: "kubelogin.exe"


### PR DESCRIPTION
This updates the version of oidc-login to v1.12.0.

-----

**Checklist for plugin developers:**

- [ ] Read the [Plugin Naming Guide](https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
