### PR TITLE
Move all plugin versions to semver for upcoming migration

### DIFF
--- a/plugins/ca-cert.yaml
+++ b/plugins/ca-cert.yaml
@@ -14,7 +14,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "master"
+  version: "v0.0.0"
   homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Print the PEM CA certificate of the current cluster
   description: |

--- a/plugins/mtail.yaml
+++ b/plugins/mtail.yaml
@@ -14,7 +14,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "master"
+  version: "v0.0.0"
   homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Tail logs from multiple pods matching label selector
   caveats: |

--- a/plugins/rm-standalone-pods.yaml
+++ b/plugins/rm-standalone-pods.yaml
@@ -14,7 +14,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "master"
+  version: "v0.0.0"
   homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Remove all pods without owner references
   caveats: |

--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -14,7 +14,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "master"
+  version: "v0.0.0"
   homepage: https://github.com/ahmetb/kubectl-extras
   shortDescription: Decode secrets
   caveats: |


### PR DESCRIPTION
This helps us not implement a migration step in the proposed upgrade logic that
only supports SemVer in the version field.

(Turns out only the plugins I own are using "version" fields that are not
semver.)

/assign @corneliusweig 
/kind cleanup
/priority important-soon