### PR TITLE
update: plugin doctor to 0.3.0

### DIFF
--- a/plugins/doctor.yaml
+++ b/plugins/doctor.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: doctor
 spec:
-  version: "v0.2.1"
+  version: "v0.3.0"
   platforms:
-  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.2.1/kubectl-doctor_darwin_amd64.zip
-    sha256: 99b804b16549ec3cd59223f4e69f6ee8eb17d96727839c57d212343af9b3f978
+  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.3.0/kubectl-doctor_darwin_amd64.zip
+    sha256: c07c4a2ae741e2dbcd0fc4c9e543ca6558877ee74a16e9d9c129a6ffc834f1a2
     bin: kubectl-doctor
     files:
     - from: "*"
@@ -15,8 +15,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.2.1/kubectl-doctor_linux_amd64.zip
-    sha256: 541391851273fea92a82dbaac4bf6d67748b244499e4b5f110cf701b077f9f22
+  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.3.0/kubectl-doctor_linux_amd64.zip
+    sha256: 94ac5b4f6061176ade6650031e85018baf093b2a27b28ce5e73a78af1ceebc2a
     bin: kubectl-doctor
     files:
     - from: "*"
@@ -25,8 +25,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.2.1/kubectl-doctor_linux_arm.zip
-    sha256: 444ce31309c5ccd3597f23a86da824060e92d1a7dff3182d485daa8455883e83
+  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.3.0/kubectl-doctor_linux_arm.zip
+    sha256: 862eaf8e81df8fb7afd5e3f711373def4b7c5fd6aa807e17f186b2b04fb5d949
     bin: kubectl-doctor
     files:
     - from: "*"
@@ -35,8 +35,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.2.1/kubectl-doctor_windows_amd64.zip
-    sha256: 1b86784a9dc0673462df5b75bbf7e23772bfb11665feacb91bc8f7d2474711a1
+  - uri: https://github.com/emirozer/kubectl-doctor/releases/download/0.3.0/kubectl-doctor_windows_amd64.zip
+    sha256: f7db26a242fa6f3f525878aad81971750bf149ac0801b88539ca4cc1bf29713a
     bin: kubectl-doctor.exe
     files:
     - from: "*"


### PR DESCRIPTION
release page for issue mapping: https://github.com/emirozer/kubectl-doctor/releases/tag/0.3.0

Also addresses the issue @corneliusweig warned me here: https://github.com/emirozer/kubectl-doctor/issues/6

The LICENSE is now packed with the zip packages.