### PR TITLE
Add plugin: kubeval

### DIFF
--- a/plugins/kubeval.yaml
+++ b/plugins/kubeval.yaml
@@ -1,12 +1,12 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 ￼kind: Plugin
 ￼metadata:
-￼  name: validate-config
+￼  name: kubeval
 ￼spec:
 ￼  version: "0.14.0"
-￼  shortDescription: Validate your Kubernetes configuration files
+￼  shortDescription: Validate schema of resource files
   description: |
-    The plugin validate a Kubernetes YAML or JSON configuration file.
+    The plugin validates a Kubernetes YAML or JSON configuration file.
     It does so using schemas generated from the Kubernetes OpenAPI specification,
     and therefore can validate schemas for multiple versions of Kubernetes
   homepage: https://github.com/instrumenta/kubeval
@@ -17,6 +17,8 @@ apiVersion: krew.googlecontainertools.github.com/v1alpha2
 ￼      files:
 ￼      - from: "./kubeval"
 ￼        to: "."
+      - from: LICENSE
+        to: .
 ￼      selector:
 ￼        matchLabels:
 ￼          os: linux
@@ -25,8 +27,10 @@ apiVersion: krew.googlecontainertools.github.com/v1alpha2
 ￼      sha256: "05b9993e59a32b95bc5496dd98598e4a425643151efd108c0449405dd4a2a4c7"
 ￼      bin: kubeval
 ￼      files:
-￼        - from: "./kubeval"
-￼          to: "."
+￼      - from: "./kubeval"
+￼        to: "."
+￼      - from: LICENSE
+        to: .
 ￼      selector:
 ￼        matchLabels:
 ￼          os: darwin
@@ -35,8 +39,10 @@ apiVersion: krew.googlecontainertools.github.com/v1alpha2
       sha256: "2a844518981848a7d77cced9b51a05174ba9c17fc007a1c48cd2af0d3fb021d7"
 ￼      bin: kubeval.exe
 ￼      files:
-￼        - from: "./kubeval.exe"
-￼          to: "."
+￼      - from: "./kubeval.exe"
+￼        to: "."
+￼      - from: LICENSE
+        to: .
 ￼      selector:
 ￼        matchLabels:
 ￼          os: windows

--- a/plugins/kubeval.yaml
+++ b/plugins/kubeval.yaml
@@ -19,7 +19,7 @@ apiVersion: krew.googlecontainertools.github.com/v1alpha2
 ￼          arch: amd64
 ￼    - uri: https://github.com/instrumenta/kubeval/releases/download/0.14.0/kubeval-darwin-amd64.tar.gz
 ￼      sha256: "05b9993e59a32b95bc5496dd98598e4a425643151efd108c0449405dd4a2a4c7"
-￼      bin: kubectl-kubeval.sh
+￼      bin: kubeval
 ￼      files:
 ￼        - from: "./kubeval"
 ￼          to: "."
@@ -29,9 +29,9 @@ apiVersion: krew.googlecontainertools.github.com/v1alpha2
 ￼          arch: amd64
     - uri: https://github.com/instrumenta/kubeval/releases/download/0.14.0/kubeval-windows-amd64.zip
       sha256: "2a844518981848a7d77cced9b51a05174ba9c17fc007a1c48cd2af0d3fb021d7"
-￼      bin: kubectl-kubeval.sh
+￼      bin: kubeval.exe
 ￼      files:
-￼        - from: "./kubeval"
+￼        - from: "./kubeval.exe"
 ￼          to: "."
 ￼      selector:
 ￼        matchLabels:

--- a/plugins/kubeval.yaml
+++ b/plugins/kubeval.yaml
@@ -1,11 +1,15 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 ￼kind: Plugin
 ￼metadata:
-￼  name: validate-manifests
+￼  name: validate-config
 ￼spec:
 ￼  version: "0.14.0"
-￼  shortDescription: Validate your Kubernetes configuration files, supports multiple Kubernetes versions
-￼  homepage: https://github.com/instrumenta/kubeval
+￼  shortDescription: Validate your Kubernetes configuration files
+  description: |
+    The plugin validate a Kubernetes YAML or JSON configuration file.
+    It does so using schemas generated from the Kubernetes OpenAPI specification,
+    and therefore can validate schemas for multiple versions of Kubernetes
+  homepage: https://github.com/instrumenta/kubeval
 ￼  platforms:
 ￼    - uri: https://github.com/instrumenta/kubeval/releases/download/0.14.0/kubeval-linux-amd64.tar.gz
 ￼      sha256: "8b1b8c63df9ee3206113a3352e07474ea071610cfacf40a64db74c56e163f1e2"

--- a/plugins/kubeval.yaml
+++ b/plugins/kubeval.yaml
@@ -1,0 +1,39 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+￼kind: Plugin
+￼metadata:
+￼  name: validate-manifests
+￼spec:
+￼  version: "0.14.0"
+￼  shortDescription: Validate your Kubernetes configuration files, supports multiple Kubernetes versions
+￼  homepage: https://github.com/instrumenta/kubeval
+￼  platforms:
+￼    - uri: https://github.com/instrumenta/kubeval/releases/download/0.14.0/kubeval-linux-amd64.tar.gz
+￼      sha256: "8b1b8c63df9ee3206113a3352e07474ea071610cfacf40a64db74c56e163f1e2"
+￼      bin: kubeval
+￼      files:
+￼      - from: "./kubeval"
+￼        to: "."
+￼      selector:
+￼        matchLabels:
+￼          os: linux
+￼          arch: amd64
+￼    - uri: https://github.com/instrumenta/kubeval/releases/download/0.14.0/kubeval-darwin-amd64.tar.gz
+￼      sha256: "05b9993e59a32b95bc5496dd98598e4a425643151efd108c0449405dd4a2a4c7"
+￼      bin: kubectl-kubeval.sh
+￼      files:
+￼        - from: "./kubeval"
+￼          to: "."
+￼      selector:
+￼        matchLabels:
+￼          os: darwin
+￼          arch: amd64
+    - uri: https://github.com/instrumenta/kubeval/releases/download/0.14.0/kubeval-windows-amd64.zip
+      sha256: "2a844518981848a7d77cced9b51a05174ba9c17fc007a1c48cd2af0d3fb021d7"
+￼      bin: kubectl-kubeval.sh
+￼      files:
+￼        - from: "./kubeval"
+￼          to: "."
+￼      selector:
+￼        matchLabels:
+￼          os: windows
+￼          arch: amd64


### PR DESCRIPTION
This plugin allow for running `kubeval` , a tool for validating a Kubernetes YAML or JSON configuration file. 
It does so using schemas generated from the Kubernetes OpenAPI specification, and therefore can validate schemas for multiple versions of Kubernetes.
