### PR TITLE
add df-pv plugin

### DIFF
--- a/plugins/df-pv.yml
+++ b/plugins/df-pv.yml
@@ -1,0 +1,55 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: df-pv
+spec:
+  version: "v0.1.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/yashbhutwala/kubectl-df-pv/releases/download/v0.1.0/df-pv_0.1.0_linux_amd64-0.1.0.tar.gz
+    sha256: "eff764fb1d2869599f131ede6af3b64db4c6126ad711ba03868c2d218da4fbb3"
+    files:
+    - from: "df-pv"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "df-pv"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/yashbhutwala/kubectl-df-pv/releases/download/v0.1.0/df-pv_0.1.0_darwin_amd64-0.1.0.tar.gz
+    sha256: "2f85948bba1cc16a7f1383a57a3afa083010c97ce2678a2a893319aa75bf5bc6"
+    files:
+    - from: "df-pv"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "df-pv"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/yashbhutwala/kubectl-df-pv/releases/download/v0.1.0/df-pv_0.1.0_windows_amd64-0.1.0.zip
+    sha256: "d27f9407505917282d09ce0e720d7ac14d6c5d940e5e6c68463203cad19565da"
+    files:
+    - from: "df-pv.exe"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "df-pv.exe"
+  shortDescription: df (disk free) for persistent volumes
+  homepage: https://github.com/yashbhutwala/kubectl-df-pv
+  caveats: |
+    Usage:
+      $ kubectl df-pv
+
+    For additional options:
+      $ kubectl df-pv --help
+      or https://github.com/yashbhutwala/kubectl-df-pv/blob/v0.1.0/doc/USAGE.md
+
+  description: |
+    This plugin emulates df for persistent volumes.  This utility is meant for `cluster-admin` like user; specifically, you need a service account with enough RBAC privileges to access `api/v1/nodes/` from the `api-server`.  The output is very similar to df on Unix.

--- a/plugins/df-pv.yml
+++ b/plugins/df-pv.yml
@@ -52,4 +52,4 @@ spec:
       or https://github.com/yashbhutwala/kubectl-df-pv/blob/v0.1.0/doc/USAGE.md
 
   description: |
-    This plugin emulates df for persistent volumes.  This utility is meant for `cluster-admin` like user; specifically, you need a service account with enough RBAC privileges to access `api/v1/nodes/` from the `api-server`.  The output is very similar to df on Unix.
+    This plugin emulates Unix style df for persistent volumes.

--- a/plugins/df-pv.yml
+++ b/plugins/df-pv.yml
@@ -41,15 +41,7 @@ spec:
     - from: "LICENSE"
       to: "."
     bin: "df-pv.exe"
-  shortDescription: df (disk free) for persistent volumes
+  shortDescription: Show disk usage (like unix df) for persistent volumes
   homepage: https://github.com/yashbhutwala/kubectl-df-pv
-  caveats: |
-    Usage:
-      $ kubectl df-pv
-
-    For additional options:
-      $ kubectl df-pv --help
-      or https://github.com/yashbhutwala/kubectl-df-pv/blob/v0.1.0/doc/USAGE.md
-
   description: |
     This plugin emulates Unix style df for persistent volumes.


### PR DESCRIPTION
Signed-off-by: Yash Bhutwala <ymb002@bucknell.edu>

Add a plugin to see `df` for Persistent Volumes, [details here](https://github.com/yashbhutwala/kubectl-df-pv/blob/v0.1.0/README.md)

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
