### PR TITLE
update release of modify-secret to v0.0.6

### DIFF
--- a/plugins/modify-secret.yaml
+++ b/plugins/modify-secret.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: modify-secret
 spec:
-  version: v0.0.4
+  version: v0.0.6
   platforms:
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/rajatjindal/kubectl-modify-secret/releases/download/v0.0.5/darwin-amd64-v0.0.5.tar.gz
-    sha256: ab078c03ac54f23c957150420fff5c7d6fbfda1e3f99e302a6974ccb6f3d93ac
+    uri: https://github.com/rajatjindal/kubectl-modify-secret/releases/download/v0.0.6/darwin-amd64-v0.0.6.tar.gz
+    sha256: 78acc17ef02b6baeaed9aeb7dcd5e0910e9909e0d00ab7076d8ba22ec53ad385
     files:
     - from: "*"
       to: "."
@@ -19,8 +19,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/rajatjindal/kubectl-modify-secret/releases/download/v0.0.5/linux-amd64-v0.0.5.tar.gz
-    sha256: b03d08973277ba0c14c032ac2b24c4f24225781dd38efeac7ff33048d8cbfcd2
+    uri: https://github.com/rajatjindal/kubectl-modify-secret/releases/download/v0.0.6/linux-amd64-v0.0.6.tar.gz
+    sha256: 138e20a872fe6a6afbdf74f4998198ebad7e640a355076d666b0216b02f55038
     files:
     - from: "*"
       to: "."


### PR DESCRIPTION
Uprev release of modify-secret to v0.0.6 that fixes the msg user receives when no changes have been done to the secret.