### PR TITLE
access-matrix: add RBAC keyword

### DIFF
--- a/plugins/access-matrix.yaml
+++ b/plugins/access-matrix.yaml
@@ -35,7 +35,7 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-  shortDescription: Show an access matrix for server resources
+  shortDescription: Show an RBAC access matrix for server resources
   homepage: https://github.com/corneliusweig/rakkess
   caveats: |
       Usage:


### PR DESCRIPTION
Would be good to mention RBAC in the shortDescription, as people scanning
the list cannot tell which plugins are rbac-related.

/assign @corneliusweig

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->