### PR TITLE
fixed: install actions for bulk-actions

### DIFF
--- a/plugins/bulk-action.yaml
+++ b/plugins/bulk-action.yaml
@@ -14,8 +14,8 @@ spec:
       sha256: 80f7b55d82673253eb0957d2c248163fcce3e4c3bc609410b1e9ee2d6d6a91a7
       files:
         - from: kubectl-plugins-*/kubectl-bulk
-          to: kubectl-bulk-action
-      bin: ./kubectl-bulk-action
+          to: .
+      bin: ./kubectl-bulk
   shortDescription: Do bulk actions on Kubernetes resources.
   caveats: |
     Usage:


### PR DESCRIPTION
-----

**Checklist for plugin developers:**

- [x] Read the [Plugin Naming Guide](https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md) (for new plugins)
- [x] Verify the installation from URL or a local archive works (`kubectl krew install --manifest=[...] --archive=[...]`)
