### PR TITLE
Adds kubectl-fields plugin

### DIFF
--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fields
 spec:
   platforms:
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.0/kubectl-fields-Darwin-x86_64.tar.gz
-    sha256: 2e163e28075a69d4d1dca2b338ec889d967b38fb3e0ed2de1c89993b99ae2889
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.1/kubectl-fields-Darwin-x86_64.tar.gz
+    sha256: 9fe7b746fa74ba3deedabf77ecb35e7e24b7fc0410dd96219dff4ece02543fdf
     bin: kubectl-fields
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.0/kubectl-fields-Linux-x86_64.tar.gz
-    sha256: 951739ca1c73dac0729ec46828e677effa80b607efbbf4e79829f7a243126af7
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.1/kubectl-fields-Linux-x86_64.tar.gz
+    sha256: 21ee6334120bae36ab4a4b23fed731423d81b21058a6df33e92b38110e0fbb2b
     bin: kubectl-fields
     files:
     - from: "*"
@@ -24,8 +24,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.0/kubectl-fields-Windows-x86_64.tar.gz
-    sha256: 2785c6ccb4b1895c37423192f988dca4f3d4f8222cdce9fa0fdf60810e7c4eda
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.1/kubectl-fields-Windows-x86_64.zip
+    sha256: 1eea1afb8b623934a240d9cc31923e9ab036524ae3d8a8349b50daced7e99cd7
     bin: kubectl-fields.exe
     files:
     - from: "*"
@@ -34,11 +34,11 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: v1.0.0
+  version: v1.0.1
   homepage: https://github.com/rewanth1997/kubectl-fields
   caveats: |
     Usage:
-      $ kubectl fields [options] <RESOURCE> <PATTERN>
+      $ kubectl fields <RESOURCE> [options] <PATTERN> [<PATTERN 2> ...]
 
     Options:
       -h, --help          help for kubectl-fields
@@ -59,7 +59,7 @@ spec:
     containers.securityContext.capabilities
     initContainers.securityContext.capabilities
 
-    $ kubectl fields -i svc ip
+    $ kubectl fields svc -i ip
     spec.clusterIP
     spec.externalIPs
     spec.loadBalancerIP

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fields
 spec:
   platforms:
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.1/kubectl-fields-Darwin-x86_64.tar.gz
-    sha256: 9fe7b746fa74ba3deedabf77ecb35e7e24b7fc0410dd96219dff4ece02543fdf
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.1.1-beta/kubectl-fields-Darwin-x86_64.tar.gz
+    sha256: ac82ee062e8bf1a9c6f6fab2e718e6d560c4ca1855616c2a67b0411792b575bc
     bin: kubectl-fields
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.1/kubectl-fields-Linux-x86_64.tar.gz
-    sha256: 21ee6334120bae36ab4a4b23fed731423d81b21058a6df33e92b38110e0fbb2b
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.1.1-beta/kubectl-fields-Linux-x86_64.tar.gz
+    sha256: 051140e9df85e7c3b982fc7b4199084441bbfc6328624f9a0dff07193058f135
     bin: kubectl-fields
     files:
     - from: "*"
@@ -24,8 +24,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.1/kubectl-fields-Windows-x86_64.zip
-    sha256: 1eea1afb8b623934a240d9cc31923e9ab036524ae3d8a8349b50daced7e99cd7
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.1.1-beta/kubectl-fields-Windows-x86_64.zip
+    sha256: d188b7d2d1c567d7b074a3d8eb6c075aa8713e483074b839ff0da0300a8c710a
     bin: kubectl-fields.exe
     files:
     - from: "*"

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -34,7 +34,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: v1.0.1
+  version: v1.1.1-beta
   homepage: https://github.com/rewanth1997/kubectl-fields
   caveats: |
     Usage:

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -38,15 +38,9 @@ spec:
   homepage: https://github.com/rewanth1997/kubectl-fields
   caveats: |
     Usage:
-      $ kubectl fields <RESOURCE> [options] <PATTERN>
+      kubectl fields <RESOURCE> [options] <PATTERN>
 
-    Options:
-      -I, --case-sensitive   Case sensitive pattern match
-      -h, --help             help for kubectl-fields
-          --no-color         Do not print colored output
-          --stdin            Expects input via pipes
-
-    Read the documentation:
+    Documentation:
       https://github.com/rewanth1997/kubectl-fields/tree/v1.2.0-beta
   shortDescription: Grep resources hierarchy by field name
   description: |

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -1,0 +1,78 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: fields
+spec:
+  platforms:
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.0/kubectl-fields-Darwin-x86_64.tar.gz
+    sha256: 2e163e28075a69d4d1dca2b338ec889d967b38fb3e0ed2de1c89993b99ae2889
+    bin: kubectl-fields
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.0/kubectl-fields-Linux-x86_64.tar.gz
+    sha256: 951739ca1c73dac0729ec46828e677effa80b607efbbf4e79829f7a243126af7
+    bin: kubectl-fields
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.0.0/kubectl-fields-Windows-x86_64.tar.gz
+    sha256: 2785c6ccb4b1895c37423192f988dca4f3d4f8222cdce9fa0fdf60810e7c4eda
+    bin: kubectl-fields.exe
+    files:
+    - from: "*"
+      to: "."
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+  version: v1.0.0
+  homepage: https://github.com/rewanth1997/kubectl-fields
+  caveats: |
+    Usage:
+      $ kubectl fields [options] <RESOURCE> <PATTERN>
+
+    Options:
+      -h, --help          help for kubectl-fields
+      -i, --ignore-case   Ignore case distinction
+      --stdin         Expects input via pipes
+
+    Read the documentation:
+      https://github.com/rewanth1997/kubectl-fields/blob/master/README.md
+  shortDescription: Kubectl resources hierarchy parser
+  description: |
+    Kubectl resources hierarchy parser.
+
+    More on https://github.com/rewanth1997/kubectl-fields
+
+    Examples:
+
+    $ kubectl fields po.spec capa
+    containers.securityContext.capabilities
+    initContainers.securityContext.capabilities
+
+    $ kubectl fields -i svc ip
+    spec.clusterIP
+    spec.externalIPs
+    spec.loadBalancerIP
+    spec.sessionAffinityConfig.clientIP
+    status.loadBalancer.ingress.ip
+
+    Additional kubectl-fields example (the hard way not recommended). Developed to run tests on pipeline
+
+    $ kubectl explain --recursive po.spec | ./kubectl-fields --stdin ver
+    dnsConfig.nameservers
+    volumes.csi.driver
+    volumes.flexVolume.driver
+    volumes.iscsi.chapAuthDiscovery
+    volumes.nfs.server`
+
+    No more greps, pipes and scrolling up and down to find hierarchial order for resources :-)

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -45,7 +45,7 @@ spec:
   shortDescription: Grep resources hierarchy by field name
   description: |
     kubectl-fields parses specified kubectl resources to match given pattern(s).
-    It prints matched fields parental hierarchy in one-liner format.
+    It prints parental hierarchy of matched fields in one-liner format.
 
     More on https://github.com/rewanth1997/kubectl-fields
 
@@ -60,5 +60,3 @@ spec:
     $ kubectl fields svc -i affinity
     spec.sessionAffinity
     spec.sessionAffinityConfig`
-
-    No more greps, pipes and scrolling up and down to find hierarchial order for resources :-)

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -38,7 +38,7 @@ spec:
   homepage: https://github.com/rewanth1997/kubectl-fields
   caveats: |
     Usage:
-      $ kubectl fields <RESOURCE> [options] <PATTERN> [<PATTERN 2> ...]
+      $ kubectl fields <RESOURCE> [options] <PATTERN>
 
     Options:
       -h, --help          help for kubectl-fields
@@ -46,33 +46,23 @@ spec:
       --stdin         Expects input via pipes
 
     Read the documentation:
-      https://github.com/rewanth1997/kubectl-fields/blob/master/README.md
-  shortDescription: Kubectl resources hierarchy parser
+      https://github.com/rewanth1997/kubectl-fields/tree/v1.0.1
+  shortDescription: Grep resources hierarchy by field name
   description: |
-    Kubectl resources hierarchy parser.
+    Kubectl-fields is a cli tool to parse kubectl explain --recursive output and grep matching pattern in one-liner hierarchy format.
 
     More on https://github.com/rewanth1997/kubectl-fields
 
     Examples:
 
+    Find resource field names:
     $ kubectl fields po.spec capa
     containers.securityContext.capabilities
     initContainers.securityContext.capabilities
 
-    $ kubectl fields svc -i ip
-    spec.clusterIP
-    spec.externalIPs
-    spec.loadBalancerIP
-    spec.sessionAffinityConfig.clientIP
-    status.loadBalancer.ingress.ip
-
-    Additional kubectl-fields example (the hard way not recommended). Developed to run tests on pipeline
-
-    $ kubectl explain --recursive po.spec | ./kubectl-fields --stdin ver
-    dnsConfig.nameservers
-    volumes.csi.driver
-    volumes.flexVolume.driver
-    volumes.iscsi.chapAuthDiscovery
-    volumes.nfs.server`
+    Find resource field names case-insensitively:
+    $ kubectl fields svc -i affinity
+    spec.sessionAffinity
+    spec.sessionAffinityConfig`
 
     No more greps, pipes and scrolling up and down to find hierarchial order for resources :-)

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fields
 spec:
   platforms:
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.1.1-beta/kubectl-fields-Darwin-x86_64.tar.gz
-    sha256: ac82ee062e8bf1a9c6f6fab2e718e6d560c4ca1855616c2a67b0411792b575bc
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.2.0-beta/kubectl-fields-Darwin-x86_64.tar.gz
+    sha256: 35072754f24a0bf239c6bb90a53c528b7b88f99435e2a142907599b18169fade
     bin: kubectl-fields
     files:
     - from: "*"
@@ -14,8 +14,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.1.1-beta/kubectl-fields-Linux-x86_64.tar.gz
-    sha256: 051140e9df85e7c3b982fc7b4199084441bbfc6328624f9a0dff07193058f135
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.2.0-beta/kubectl-fields-Linux-x86_64.tar.gz
+    sha256: 730602c8400ad7b712a2eab26d3e1a5feb6593f442f369a3ea246fbb37f6fd3d
     bin: kubectl-fields
     files:
     - from: "*"
@@ -24,8 +24,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.1.1-beta/kubectl-fields-Windows-x86_64.zip
-    sha256: d188b7d2d1c567d7b074a3d8eb6c075aa8713e483074b839ff0da0300a8c710a
+  - uri: https://github.com/rewanth1997/kubectl-fields/releases/download/v1.2.0-beta/kubectl-fields-Windows-x86_64.zip
+    sha256: 2ea706370ea3260e9e68943947bbaff295bc4fa1b97cf1492912b01d04d303a2
     bin: kubectl-fields.exe
     files:
     - from: "*"
@@ -34,22 +34,24 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: v1.1.1-beta
+  version: v1.2.0-beta
   homepage: https://github.com/rewanth1997/kubectl-fields
   caveats: |
     Usage:
       $ kubectl fields <RESOURCE> [options] <PATTERN>
 
     Options:
-      -h, --help          help for kubectl-fields
-      -i, --ignore-case   Ignore case distinction
-      --stdin         Expects input via pipes
+      -I, --case-sensitive   Case sensitive pattern match
+      -h, --help             help for kubectl-fields
+          --no-color         Do not print colored output
+          --stdin            Expects input via pipes
 
     Read the documentation:
-      https://github.com/rewanth1997/kubectl-fields/tree/v1.0.1
+      https://github.com/rewanth1997/kubectl-fields/tree/v1.2.0-beta
   shortDescription: Grep resources hierarchy by field name
   description: |
-    Kubectl-fields is a cli tool to parse kubectl explain --recursive output and grep matching pattern in one-liner hierarchy format.
+    kubectl-fields parses specified kubectl resources to match given pattern(s).
+    It prints matched fields parental hierarchy in one-liner format.
 
     More on https://github.com/rewanth1997/kubectl-fields
 


### PR DESCRIPTION
Requesting to add `fields` plugin to krew index.

I hope I followed all guidelines, and I did verify installing it locally.

An extensive set of testcases have been added to pipeline for robustness testing of new binary. 
Link to source code: [https://github.com/rewanth1997/kubectl-fields](https://github.com/rewanth1997/kubectl-fields)

```console
wget https://raw.githubusercontent.com/rewanth1997/kubectl-fields/master/deploy/krew/plugin.yaml
kubectl krew install --manifest=./plugin.yaml
```

Repo link: https://github.com/rewanth1997/kubectl-fields

Please review the code. I'm happy to make the necessary changes if any.

Regards,
Rewanth