### PR TITLE
Add exec-cronjob plugin

### DIFF
--- a/plugins/exec-cronjob.yaml
+++ b/plugins/exec-cronjob.yaml
@@ -1,0 +1,32 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: exec-cronjob
+spec:
+  version: v0.4.0
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.4.0.zip
+    sha256: 688bceed5fdd54414fc70080dacb776025c9ab31fb7bda3fca166bba05976a38
+    files:
+    - from: kubectl-plugins-*/exec-cronjob/*
+      to: "."
+    bin: kubectl-exec_cronjob.sh
+  shortDescription: Execute a cron job
+  description: |
+    Execute a CronJob, by extracting the Job spec and apply it in the given
+    namespace
+  caveats: |
+    Usage:
+        kubectl exec-cronjob <name> [options]
+
+    Options:
+        -n, --namespace='': If present, the namespace scope for this CLI request
+        --dry-run: If true, only print the object that would be sent, without sending it.
+        -h, --help: Display this help
+
+    Read the documentation at:
+      https://github.com/thecloudnatives/kubectl-plugins
+  homepage: https://github.com/thecloudnatives/kubectl-plugins

--- a/plugins/exec-cronjob.yaml
+++ b/plugins/exec-cronjob.yaml
@@ -3,21 +3,21 @@ kind: Plugin
 metadata:
   name: exec-cronjob
 spec:
-  version: v0.4.0
+  version: v0.4.1
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.4.0.zip
-    sha256: 688bceed5fdd54414fc70080dacb776025c9ab31fb7bda3fca166bba05976a38
+    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.4.1.zip
+    sha256: fc5410ebe09295a75ea9a67dd10ba83b3c6e5043ea9f0cf98897e362c665003a
     files:
     - from: kubectl-plugins-*/exec-cronjob/*
       to: "."
     bin: kubectl-exec_cronjob.sh
   shortDescription: Execute a cron job
   description: |
-    Execute a CronJob, by extracting the Job spec and apply it in the given
-    namespace
+    Run a cron job immediately by extracting the Job spec and creating a Job
+    instance thereof.
   caveats: |
     Usage:
         kubectl exec-cronjob <name> [options]
@@ -28,5 +28,5 @@ spec:
         -h, --help: Display this help
 
     Read the documentation at:
-      https://github.com/thecloudnatives/kubectl-plugins
-  homepage: https://github.com/thecloudnatives/kubectl-plugins
+      https://github.com/thecloudnatives/kubectl-plugins#exec-cronjob
+  homepage: https://github.com/thecloudnatives/kubectl-plugins#exec-cronjob

--- a/plugins/exec-cronjob.yaml
+++ b/plugins/exec-cronjob.yaml
@@ -3,21 +3,21 @@ kind: Plugin
 metadata:
   name: exec-cronjob
 spec:
-  version: v0.4.1
+  version: v0.4.2
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.4.1.zip
-    sha256: fc5410ebe09295a75ea9a67dd10ba83b3c6e5043ea9f0cf98897e362c665003a
+    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.4.2.zip
+    sha256: 4737ec20e3eac922cf8cfdc3c384a3124d3d98786277ea9152dcc085846dabbc
     files:
     - from: kubectl-plugins-*/exec-cronjob/*
       to: "."
     bin: kubectl-exec_cronjob.sh
-  shortDescription: Run a cron job immediately
+  shortDescription: Run a CronJob immediately as Job
   description: |
-    Run a cron job immediately by extracting the Job spec and creating a Job
-    instance thereof.
+    Run a CronJob immediately as Job by extracting the Job spec and creating a
+    Job instance thereof.
   caveats: |
     Usage:
         kubectl exec-cronjob <name> [options]

--- a/plugins/exec-cronjob.yaml
+++ b/plugins/exec-cronjob.yaml
@@ -14,7 +14,7 @@ spec:
     - from: kubectl-plugins-*/exec-cronjob/*
       to: "."
     bin: kubectl-exec_cronjob.sh
-  shortDescription: Execute a cron job
+  shortDescription: Run a cron job immediately
   description: |
     Run a cron job immediately by extracting the Job spec and creating a Job
     instance thereof.


### PR DESCRIPTION
Add exec-cronjob plugin which extract the job spec of a cron job and instantly execute it.

```
Execute a CronJob, by extracting the Job spec and apply it in the given
namespace.

Usage:
    kubectl exec-cronjob <name> [options]

Options:
    -n, --namespace='': If present, the namespace scope for this CLI request
    --dry-run: If true, only print the object that would be sent, without sending it.
    -h, --help: Display this help
```