### PR TITLE
Update view-secrets references

### DIFF
--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -3,22 +3,24 @@ kind: Plugin
 metadata:
   name: view-secret
 spec:
-  version: "v0.1.0"
+  version: "v0.2.0"
   homepage: https://github.com/elsesiy/kubectl-view-secret
   shortDescription: |
     Decode Kubernetes secrets
   description: |+2
-    Base64 decode all key/value pairs in a given secret.
+    Base64 decode by key or all key/value pairs in a given secret.
 
-    $ kubectl view-secret <secret>
-    $ kubectl view-secret <secret> --namespace foo
+    $ kubectl view-secret <secret> # print secret keys
+    $ kubectl view-secret <secret> <key> # decode secret by key
+    $ kubectl view-secret <secret> -a/--all # decode all secret contents
+    $ kubectl view-secret <secret> -n/--namespace foo # print keys for secret in different namespace
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.1.0/kubectl-view-secret_0.1.0_Darwin_x86_64.tar.gz
-      sha256: "35d6922031ac89726880218cd5b25a682ddc3a23f877b937d750a8f92707e29c"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.2.0/kubectl-view-secret_0.2.0_Darwin_x86_64.tar.gz
+      sha256: "46d5fa2dadbdf13d1a470263fe75a4c6e4b061cfd383ab4642e8786206334f3d"
       files:
         - from: kubectl-view-secret
           to: .
@@ -27,8 +29,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.1.0/kubectl-view-secret_0.1.0_Linux_x86_64.tar.gz
-      sha256: "67f6f13b437aa7381423001743c30ee43a939a547e2b41f4abd6377d3139edf2"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.2.0/kubectl-view-secret_0.2.0_Linux_x86_64.tar.gz
+      sha256: "ac24776dd1170b78280445cac7562d3d4f5c984cedb613daef8cb1b0b934f442"
       files:
         - from: kubectl-view-secret
           to: .
@@ -37,8 +39,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.1.0/kubectl-view-secret_0.1.0_Windows_x86_64.tar.gz
-      sha256: "80201481c07747878cb449ad868adcef8b4c3fb75e91e455551cc74b6d868daa"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.2.0/kubectl-view-secret_0.2.0_Windows_x86_64.tar.gz
+      sha256: "bac09b27a02738892d90199a2a3659d7fed5b6f43ac6f8dcd06e2ab9415293fb"
       files:
         - from: kubectl-view-secret.exe
           to: .

--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -3,19 +3,43 @@ kind: Plugin
 metadata:
   name: view-secret
 spec:
+  version: "v0.1.0"
+  homepage: https://github.com/elsesiy/kubectl-view-secret
+  shortDescription: |
+    Decode Kubernetes secrets
+  description: |+2
+    Base64 decode all key/value pairs in a given secret.
+
+    $ kubectl view-secret <secret>
+    $ kubectl view-secret <secret> --namespace foo
   platforms:
-  - sha256: 208fde0b9f42ef71f79864b1ce594a70832c47dc5426e10ca73bf02e54d499d0
-    uri: https://github.com/ahmetb/kubectl-extras/archive/b16b7c43a28240ed280c03b20e6a2f232f992479.zip
-    bin: view-secret.sh
-    files:
-    - from: "/*/view-secret/*"
-      to: "."
-    selector:
-      matchExpressions:
-      - {key: os, operator: In, values: [darwin, linux]}
-  version: "v0.0.0"
-  homepage: https://github.com/ahmetb/kubectl-extras
-  shortDescription: Decode secrets
-  caveats: |
-    This plugin needs the following programs:
-    * jq
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.1.0/kubectl-view-secret_0.1.0_Darwin_x86_64.tar.gz
+      sha256: "35d6922031ac89726880218cd5b25a682ddc3a23f877b937d750a8f92707e29c"
+      files:
+        - from: kubectl-view-secret
+          to: .
+      bin: kubectl-view-secret
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.1.0/kubectl-view-secret_0.1.0_Linux_x86_64.tar.gz
+      sha256: "67f6f13b437aa7381423001743c30ee43a939a547e2b41f4abd6377d3139edf2"
+      files:
+        - from: kubectl-view-secret
+          to: .
+      bin: kubectl-view-secret
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.1.0/kubectl-view-secret_0.1.0_Windows_x86_64.tar.gz
+      sha256: "80201481c07747878cb449ad868adcef8b4c3fb75e91e455551cc74b6d868daa"
+      files:
+        - from: kubectl-view-secret.exe
+          to: .
+      bin: kubectl-view-secret.exe

--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -3,24 +3,34 @@ kind: Plugin
 metadata:
   name: view-secret
 spec:
-  version: "v0.2.0"
+  version: "v0.3.0"
   homepage: https://github.com/elsesiy/kubectl-view-secret
   shortDescription: |
     Decode Kubernetes secrets
   description: |+2
     Base64 decode by key or all key/value pairs in a given secret.
 
-    $ kubectl view-secret <secret> # print secret keys
-    $ kubectl view-secret <secret> <key> # decode secret by key
-    $ kubectl view-secret <secret> -a/--all # decode all secret contents
-    $ kubectl view-secret <secret> -n/--namespace foo # print keys for secret in different namespace
+    # print secret keys
+    $ kubectl view-secret <secret>
+
+    # decode specific entry
+    $ kubectl view-secret <secret> <key>
+
+    # decode all secret contents
+    $ kubectl view-secret <secret> -a/--all
+
+    # print keys for secret in different namespace
+    $ kubectl view-secret <secret> -n/--namespace foo
+
+    # suppress info output
+    $ kubectl view-secret <secret> -q/--quiet
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.2.0/kubectl-view-secret_0.2.0_Darwin_x86_64.tar.gz
-      sha256: "46d5fa2dadbdf13d1a470263fe75a4c6e4b061cfd383ab4642e8786206334f3d"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.3.0/kubectl-view-secret_0.3.0_Darwin_x86_64.tar.gz
+      sha256: "36ef260835d35814d0e18c7fb1792a61686f0e584373ee0e04554f4d675a76ee"
       files:
         - from: kubectl-view-secret
           to: .
@@ -29,8 +39,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.2.0/kubectl-view-secret_0.2.0_Linux_x86_64.tar.gz
-      sha256: "ac24776dd1170b78280445cac7562d3d4f5c984cedb613daef8cb1b0b934f442"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.3.0/kubectl-view-secret_0.3.0_Linux_x86_64.tar.gz
+      sha256: "5886e5350dac40c38e904c126161e252f832df45b87bf60da7320bbdde0f56c7"
       files:
         - from: kubectl-view-secret
           to: .
@@ -39,8 +49,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.2.0/kubectl-view-secret_0.2.0_Windows_x86_64.tar.gz
-      sha256: "bac09b27a02738892d90199a2a3659d7fed5b6f43ac6f8dcd06e2ab9415293fb"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.3.0/kubectl-view-secret_0.3.0_Windows_x86_64.tar.gz
+      sha256: "baa0bf9110d6ff443e34a7900220e3d3072d8c267be6d0ff50ee989989953497"
       files:
         - from: kubectl-view-secret.exe
           to: .


### PR DESCRIPTION
Hi,
as announced to @ahmetb [here](https://github.com/ahmetb/kubectl-extras/pull/12), I re-wrote the `view-secrets` plugin.

This PR changes the existing references to the new repo.