### PR TITLE
Update plugin "access-matrix" to v0.4.2

### DIFF
--- a/plugins/access-matrix.yaml
+++ b/plugins/access-matrix.yaml
@@ -3,34 +3,40 @@ kind: Plugin
 metadata:
   name: access-matrix
 spec:
-  version: "v0.4.1"
+  version: "v0.4.2"
   platforms:
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.4.1/bundle.tar.gz
-      sha256: 50c6321db984dcc4ddadf0d62385145431562450bbac75b67ad3db959dd327de
-      bin: rakkess-linux-amd64
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.4.2/access-matrix-amd64-linux.tar.gz
+      sha256: eabea010d3e6f3535b34a0e9641217575705a2f47448c04b46d9d201020618e7
+      bin: access-matrix
       files:
-        - from: ./rakkess-linux-amd64
-          to: "."
+        - from: ./LICENSE
+          to: .
+        - from: ./access-matrix-amd64-linux
+          to: access-matrix
       selector:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.4.1/bundle.tar.gz
-      sha256: 50c6321db984dcc4ddadf0d62385145431562450bbac75b67ad3db959dd327de
-      bin: rakkess-darwin-amd64
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.4.2/access-matrix-amd64-darwin.tar.gz
+      sha256: 4dcb7a2aa7eb1d4eddbcd4867eb56daeff22d3e50a0c9388bddf5918d5611ec3
+      bin: access-matrix
       files:
-        - from: ./rakkess-darwin-amd64
-          to: "."
+        - from: ./LICENSE
+          to: .
+        - from: ./access-matrix-amd64-darwin
+          to: access-matrix
       selector:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.4.1/bundle.tar.gz
-      sha256: 50c6321db984dcc4ddadf0d62385145431562450bbac75b67ad3db959dd327de
-      bin: rakkess-windows-amd64.exe
+    - uri: https://github.com/corneliusweig/rakkess/releases/download/v0.4.2/access-matrix-amd64-windows.zip
+      sha256: e1130e3e97dee6f1372442696dedd3478cdb5441046f58bc2cef6f16abba1268
+      bin: access-matrix.exe
       files:
-        - from: ./rakkess-windows-amd64
-          to: rakkess-windows-amd64.exe
+        - from: ./LICENSE
+          to: .
+        - from: ./access-matrix-amd64-windows.exe
+          to: access-matrix.exe
       selector:
         matchLabels:
           os: windows
@@ -40,9 +46,10 @@ spec:
   caveats: |
       Usage:
         kubectl access-matrix
+        kubectl access-matrix for pods
 
       Documentation:
-        https://github.com/corneliusweig/rakkess/blob/v0.4.1/doc/USAGE.md#usage
+        https://github.com/corneliusweig/rakkess/blob/v0.4.2/doc/USAGE.md#usage
   description: |+2
 
       Show an access matrix for server resources
@@ -57,4 +64,4 @@ spec:
       resource (needs read access to Roles and ClusterRoles). For example:
        $ kubectl access-matrix for configmap
 
-      More on https://github.com/corneliusweig/rakkess/blob/v0.4.1/doc/USAGE.md#usage
+      More on https://github.com/corneliusweig/rakkess/blob/v0.4.2/doc/USAGE.md#usage


### PR DESCRIPTION
Release notes:
https://github.com/corneliusweig/rakkess/releases/tag/v0.4.2

In particular: Show the correct command name when built for krew

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
