### PR TITLE
Add License to plugins

### DIFF
--- a/plugins/exec-as.yaml
+++ b/plugins/exec-as.yaml
@@ -4,11 +4,13 @@ metadata:
   name: exec-as
 spec:
   platforms:
-  - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.2-krew.zip
-    sha256: 9bd734b1dc08fc59df3f40418e92b228a830098a27257d454deccc5aa1384cf4
+  - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.3-krew.zip
+    sha256: e0bae378c0cf049526cc8d45d3389d78f7054bc5cfc5de24bd41b184ce9e806c
     bin: kubectl-exec-as
     files:
     - from: "**/kubectl-exec-as"
+      to: "."
+    - from: "**/LICENSE"
       to: "."
     selector:
       matchExpressions:

--- a/plugins/exec-as.yaml
+++ b/plugins/exec-as.yaml
@@ -15,7 +15,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "v1.0.2-krew"
+  version: "v1.0.3-krew"
   caveats: The node which the pod is running on cannot have more than one taint.
   homepage: https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-exec-as
   shortDescription: Like kubectl exec, but offers a `user` flag to exec as root or any other user.

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prompt
 spec:
   platforms:
-  - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
+  - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.3-krew.zip
     sha256: e0bae378c0cf049526cc8d45d3389d78f7054bc5cfc5de24bd41b184ce9e806c
     bin: kubectl-prompt
     files:
@@ -15,7 +15,7 @@ spec:
     selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-  version: "v1.0.0-krew"
+  version: "v1.0.3-krew"
   homepage: https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-prompt
   caveats: |
     This plugin requires bash.

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -5,10 +5,12 @@ metadata:
 spec:
   platforms:
   - uri: https://github.com/jordanwilson230/kubectl-plugins/archive/v1.0.0-krew.zip
-    sha256: efa1c2122ecaeb0a43ba1ed9e54c1ff1274d20de76934f7bb91dd154f2327aa1
+    sha256: e0bae378c0cf049526cc8d45d3389d78f7054bc5cfc5de24bd41b184ce9e806c
     bin: kubectl-prompt
     files:
     - from: "*/kubectl-prompt"
+      to: "."
+    - from: "**/LICENSE"
       to: "."
     selector:
       matchExpressions:


### PR DESCRIPTION
Updates to a new release (v1.0.3-krew) I've cut, which includes the LICENSE file.
Updates the exec-as.yaml and prompt.yaml in this repository to pull the updated release.


<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
