### PR TITLE
Update view-utilization to v0.3.1

### DIFF
--- a/plugins/view-utilization.yaml
+++ b/plugins/view-utilization.yaml
@@ -3,13 +3,13 @@ kind: Plugin
 metadata:
   name: view-utilization
 spec:
-  version: "v0.2.2"
+  version: "v0.3.1"
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/etopeter/kubectl-view-utilization/releases/download/v0.2.2/kubectl-view-utilization-v0.2.2.tar.gz
-    sha256: "c43d6ba2e86dc18231ef014f62bee9190a465bd9a379eddd234d896db3c715e5"
+    uri: https://github.com/etopeter/kubectl-view-utilization/releases/download/v0.3.1/kubectl-view-utilization-v0.3.1.tar.gz
+    sha256: "7a24cc50d4e7375f12000a27a73cb47eafa8165f67823066f591a0d236a66d42"
     bin: "kubectl-view-utilization"
     files:
     - from: "*"


### PR DESCRIPTION
Update to release v0.3.1.
- Added license file to distribution package.
- Fixed node view graph not showing for low utilization nodes
