### PR TITLE
adds the fleet plugin

### DIFF
--- a/plugins/fleet.yaml
+++ b/plugins/fleet.yaml
@@ -1,0 +1,59 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: fleet
+spec:
+  version: "v0.1.3"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/mhausenblas/kcf/releases/download/v0.1.3/fleet_linux_amd64.tar.gz
+    sha256: "4b70b89fd78d3dc674ff5db918f0047dca816c1622dbbf81f957b1a1419cac39"
+    files:
+    - from: "./fleet"
+      to: "."
+    - from: "./LICENSE"
+      to: "."
+    bin: "fleet"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/mhausenblas/kcf/releases/download/v0.1.3/fleet_darwin_amd64.tar.gz
+    sha256: "6b1c2404a0a5a734f6313e765930b92877109ee396d290291d66d2139a74a18b"
+    files:
+    - from: "./fleet"
+      to: "."
+    - from: "./LICENSE"
+      to: "."
+    bin: "fleet"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/mhausenblas/kcf/releases/download/v0.1.3/fleet_windows_amd64.zip
+    sha256: "9b9df8d64551e91ae248780e78c7a6ace61c657c9d011510bab7cbad0c8734d9"
+    files:
+    - from: "/fleet.exe"
+      to: "."
+    - from: "./LICENSE"
+      to: "."
+    bin: "fleet.exe"
+  shortDescription: Shows config and resources of a fleet of clusters
+  homepage: https://github.com/mhausenblas/kcf
+  caveats: |
+    Usage:
+      $ kubectl fleet
+
+    For additional options:
+      $ kubectl fleet --help
+      or https://github.com/mhausenblas/kcf/blob/v0.1.3/doc/USAGE.md
+
+  description: |
+    Allows to get an overview and details on a fleet of Kubernetes clusters.
+    The top-level command lists all active clusters found in the kubeconfig provided.
+    For each cluster, configuration info such as the control plane version or 
+    API server endpoint are displayed, as well as select stats, for example, 
+    the number of worker nodes or namespaces found in the cluster.


### PR DESCRIPTION
The `fleet` plugin is mainly targeted at infra ops, dealing with multiple clusters. It's written in Go, has no dependencies and is based off of `replicatedhq/krew-plugin-template`. Note: only tested with macOS and Linux.