### PR TITLE
Add license for ca-cert and rm-standalone-pods

### DIFF
--- a/plugins/ca-cert.yaml
+++ b/plugins/ca-cert.yaml
@@ -10,6 +10,8 @@ spec:
     files:
     - from: "/*/ca-cert/*"
       to: "."
+    - from: "/*/LICENSE"
+      to: "."
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}

--- a/plugins/rm-standalone-pods.yaml
+++ b/plugins/rm-standalone-pods.yaml
@@ -10,6 +10,8 @@ spec:
     files:
     - from: "/*/rm-standalone-pods/*"
       to: "."
+    - from: "/*/LICENSE"
+      to: "."
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}


### PR DESCRIPTION
In response to https://github.com/ahmetb/kubectl-extras/issues/15.

This copies LICENSE file next to the binaries.