### PR TITLE
Add v prefix to semver versions

### DIFF
--- a/plugins/ingress-nginx.yaml
+++ b/plugins/ingress-nginx.yaml
@@ -6,7 +6,7 @@ spec:
   shortDescription: Interact with ingress-nginx
   description: |
     The official kubectl plugin for ingress-nginx.
-  version: 0.24.0
+  version: v0.24.0
   homepage: https://kubernetes.github.io/ingress-nginx/kubectl-plugin/
   platforms:
   - uri: https://github.com/kubernetes/ingress-nginx/releases/download/nginx-0.24.0/kubectl-ingress_nginx-darwin-amd64.tar.gz

--- a/plugins/ssh-jump.yaml
+++ b/plugins/ssh-jump.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: ssh-jump
 spec:
-  version: "0.1.0"
+  version: "v0.1.0"
   homepage: https://github.com/yokawasa/kubectl-plugin-ssh-jump
   platforms:
   - selector:
@@ -16,11 +16,11 @@ spec:
       to: "."
     bin: "./kubectl-ssh-jump"
   shortDescription: A kubectl plugin to SSH into Kubernetes nodes using a SSH jump host Pod
-  caveats: |    
+  caveats: |
     This plugin needs the following programs:
     * ssh(1)
     * ssh-agent(1)
-    
+
     Please follow the documentation: https://github.com/yokawasa/kubectl-plugin-ssh-jump
   description: |
     A kubectl plugin to SSH into Kubernetes nodes using a SSH jump host Pod.


### PR DESCRIPTION
Looks like only two plugins currently don't have v prefix in their version
string. I'd love to unify this to consistently enforce a vprefix in krew
version handling.

/assign @corneliusweig