### PR TITLE
Do not wrap `shortDescription` in who-can

### DIFF
--- a/plugins/who-can.yaml
+++ b/plugins/who-can.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: "v0.1.0-beta.2"
   homepage: https://github.com/aquasecurity/kubectl-who-can
-  shortDescription: |
+  shortDescription: >-
     Shows who has RBAC permissions to access Kubernetes resources
   description: |+2
     Shows which subjects have RBAC permissions to VERB [TYPE | TYPE/NAME | NONRESOURCEURL]


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
So far this was not noticed, because the shortDescription was truncated.

This will allow the CI in https://github.com/kubernetes-sigs/krew/pull/393 to pass.