### PR TITLE
Add virt.yaml for v0.17.2

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -13,8 +13,8 @@ spec:
       sha256: "bbf3b4f15b64ffe4c9196b53d045a92bc8113d24cfde471dded3c8c505aef663"
       files:
         - from: "/virtctl/virtctl-v0.17.2-linux-amd64"
-          to: "."
-      bin: "./virtctl-v0.17.2-linux-amd64"
+          to: "virtctl"
+      bin: "virtctl"
     - selector:
         matchLabels:
           os: windows
@@ -23,8 +23,8 @@ spec:
       sha256: "828876ae8abc50c7965f7b9eaa1ff3f6d3d9b0dad25c79e6a7d49dd6a1543087"
       files:
         - from: "/virtctl/virtctl-v0.17.2-windows-amd64.exe"
-          to: "."
-      bin: "./virtctl-v0.17.2-windows-amd64.exe"
+          to: "virtctl.exe"
+      bin: "virtctl.exe"
     - selector:
         matchLabels:
           os: darwin
@@ -33,15 +33,40 @@ spec:
       sha256: "ffdc599d4581a98e230ffab30cde39a20db3a695d300d726f72bbdebd9a57361"
       files:
         - from: "/virtctl/virtctl-v0.17.2-darwin-amd64"
-          to: "."
-      bin: "./virtctl-v0.17.2-darwin-amd64"
+          to: "virtctl"
+      bin: "virtctl"
   shortDescription: controls virtual machine related operations.
   homepage: https://kubevirt.io
   caveats: |
-    Usage:
-      kubectl virt
+    virt plugin is a wrapper for virtctl originating from the kubevirt.io project. In order to use virtctl you will
+    need to have kubevirt installed on your kubernetes cluster to use it. See https://kubevirt.io/ for details
 
-    Documentation:
-      https://kubevirt.io/user-guide/docs/latest/administration/intro.html#client-side-virtctl-deployment
+    Run
+
+      kubectl virt help
+
+    to get an overview of the available commands
+
+    See
+
+      https://kubevirt.io/user-guide/docs/latest/using-virtual-machines/graphical-and-console-access.html
+
+    for a usage example
   description: |
-    virt plugin controls virtual machine related operations on your kubernetes cluster.
+    virt plugin is a wrapper for virtctl originating from the kubevirt project. KubeVirt is a virtualization add-on to
+    Kubernetes, i.e. it enables to run existing virtual machines on kubernetes clusters. virtctl controls virtual
+    machine related operations on your kubernetes cluster.
+
+    Kubevirt documentation:
+      Overview:
+        https://kubevirt.io/
+      Installation:
+        https://kubevirt.io/user-guide/docs/latest/administration/intro.html
+      User Guide:
+        https://kubevirt.io/user-guide/docs/latest/welcome/index.html
+      Minikube Quickstart:
+        https://kubevirt.io/quickstart_minikube/
+      Virtctl usage examples:
+        https://kubevirt.io/user-guide/docs/latest/using-virtual-machines/graphical-and-console-access.html
+        https://kubevirt.io/user-guide/docs/latest/using-virtual-machines/expose-service.html
+        https://kubevirt.io/user-guide/docs/latest/using-virtual-machines/virtual-machine-replica-set.html

--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: virt
+spec:
+  version: "v0.17.2"
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: "https://github.com/dhiller/kubectl-virt-plugin/releases/download/v0.17.2/virtctl-v0.17.2-linux-amd64.tar.gz"
+      sha256: "bbf3b4f15b64ffe4c9196b53d045a92bc8113d24cfde471dded3c8c505aef663"
+      files:
+        - from: "/virtctl/virtctl-v0.17.2-linux-amd64"
+          to: "."
+      bin: "./virtctl-v0.17.2-linux-amd64"
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: "https://github.com/dhiller/kubectl-virt-plugin/releases/download/v0.17.2/virtctl-v0.17.2-windows-amd64.exe.tar.gz"
+      sha256: "828876ae8abc50c7965f7b9eaa1ff3f6d3d9b0dad25c79e6a7d49dd6a1543087"
+      files:
+        - from: "/virtctl/virtctl-v0.17.2-windows-amd64.exe"
+          to: "."
+      bin: "./virtctl-v0.17.2-windows-amd64.exe"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: "https://github.com/dhiller/kubectl-virt-plugin/releases/download/v0.17.2/virtctl-v0.17.2-darwin-amd64.tar.gz"
+      sha256: "ffdc599d4581a98e230ffab30cde39a20db3a695d300d726f72bbdebd9a57361"
+      files:
+        - from: "/virtctl/virtctl-v0.17.2-darwin-amd64"
+          to: "."
+      bin: "./virtctl-v0.17.2-darwin-amd64"
+  shortDescription: controls virtual machine related operations.
+  homepage: https://kubevirt.io
+  caveats: |
+    Usage:
+      kubectl virt
+
+    Documentation:
+      https://kubevirt.io/user-guide/docs/latest/administration/intro.html#client-side-virtctl-deployment
+  description: |
+    virt plugin controls virtual machine related operations on your kubernetes cluster.


### PR DESCRIPTION
Create krew plugin for virtctl as part of the kubevirt project.
`virtctl` is the binary for executing advanced virtual machine
instance operations, see kubevirt.io for project details.

-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
