### PR TITLE
Add plugin: add-config

### DIFF
--- a/plugins/add-config.yaml
+++ b/plugins/add-config.yaml
@@ -1,0 +1,49 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: add-config
+spec:
+  version: "v0.1.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/nasa9084/kubectl-add_config/releases/download/v0.1.0/kubectl-add_config-v0.1.0.tar.gz
+    sha256: "ef6e8d09cac971dafc4732720a6ecf77571ebf1553335756e44527ac0d7ed8a1"
+    files:
+    - from: "*"
+      to: "."
+    bin: "./bin/kubectl-add_config-linux"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/nasa9084/kubectl-add_config/releases/download/v0.1.0/kubectl-add_config-v0.1.0.tar.gz
+    sha256: "ef6e8d09cac971dafc4732720a6ecf77571ebf1553335756e44527ac0d7ed8a1"
+    files:
+    - from: "*"
+      to: "."
+    bin: "./bin/kubectl-add_config-darwin"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/nasa9084/kubectl-add_config/releases/download/v0.1.0/kubectl-add_config-v0.1.0.tar.gz
+    sha256: "ef6e8d09cac971dafc4732720a6ecf77571ebf1553335756e44527ac0d7ed8a1"
+    files:
+    - from: "*"
+      to: "."
+    bin: "./bin/kubectl-add_config-windows.exe"
+  shortDescription: Add a new kubeconfig into local kubeconfig
+  homepage: https://github.com/nasa9084/kubectl-add_config
+  caveats: |
+    This plugin needs the following programs:
+      * kubectl
+    Usage:
+      `kubectl add-config -f NEW_KUBECONFIG`
+      or if you using on macOS, new config is copied in clipboard then:
+        `pbpaste | kubectl add-config`
+  description: |
+    This plugin merges a new kubeconfig file into your local existing kubeconfig using kubectl config add-XXX commands.
+    You can pass kubeconfig file path via `-f` option, if not specified, this plugin loads kubeconfig from stdin.


### PR DESCRIPTION
- [x] Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

This is a plugin to add a new kubeconfig into local kubeconfig. Some k8s cluster provider provides the configuration for kubernetes cluster as full-spec kubeconfig file. It is troublesome adding the config file into local existing kubeconfig or using KUBECONFIG environment variable if there has already kubeconfig.
