### PR TITLE
oke-cluster-start-stop new plugin

### DIFF
--- a/plugins/oke-cluster-start-stop.yaml
+++ b/plugins/oke-cluster-start-stop.yaml
@@ -1,0 +1,24 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: oke-cluster-start-stop
+spec:
+  version: "v1.0.1"
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/javiermugueta/oke-cluster-start-stop/releases/download/1.0.0/oke-cluster-start-stop-1.0.0.zip
+    sha256: "72b48eebd1b7bc71eca2573274d4ef7b7fb91e6806d873ba815e12a880741a68"
+    files:
+    - from: "./kubectl-oke-cluster-start-stop"
+      to: "."
+    bin: "./kubectl-oke-cluster-start-stop"
+  shortDescription: Starts/stops compute nodes in OKE cluster.
+  homepage: https://github.com/javiermugueta/oke-cluster-start-stop 
+  caveats: |
+    This plugin needs the following programs:
+    * homebrew
+    * jq (it is installed automatically in case it is not)
+  description: |
+    This plugin starts or stops all the compute nodes of a k8s cluster in Oracle Kubernetes Engine (OKE).


### PR DESCRIPTION
Plugin for start/stop all compute nodes of a k8s OKE (Oracle Kubernetes Engine) cluster
More info: https://github.com/javiermugueta/oke-cluster-start-stop

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
