### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,4 +2,3 @@ aliases:
   krew-index-maintainers:
     - ahmetb
     - corneliusweig
-    - juanvallejo

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -11,4 +11,4 @@
 # INSTRUCTIONS AT https://kubernetes.io/security/
 
 ahmetb
-juanvallejo
+corneliusweig


### PR DESCRIPTION
Per https://github.com/kubernetes/org/pull/1396 Juan no longer has admin or maintainer access to krew-index due to inactivity. As long as he is in the OWNERS file, Prow will request review by him which won't happen. This should fix it.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
