### PR TITLE
Improve travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,30 @@ language: go
 go:
 - 1.13.x
 
+env:
+  global:
+  - KREW_VERSION=v0.3.2
+  - GO111MODULE=on
+
 before_install:
   # install kubectl
   - sudo curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubectl
   - sudo chmod +x /usr/bin/kubectl
 
   # install krew (temporarily hardcode version)
-  # TODO(ahmetb) pin this to a version via a variable
   - (
       cd "$(mktemp -d)" &&
-      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/v0.3.1/krew.{tar.gz,yaml}" &&
+      curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew.{tar.gz,yaml}" &&
       tar zxvf krew.tar.gz &&
       ./krew-linux_amd64 install --manifest=krew.yaml --archive=krew.tar.gz
     )
 
-  # TODO(ahmetb) pin this to a version via a variable
-  - env GOBIN=$HOME/bin go get sigs.k8s.io/krew/cmd/validate-krew-manifest
+  - env GOBIN=$HOME/bin go get sigs.k8s.io/krew/cmd/validate-krew-manifest@${KREW_VERSION}
 
 install: true # skip go get ./...
 
 script:
   - export PATH="$PATH:$HOME/.krew/bin";
     git diff --name-only --diff-filter=AM $TRAVIS_BRANCH...HEAD |
-      grep -E '\.yaml$' |
+      grep -E 'plugins/.*' |
       xargs -I _ $HOME/bin/validate-krew-manifest -manifest _


### PR DESCRIPTION
- Use latest krew to install and verify manifests
- Check installation for everything in the `plugins` folder. That way, the CI will find if a manifest erroneously has a .yml extension instead of .yaml

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Fixes #370.