### PR TITLE
Bump grep to v1.2.0

### DIFF
--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -4,8 +4,8 @@ metadata:
   name: grep
 spec:
   platforms:
-  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.1.0/kubectl-grep-Darwin-x86_64.tar.gz
-    sha256: 2348dd6484903bfc394cfd9714e5bb66aa101c81e1f48227d819f726f89fbf96
+  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.2.0/kubectl-grep-Darwin-x86_64.tar.gz
+    sha256: d6d0c191ba4c5ebd8afff706404044392d3eb76acfb6cc0c985fac6bf111a0f9
     bin: kubectl-grep
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.1.0/kubectl-grep-Linux-x86_64.tar.gz
-    sha256: 1362e8a77bed882b5973ab7418c8e82d3aa46fdd1eced36d9c684a055f4cea02
+  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.2.0/kubectl-grep-Linux-x86_64.tar.gz
+    sha256: c2720eac05fdc3645501ff7f9738c3411ce35cf78861a65e042e89b509521071
     bin: kubectl-grep
     files:
     - from: "*"
@@ -24,8 +24,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.1.0/kubectl-grep-Windows-x86_64.tar.gz
-    sha256: d45edf88d0840057d38349ef3b8d6ea1246cc31ec94a6656cbbb758eb1c3d597
+  - uri: https://github.com/guessi/kubectl-grep/releases/download/v1.2.0/kubectl-grep-Windows-x86_64.tar.gz
+    sha256: 44d5702a3b90d81621fcfa34bd298ad1a83ca92599b29ab8da3607f9cf94e97b
     bin: kubectl-grep.exe
     files:
     - from: "*"
@@ -34,7 +34,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: v1.1.0
+  version: v1.2.0
   homepage: https://github.com/guessi/kubectl-grep
   caveats: |
     This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
@@ -42,29 +42,12 @@ spec:
     Usage:
 
       $ kubectl grep # output help messages
-      $ kubectl grep pods keyword
-      $ kubectl grep deployments keyword
-      $ kubectl grep pods keyword -n namespace
-      $ kubectl grep pods keyword --all-namespaces
 
     More Info:
     - https://github.com/guessi/kubectl-grep
   shortDescription: Filter Kubernetes resources by matching their names
   description: |
     Filter Kubernetes resources by matching their names
-
-    From ...
-    $ kubectl get -n namespace [resourceType] | grep 'keyword'
-
-    To ...
-    $ kubectl grep [resourceType] [keyword]
-
-    Supported Resource Types:
-    - daemonset
-    - deployment
-    - hpa
-    - node
-    - pod
 
     Examples:
 


### PR DESCRIPTION
**CHANGELOG:**
- https://github.com/guessi/kubectl-grep/blob/master/CHANGELOG.md#v120--2019-09-15

**Remove previous installed kubectl-grep**
```
% kubectl krew uninstall grep
Uninstalled plugin grep
```

**Local test for installation script**
```
% kubectl krew install --manifest plugins/grep.yaml
Installing plugin: grep
CAVEATS:
\
 |  This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
 |
 |  Usage:
 |
 |    $ kubectl grep # output help messages
 |
 |  More Info:
 |  - https://github.com/guessi/kubectl-grep
/
Installed plugin: grep
WARNING: You installed a plugin from the krew-index plugin repository.
   These plugins are not audited for security by the Krew maintainers.
   Run them at your own risk.
```

**Verification**
```
% kubectl grep version
kubectl-grep version: v1.2.0
```