### PR TITLE
New plugin: eksporter

### DIFF
--- a/plugins/eksporter.yaml
+++ b/plugins/eksporter.yaml
@@ -34,4 +34,4 @@ spec:
       kubectl get -oyaml | kubectl create -f -
 
     Run the tool with:
-      kubectl exporter <resource> <resource_name>
+      kubectl eksporter <resource> <resource_name>

--- a/plugins/eksporter.yaml
+++ b/plugins/eksporter.yaml
@@ -7,7 +7,7 @@ spec:
   platforms:
   - selector:
       matchExpressions:
-      - {key: os, operator: In, values: [darwin, linux]}
+      - {key: os, operator: In, values: [darwin, linux, windows]}
     uri: https://github.com/Kyrremann/kubeflow-eksporter/releases/download/v1.0.0/eksporter.tar.gz
     sha256: "1c13fac59c1c306db8498f394ee4cf1ba98eaa44c6f404fc2fad505533f00835"
     files:

--- a/plugins/eksporter.yaml
+++ b/plugins/eksporter.yaml
@@ -7,7 +7,12 @@ spec:
   platforms:
   - selector:
       matchExpressions:
-      - {key: os, operator: In, values: [darwin, linux, windows]}
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+        - windows
     uri: https://github.com/Kyrremann/kubeflow-eksporter/releases/download/v1.0.0/eksporter.tar.gz
     sha256: "1c13fac59c1c306db8498f394ee4cf1ba98eaa44c6f404fc2fad505533f00835"
     files:

--- a/plugins/eksporter.yaml
+++ b/plugins/eksporter.yaml
@@ -14,11 +14,19 @@ spec:
     - from: "/eksporter.rb"
       to: "."
     bin: "./eksporter.rb"
-  shortDescription: Eksport resources without generated fields
+  shortDescription: Export resources and removes a pre-defined set of fields for later import
   homepage: https://github.com/Kyrremann/kubeflow-eksporter
   caveats: |
     This plugin needs the following programs:
     * ruby
   description: |
-    This plugin helps you export resources, and trims away the fields
-    not necessary for applying the resource back into the cluster.
+    This plugin helps you export a resource, and removes a pre-defined set of
+    fields. This is useful for when you have resource you want to migrate from
+    one namespace or cluster, to another one, but need to edit/add some fields
+    before applying.
+
+    If you just need to move one resource, it's probably easier to just:
+      kubectl get -oyaml | kubectl create -f -
+
+    Run the tool with:
+      kubectl exporter <resource> <resource_name>

--- a/plugins/eksporter.yaml
+++ b/plugins/eksporter.yaml
@@ -1,0 +1,24 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: eksporter
+spec:
+  version: "v1.0.0"
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/Kyrremann/kubeflow-eksporter/releases/download/v1.0.0/eksporter.tar.gz
+    sha256: "1c13fac59c1c306db8498f394ee4cf1ba98eaa44c6f404fc2fad505533f00835"
+    files:
+    - from: "/eksporter.rb"
+      to: "."
+    bin: "./eksporter.rb"
+  shortDescription: Eksport resources without generated fields
+  homepage: https://github.com/Kyrremann/kubeflow-eksporter
+  caveats: |
+    This plugin needs the following programs:
+    * ruby
+  description: |
+    This plugin helps you export resources, and trims away the fields
+    not necessary for applying the resource back into the cluster.


### PR DESCRIPTION
This plugin helps you export resources, and trims away the fields not necessary for applying the resource back into the cluster.

It looks similar to the new plugin #191, but are focused on point 1 mentioned in the comments.

For me using `kubectl get -oyaml | kubectl create -f -` or similar technique aren't what I want.

---
PLUGIN DEVELOPERS: If you are submitting a new plugin

- [x]  Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- [x]  Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
