### PR TITLE
Add plugin:  preflight

### DIFF
--- a/plugins/preflight.yaml
+++ b/plugins/preflight.yaml
@@ -13,8 +13,8 @@ spec:
     sha256: "75f82c2b720b578cefe05afb50d2559a9f7eb2ed1860cb5c5cb30254878e161c"
     files:
     - from: "./preflight"
-      to: "kubectl-preflight"
-    bin: "kubectl-preflight"
+      to: "."
+    bin: "preflight"
   - selector:
       matchLabels:
         os: darwin
@@ -23,8 +23,8 @@ spec:
     sha256: "cc8ca71f31ec40796738a745794136b08fa3c224220040c8d413c76d70bc7bc5"
     files:
     - from: "./preflight"
-      to: "kubectl-preflight"
-    bin: "kubectl-preflight"
+      to: "."
+    bin: "preflight"
   - selector:
       matchLabels:
         os: windows
@@ -33,7 +33,31 @@ spec:
     sha256: "5d96a7b9abb3699fc495b8739519e7b608c1d42f8b22b1e6581b889de7376872"
     files:
     - from: "/preflight.exe"
-      to: "kubectl-preflight.exe"
-    bin: "kubectl-preflight.exe"
-  shortDescription: Executes preflight tests and application conformance verifications on a cluster before installing an application
+      to: "."
+    bin: "preflight.exe"
+  shortDescription: Executes application preflight tests in a cluster
   homepage: https://github.com/replicaetdhq/troubleshoot
+  caveats: |
+    Usage:
+      $ kubectl preflight <URL>
+
+    Flags:
+      -h, --help                          help for preflight
+          --interactive                   interactive preflights (default true)
+          --kubecontext string            the kubecontext to use when connecting (default "~/.kube/config")
+          --serviceaccount string         name of the service account to use. if not provided, one will be created
+          --format string                 output format, one of human, json, yaml. only used when interactive is set to false (default "human")
+
+    Documentation:
+      https://help.replicated.com/docs/troubleshoot/kubernetes/preflight/overview/
+
+  description: |
+    This plugin executes application-specific preflight checks and conformance tests against a cluster, prior to installation of an application.
+
+    Application developers can create and host a Preflight manifest that defines the minimum and desired Kubernetes environment
+    for an application. Before installing the application, a cluster admin can use this plugin to execute the application preflight checks
+    to identify any missing components, configuration or incompatibilities between the cluster and the desired environment.
+
+    When executing Preflight tests, the test results will be displayed in a terminal-based UI on the workstation that executed the command.
+
+    For information on creating a Preflight manifest, view the documentation at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/

--- a/plugins/preflight.yaml
+++ b/plugins/preflight.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: preflight
 spec:
-  version: "v0.9.0"
+  version: "v0.9.1"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.9.0_linux_amd64-0.9.0.tar.gz
-    sha256: "75f82c2b720b578cefe05afb50d2559a9f7eb2ed1860cb5c5cb30254878e161c"
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.1/preflight_0.9.1_linux_amd64-0.9.1.tar.gz
+    sha256: "2a50b896b2bd0fdd10ae0bc63ecfe417da1de2ab81255990958fa433d123ef85"
     files:
     - from: "./preflight"
       to: "."
@@ -19,8 +19,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.9.0_darwin_amd64-0.9.0.tar.gz
-    sha256: "cc8ca71f31ec40796738a745794136b08fa3c224220040c8d413c76d70bc7bc5"
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.1/preflight_0.9.1_darwin_amd64-0.9.1.tar.gz
+    sha256: "e8d99442c12606f062edce164c7a503aca316928b796708a08f8ae3fc8e3444d"
     files:
     - from: "./preflight"
       to: "."
@@ -29,8 +29,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.9.0_windows_amd64-0.9.0.zip
-    sha256: "5d96a7b9abb3699fc495b8739519e7b608c1d42f8b22b1e6581b889de7376872"
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.1/preflight_0.9.1_windows_amd64-0.9.1.zip
+    sha256: "ac1940826bda4025cf2e8be1627f3ba9ef0df0ee259dba388cb7a167c617dfd4"
     files:
     - from: "/preflight.exe"
       to: "."

--- a/plugins/preflight.yaml
+++ b/plugins/preflight.yaml
@@ -36,28 +36,40 @@ spec:
       to: "."
     bin: "preflight.exe"
   shortDescription: Executes application preflight tests in a cluster
-  homepage: https://github.com/replicaetdhq/troubleshoot
+  homepage: https://github.com/replicatedhq/troubleshoot
   caveats: |
     Usage:
-      $ kubectl preflight <URL>
+      $ kubectl preflight <uri/path>
 
-    Flags:
-      -h, --help                          help for preflight
-          --interactive                   interactive preflights (default true)
-          --kubecontext string            the kubecontext to use when connecting (default "~/.kube/config")
-          --serviceaccount string         name of the service account to use. if not provided, one will be created
-          --format string                 output format, one of human, json, yaml. only used when interactive is set to false (default "human")
+      where <uri/path> references a set of application preflight checks
+
+      For example:
+
+      $ kubectl preflight https://preflight.replicated.com
+
+    For additional options:
+      $ kubectl preflight --help
 
     Documentation:
+      Full documentation on this plugin is available at:
       https://help.replicated.com/docs/troubleshoot/kubernetes/preflight/overview/
 
+      For application developers writing collectors and analyzers:
+      https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
+
   description: |
-    This plugin executes application-specific preflight checks and conformance tests against a cluster, prior to installation of an application.
+    This plugin executes application-specific preflight checks and conformance
+    tests against a cluster, prior to installation of an application.
 
-    Application developers can create and host a Preflight manifest that defines the minimum and desired Kubernetes environment
-    for an application. Before installing the application, a cluster admin can use this plugin to execute the application preflight checks
-    to identify any missing components, configuration or incompatibilities between the cluster and the desired environment.
+    Application developers can create and host a Preflight manifest that
+    defines the minimum and desired Kubernetes environment for an application.
+    Before installing the application, a cluster admin can use this plugin to
+    execute the application preflight checksto identify any missing
+    components, configuration or incompatibilities between the cluster and the
+    desired environment.
 
-    When executing Preflight tests, the test results will be displayed in a terminal-based UI on the workstation that executed the command.
+    When executing Preflight tests, the test results will be displayed in a
+    terminal-based UI on the workstation that executed the command.
 
-    For information on creating a Preflight manifest, view the documentation at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/
+    For information on creating a Preflight manifest, view the documentation
+    at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/

--- a/plugins/preflight.yaml
+++ b/plugins/preflight.yaml
@@ -1,0 +1,39 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: preflight
+spec:
+  version: "v0.9.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.9.0_linux_amd64-0.9.0.tar.gz
+    sha256: "75f82c2b720b578cefe05afb50d2559a9f7eb2ed1860cb5c5cb30254878e161c"
+    files:
+    - from: "./preflight"
+      to: "kubectl-preflight"
+    bin: "kubectl-preflight"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.9.0_darwin_amd64-0.9.0.tar.gz
+    sha256: "cc8ca71f31ec40796738a745794136b08fa3c224220040c8d413c76d70bc7bc5"
+    files:
+    - from: "./preflight"
+      to: "kubectl-preflight"
+    bin: "kubectl-preflight"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/replicatedhq/troubleshoot/releases/download/v0.9.0/preflight_0.9.0_windows_amd64-0.9.0.zip
+    sha256: "5d96a7b9abb3699fc495b8739519e7b608c1d42f8b22b1e6581b889de7376872"
+    files:
+    - from: "/preflight.exe"
+      to: "kubectl-preflight.exe"
+    bin: "kubectl-preflight.exe"
+  shortDescription: Executes preflight tests and application conformance verifications on a cluster before installing an application
+  homepage: https://github.com/replicaetdhq/troubleshoot


### PR DESCRIPTION

- [x] Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

This is a new plugin that runs application specific preflight (conformance) tests against a cluster. 

Example:

```kubectl preflight https://preflight.replicated.com```

There's a terminal-based UI that loads and shows if the cluster meets the requirements defined in the YAML file provided.