### PR TITLE
Add plugin: outdated

### DIFF
--- a/plugins/outdated.yaml
+++ b/plugins/outdated.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: outdated
 spec:
-  version: "v0.2.1"
+  version: "v0.2.2"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.1/outdated_0.2.1_linux_amd64-0.2.1.tar.gz
-    sha256: "7db25869cfc57dda938add04c088c070097fc83ecd7a27a12157da0e0d728864"
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.2/outdated_0.2.2_linux_amd64-0.2.2.tar.gz
+    sha256: "ceebe623a058fd010df64793761c327cfc1c817c730d769c19b98e00f0ba9f4f"
     files:
     - from: "./outdated"
       to: "."
@@ -19,8 +19,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.1/outdated_0.2.1_darwin_amd64-0.2.1.tar.gz
-    sha256: "6563b39093eb4e86647b451c55e8739cfe9165c5da846a29a4e7bd9ee44337dd"
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.2/outdated_0.2.2_darwin_amd64-0.2.2.tar.gz
+    sha256: "7e7b39367c5d135179edc58d22c72be58a272816d62348ccbb06d3680c9c68e1"
     files:
     - from: "./outdated"
       to: "."
@@ -29,8 +29,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.1/outdated_0.2.1_windows_amd64-0.2.1.zip
-    sha256: "662c1c51da8cb04148964ca83b16568204496cedde250cae0b943ef5890dd570"
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.2/outdated_0.2.2_windows_amd64-0.2.2.zip
+    sha256: "05052f0f97ce1986f69f69e1d442022b7bed1089f70ad9b25645dc1292a66023"
     files:
     - from: "/outdated.exe"
       to: "."
@@ -42,7 +42,7 @@ spec:
       $ kubectl outdated
     For additional options:
       $ kubectl outdated --help
-      or https://github.com/replicatedhq/outdated/blob/v0.2.0/doc/USAGE.md
+      or https://github.com/replicatedhq/outdated/blob/v0.2.2/doc/USAGE.md
   description: |
     The plugin will scan for all pods in all namespaces that you have at least
     read access to. It will then connect to the registry that hosts the image,

--- a/plugins/outdated.yaml
+++ b/plugins/outdated.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: outdated
 spec:
-  version: "v0.2.0"
+  version: "v0.2.1"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.0/outdated_0.2.0_linux_amd64-0.2.0.tar.gz
-    sha256: "9a2d1d1409425411473918059e3aded18e159d6ebb16ccab3b31cde0c61fb35a"
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.1/outdated_0.2.1_linux_amd64-0.2.1.tar.gz
+    sha256: "7db25869cfc57dda938add04c088c070097fc83ecd7a27a12157da0e0d728864"
     files:
     - from: "./outdated"
       to: "."
@@ -19,8 +19,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.0/outdated_0.2.0_darwin_amd64-0.2.0.tar.gz
-    sha256: "245e2b1bb8831b7e6daaa256facf17807493d2cb47f3719a6ffce1368c3f5a40"
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.1/outdated_0.2.1_darwin_amd64-0.2.1.tar.gz
+    sha256: "6563b39093eb4e86647b451c55e8739cfe9165c5da846a29a4e7bd9ee44337dd"
     files:
     - from: "./outdated"
       to: "."
@@ -29,8 +29,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.0/outdated_0.2.0_windows_amd64-0.2.0.zip
-    sha256: "28536427441c1033cf135f71ac4136de54a0c6214f498b6e0184c0fd921538ce"
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.1/outdated_0.2.1_windows_amd64-0.2.1.zip
+    sha256: "662c1c51da8cb04148964ca83b16568204496cedde250cae0b943ef5890dd570"
     files:
     - from: "/outdated.exe"
       to: "."
@@ -40,16 +40,13 @@ spec:
   caveats: |
     Usage:
       $ kubectl outdated
-
     For additional options:
       $ kubectl outdated --help
       or https://github.com/replicatedhq/outdated/blob/v0.2.0/doc/USAGE.md
-
   description: |
     The plugin will scan for all pods in all namespaces that you have at least
     read access to. It will then connect to the registry that hosts the image,
     and (if there's permission), it will analyze your tag to the list of
     current tags.
-
     The output is a list of all images, with the most out-of-date images in red,
     slightly outdated in yellow, and up-to-date in green.

--- a/plugins/outdated.yaml
+++ b/plugins/outdated.yaml
@@ -1,0 +1,55 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: outdated
+spec:
+  version: "v0.2.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.0/outdated_0.2.0_linux_amd64-0.2.0.tar.gz
+    sha256: "9a2d1d1409425411473918059e3aded18e159d6ebb16ccab3b31cde0c61fb35a"
+    files:
+    - from: "./outdated"
+      to: "."
+    bin: "outdated"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.0/outdated_0.2.0_darwin_amd64-0.2.0.tar.gz
+    sha256: "245e2b1bb8831b7e6daaa256facf17807493d2cb47f3719a6ffce1368c3f5a40"
+    files:
+    - from: "./outdated"
+      to: "."
+    bin: "outdated"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/replicatedhq/outdated/releases/download/v0.2.0/outdated_0.2.0_windows_amd64-0.2.0.zip
+    sha256: "28536427441c1033cf135f71ac4136de54a0c6214f498b6e0184c0fd921538ce"
+    files:
+    - from: "/outdated.exe"
+      to: "."
+    bin: "outdated.exe"
+  shortDescription: Finds outdated container images running in a cluster
+  homepage: https://github.com/replicatedhq/outdated
+  caveats: |
+    Usage:
+      $ kubectl outdated
+
+    For additional options:
+      $ kubectl outdated --help
+      or https://github.com/replicatedhq/outdated/blob/v0.2.0/doc/USAGE.md
+
+  description: |
+    The plugin will scan for all pods in all namespaces that you have at least
+    read access to. It will then connect to the registry that hosts the image,
+    and (if there's permission), it will analyze your tag to the list of
+    current tags.
+
+    The output is a list of all images, with the most out-of-date images in red,
+    slightly outdated in yellow, and up-to-date in green.


### PR DESCRIPTION
- [x] Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...].

This is a new plugin that compares images running in a cluster to the hosting registry and informs you if they are out of date, and how many versions out of date.

The name was inspired by the [npm outdated](https://docs.npmjs.com/cli/outdated.html) and [yarn outdated](https://yarnpkg.com/lang/en/docs/cli/outdated/) commands that offer similar functionality for node modules in that ecosystem.