### PR TITLE
Remove obsolete `head` field from manifests

### DIFF
--- a/plugins/ca-cert.yaml
+++ b/plugins/ca-cert.yaml
@@ -4,8 +4,7 @@ metadata:
   name: ca-cert
 spec:
   platforms:
-  - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
-    sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
+  - sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
     uri: https://github.com/ahmetb/kubectl-extras/archive/c403c5714a4442b8314e5a86b0ff63f7a815f83f.zip
     bin: ca-cert.bash
     files:

--- a/plugins/exec-as.yaml
+++ b/plugins/exec-as.yaml
@@ -4,8 +4,7 @@ metadata:
   name: exec-as
 spec:
   platforms:
-  - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
-    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.2-krew.zip
+  - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.2-krew.zip
     sha256: 9bd734b1dc08fc59df3f40418e92b228a830098a27257d454deccc5aa1384cf4
     bin: kubectl-exec-as
     files:

--- a/plugins/gke-credentials.yaml
+++ b/plugins/gke-credentials.yaml
@@ -4,8 +4,7 @@ metadata:
   name: gke-credentials
 spec:
   platforms:
-  - head: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
-    sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
+  - sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
     uri: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
     bin: gke-credentials.sh
     files:

--- a/plugins/mtail.yaml
+++ b/plugins/mtail.yaml
@@ -4,8 +4,7 @@ metadata:
   name: mtail
 spec:
   platforms:
-  - head: https://gitlab.com/grzesuav/kubectl-mtail/-/archive/master/kubectl-mtail-master.zip
-    sha256: 592dca7f2fac476438fea5a5861f7f57c5329e82f76179061e1d689e105150d1
+  - sha256: 592dca7f2fac476438fea5a5861f7f57c5329e82f76179061e1d689e105150d1
     uri: https://gitlab.com/grzesuav/kubectl-mtail/uploads/e7e0277d55b21d3004e078b3f67133d0/mtail.tar.gz
     bin: mtail.sh
     files:

--- a/plugins/pod-logs.yaml
+++ b/plugins/pod-logs.yaml
@@ -4,8 +4,7 @@ metadata:
   name: pod-logs
 spec:
   platforms:
-  - head: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
-    sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
+  - sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
     uri: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
     bin: pod-logs.sh
     files:

--- a/plugins/pod-shell.yaml
+++ b/plugins/pod-shell.yaml
@@ -4,8 +4,7 @@ metadata:
   name: pod-shell
 spec:
   platforms:
-  - head: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
-    sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
+  - sha256: c548f94d8efd1fb8aa35a54b7e5cdb64ae012447122d9704f3cee4163bbbe9c3
     uri: https://github.com/danisla/kubefunc/archive/v1.0.1.zip
     bin: pod-shell.sh
     files:

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -4,8 +4,7 @@ metadata:
   name: prompt
 spec:
   platforms:
-  - head: https://github.com/jordanwilson230/kubectl-plugins/archive/krew.zip
-    uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
+  - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
     sha256: efa1c2122ecaeb0a43ba1ed9e54c1ff1274d20de76934f7bb91dd154f2327aa1
     bin: kubectl-prompt
     files:

--- a/plugins/rm-standalone-pods.yaml
+++ b/plugins/rm-standalone-pods.yaml
@@ -4,8 +4,7 @@ metadata:
   name: rm-standalone-pods
 spec:
   platforms:
-  - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
-    sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
+  - sha256: 8be8ed348d02285abc46bbf7a4cc83da0ee9d54dc2c5bf86a7b64947811b843c
     uri: https://github.com/ahmetb/kubectl-extras/archive/c403c5714a4442b8314e5a86b0ff63f7a815f83f.zip
     bin: rm-standalone-pods.bash
     files:

--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -4,8 +4,7 @@ metadata:
   name: view-secret
 spec:
   platforms:
-  - head: https://github.com/ahmetb/kubectl-extras/archive/master.zip
-    sha256: 208fde0b9f42ef71f79864b1ce594a70832c47dc5426e10ca73bf02e54d499d0
+  - sha256: 208fde0b9f42ef71f79864b1ce594a70832c47dc5426e10ca73bf02e54d499d0
     uri: https://github.com/ahmetb/kubectl-extras/archive/b16b7c43a28240ed280c03b20e6a2f232f992479.zip
     bin: view-secret.sh
     files:


### PR DESCRIPTION
The `head` field was removed in krew v0.3.0. This PR cleans up existing manifests which still use reference this field. All of them also offer installation via a versioned release, so there are no conflicts.

Close #240 