### PR TITLE
Add kubectl plugin to list PVCs which are not bound

### DIFF
--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -9,7 +9,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
     uri: https://github.com/ishantanu/kubectl-unbound-pvc/archive/v0.0.1.zip
-    sha256: "36231dcd6fbacd90c4929d75bff119d8ef1a2dbcec2b0baca639edfd489ecf4a"
+    sha256: "e992b2d6150c70b466b99dd767f4b0c1eacb3deb6719cfe580bdebfe8987448a"
     files:
     - from: "./kubectl-unbound-pvc-*/kubectl-unbound_pvc"
       to:  "."

--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -11,7 +11,7 @@ spec:
     # url for downloading the package archive:
     uri: https://github.com/ishantanu/kubectl-unbound-pvc/archive/v0.0.1.zip
     # sha256sum of the above archive file:
-    sha256: "7a79f11dc3227fb1b99b8c1da0c9ef26cbbc4244326744dcde05bf8fdecf10aa"
+    sha256: "36231dcd6fbacd90c4929d75bff119d8ef1a2dbcec2b0baca639edfd489ecf4a"
     # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
     files:
     - from: "./kubectl-unbound_pvc" # path to the files extracted from archive

--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -9,7 +9,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
     uri: https://github.com/ishantanu/kubectl-unbound-pvc/archive/v0.0.1.zip
-    sha256: "e992b2d6150c70b466b99dd767f4b0c1eacb3deb6719cfe580bdebfe8987448a"
+    sha256: "c8a163cc9a60af26f41d13c6641aca40fbc5f35a247867f1082a077398f0e06c"
     files:
     - from: "./kubectl-unbound-pvc-*/kubectl-unbound_pvc"
       to:  "."

--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -9,7 +9,7 @@ spec:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
     uri: https://github.com/ishantanu/kubectl-unbound-pvc/archive/v0.0.1.zip
-    sha256: "6aca698409e76c7ef8a0e03b96b43c7e9b2e1993ba47ddfa50f94cf4e61556a2"
+    sha256: "36231dcd6fbacd90c4929d75bff119d8ef1a2dbcec2b0baca639edfd489ecf4a"
     files:
     - from: "./kubectl-unbound-pvc-*/kubectl-unbound_pvc"
       to:  "."

--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -14,9 +14,9 @@ spec:
     sha256: "36231dcd6fbacd90c4929d75bff119d8ef1a2dbcec2b0baca639edfd489ecf4a"
     # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
     files:
-    - from: "./kubectl-unbound_pvc" # path to the files extracted from archive
+    - from: "./kubectl-unbound-pvc-0.0.1/kubectl-unbound_pvc" # path to the files extracted from archive
       to:  "."                 # '.' refers to the root of plugin install directory
-    - from: "./LICENSE"   # always install your LICENSE file
+    - from: "./kubectl-unbound-pvc-0.0.1/LICENSE"   # always install your LICENSE file
       to: "."
     bin: "kubectl-unbound_pvc"  # path to the plugin executable after copying files above
   shortDescription: >-    # short description gets truncated at ~50 chars

--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -1,0 +1,32 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: unbound-pvc       # plugin name must match your manifest file name (e.g. foo.yaml)
+spec:
+  version: "v0.0.1"       # required, must be in semver format, prefixed with "v"
+  platforms:
+  - selector:             # a regular Kubernetes selector
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    # url for downloading the package archive:
+    uri: https://github.com/ishantanu/kubectl-unbound-pvc/archive/v0.0.1.zip
+    # sha256sum of the above archive file:
+    sha256: "7a79f11dc3227fb1b99b8c1da0c9ef26cbbc4244326744dcde05bf8fdecf10aa"
+    # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
+    files:
+    - from: "./kubectl-unbound_pvc" # path to the files extracted from archive
+      to:  "."                 # '.' refers to the root of plugin install directory
+    - from: "./LICENSE"   # always install your LICENSE file
+      to: "."
+    bin: "kubectl-unbound_pvc"  # path to the plugin executable after copying files above
+  shortDescription: >-    # short description gets truncated at ~50 chars
+    Prints the PVCs (Persistent Volume Claims) which are not in "Bound" state
+  # (optional) url of the project homepage
+  homepage: https://github.com/ishantanu/kubectl-unbound_pvc
+  # (optional) use caveats field to show post-installation recommendations
+  caveats: |
+    This plugin needs the following programs:
+    * jq
+  description: |     # should print nicely on standard 80 char wide terminals
+    This plugin shows all the Persistent Volume Claims in a Kubernetes
+    cluster which are not in "Bound" state. 

--- a/plugins/unbound-pvc.yaml
+++ b/plugins/unbound-pvc.yaml
@@ -1,32 +1,27 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: unbound-pvc       # plugin name must match your manifest file name (e.g. foo.yaml)
+  name: unbound-pvc
 spec:
-  version: "v0.0.1"       # required, must be in semver format, prefixed with "v"
+  version: "v0.0.1"
   platforms:
-  - selector:             # a regular Kubernetes selector
+  - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    # url for downloading the package archive:
     uri: https://github.com/ishantanu/kubectl-unbound-pvc/archive/v0.0.1.zip
-    # sha256sum of the above archive file:
-    sha256: "36231dcd6fbacd90c4929d75bff119d8ef1a2dbcec2b0baca639edfd489ecf4a"
-    # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
+    sha256: "6aca698409e76c7ef8a0e03b96b43c7e9b2e1993ba47ddfa50f94cf4e61556a2"
     files:
-    - from: "./kubectl-unbound-pvc-0.0.1/kubectl-unbound_pvc" # path to the files extracted from archive
-      to:  "."                 # '.' refers to the root of plugin install directory
-    - from: "./kubectl-unbound-pvc-0.0.1/LICENSE"   # always install your LICENSE file
+    - from: "./kubectl-unbound-pvc-*/kubectl-unbound_pvc"
+      to:  "."
+    - from: "./kubectl-unbound-pvc-*/LICENSE"
       to: "."
-    bin: "kubectl-unbound_pvc"  # path to the plugin executable after copying files above
-  shortDescription: >-    # short description gets truncated at ~50 chars
-    Prints the PVCs (Persistent Volume Claims) which are not in "Bound" state
-  # (optional) url of the project homepage
+    bin: "kubectl-unbound_pvc"
+  shortDescription: >-
+    Show dangling Persistent Volume Claims
   homepage: https://github.com/ishantanu/kubectl-unbound_pvc
-  # (optional) use caveats field to show post-installation recommendations
   caveats: |
     This plugin needs the following programs:
     * jq
-  description: |     # should print nicely on standard 80 char wide terminals
+  description: |
     This plugin shows all the Persistent Volume Claims in a Kubernetes
     cluster which are not in "Bound" state. 


### PR DESCRIPTION
Signed-off-by: Shantanu Deshpande <shantanud106@gmail.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

A plugin that can list PVCs which are not in `Bound` state.