### PR TITLE
Updated to latest version v0.2.2

### DIFF
--- a/plugins/view-utilization.yaml
+++ b/plugins/view-utilization.yaml
@@ -3,13 +3,13 @@ kind: Plugin
 metadata:
   name: view-utilization
 spec:
-  version: "v0.2.1"
+  version: "v0.2.2"
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/etopeter/kubectl-view-utilization/releases/download/v0.2.1/kubectl-view-utilization-v0.2.1.tar.gz
-    sha256: "ae96c8c2234ae7e66936c6c4c7c1260f1c51d46cfa3b836c49cfd3ab991d93f8"
+    uri: https://github.com/etopeter/kubectl-view-utilization/releases/download/v0.2.2/kubectl-view-utilization-v0.2.2.tar.gz
+    sha256: "c43d6ba2e86dc18231ef014f62bee9190a465bd9a379eddd234d896db3c715e5"
     bin: "kubectl-view-utilization"
     files:
     - from: "*"


### PR DESCRIPTION
view-utilization update to latest patch. Includes fix for filtering unschedulable nodes.