### PR TITLE
Migrate mtail to new repo and bump version to 1.1.0

### DIFF
--- a/plugins/mtail.yaml
+++ b/plugins/mtail.yaml
@@ -4,18 +4,18 @@ metadata:
   name: mtail
 spec:
   platforms:
-  - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
-    sha256: 4cf181eb79b1527c20ceff4dba072a8db897ef448e5b276e2d2d70b0a61e6282
-    uri: https://github.com/ahmetb/kubectl-extras/archive/3802e1cae8c037e73d0fec7bc9519c1bca9d25a1.zip
+  - head: https://gitlab.com/grzesuav/kubectl-mtail/-/archive/master/kubectl-mtail-master.zip
+    sha256: 592dca7f2fac476438fea5a5861f7f57c5329e82f76179061e1d689e105150d1
+    uri: https://gitlab.com/grzesuav/kubectl-mtail/uploads/e7e0277d55b21d3004e078b3f67133d0/mtail.tar.gz
     bin: mtail.sh
     files:
-    - from: "/*/mtail/*"
+    - from: "mtail/*"
       to: "."
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "v0.0.0"
-  homepage: https://github.com/ahmetb/kubectl-extras
+  version: "v1.1.0"
+  homepage: https://gitlab.com/grzesuav/kubectl-mtail
   shortDescription: Tail logs from multiple pods matching label selector
   caveats: |
     This plugin needs the following programs:


### PR DESCRIPTION
Moved to new repository and added new features, please check
https://gitlab.com/grzesuav/kubectl-mtail/-/releases for details.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Verified locally
