### PR TITLE
Update exec-as version

### DIFF
--- a/plugins/exec-as.yaml
+++ b/plugins/exec-as.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   platforms:
   - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
-    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.1-krew.zip
-    sha256: f6dc82bc8c00d31e4a08a82513d83ff1cb0f21323f8ab1011b2031863603183f
+    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.2-krew.zip
+    sha256: 9bd734b1dc08fc59df3f40418e92b228a830098a27257d454deccc5aa1384cf4
     bin: kubectl-exec-as
     files:
     - from: "**/kubectl-exec-as"
@@ -14,8 +14,8 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "v1.0.1-krew"
+  version: "v1.0.2-krew"
   caveats: The node which the pod is running on cannot have more than one taint.
   homepage: https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-exec-as
   shortDescription: Like kubectl exec, but offers a `user` flag to exec as root or any other user.
-  description: Run `kubectl exec-as` for usage. Example, `kubectl exec-as -u root -p zookeeper-0`.
+  description: Run `kubectl exec-as` for usage. Example, `kubectl exec-as -u root zookeeper-0`.


### PR DESCRIPTION
- Allows namespace traversal for exec-as.
- Addresses some minor edge case bugs.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
