### PR TITLE
New plugin: capture

### DIFF
--- a/plugins/capture.yaml
+++ b/plugins/capture.yaml
@@ -1,0 +1,54 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: capture
+spec:
+  version: v0.1.0
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/sysdiglabs/kubectl-capture/releases/download/v0.1.0/kubectl-capture.v0.1.0.tar.gz
+    sha256: "86c947a9fa9acb73eeb179e29ede20755a426a4fb96aa82375246a356f3a804f"
+    bin: "kubectl-capture"
+  shortDescription: >-
+    Triggers a Sysdig capture to troubleshoot the running pod
+  homepage: https://github.com/sysdiglabs/kubectl-capture
+  caveats: |
+    To analyze the capture file you will need to use Sysdig Inspect. You can use it as docker image directly:
+
+    ```bash
+    docker run -d -v /local/path/to/captures:/captures -p8080:3000 sysdig/sysdig-inspect:latest
+    ```
+
+    Usage:
+
+    ```bash
+    $ kubectl capture pod-name -M 45
+    ```
+
+    You can set the duration in seconds of the capture with the `-M` flag, and
+    also specify the namespace using the `-ns` or `--namespace` or use eBPF to
+    trace syscalls instead the kernel module instrumentation with `--ebpf` flag.
+  description: |
+    Sysdig is a powerful open source tool for container troubleshooting,
+    performance tunning and security investigation.
+
+    This plugin triggers a capture in the underlying host which is running a
+    pod. A capture file is created for a duration of time and is download
+    locally in order to use it with Sysdig Inspect.
+
+    Example:
+
+    ```bash
+    $ kubectl capture nginx-78f5d695bd-bcbd8
+    Sysdig is starting to capture system calls:
+
+    Node: gke-sysdig-work-default-pool-e35da3a1-m8vp
+    Pod: nginx-78f5d695bd-bcbd8
+    Duration: 30 seconds
+    Parameters for Sysdig: -S -M 30 -pk -z -w /capture-nginx-78f5d695bd-bcbd8-1550246926.scap.gz
+
+    The capture has been downloaded to your hard disk at:
+    ~/captures/capture-nginx-78f5d695bd-bcbd8-1550246926.scap.gz
+    ```

--- a/plugins/capture.yaml
+++ b/plugins/capture.yaml
@@ -15,32 +15,38 @@ spec:
     Triggers a Sysdig capture to troubleshoot the running pod
   homepage: https://github.com/sysdiglabs/kubectl-capture
   caveats: |
-    To analyze the capture file you will need to use Sysdig Inspect. You can use it as docker image directly:
+    In order to get the plugin running you will need the following prerequisites:
 
-    ```bash
-    docker run -d -v /local/path/to/captures:/captures -p8080:3000 sysdig/sysdig-inspect:latest
-    ```
+    * The user must be allowed to create privileged pods.
+    * Sysdig uses kernel mechanisms to source the system calls, it tries to
+      download a kernel module to get the system calls and if it can't be
+      downloaded it will try to compile its own, so you will need to have
+      the kernel headers installed and available.
+    * Alternatively, eBPF is supported as well. You will need a kernel greater
+      than 4.14 to use eBPF probe. In particular you will need CONFIG_BPF=y,
+      CONFIG_BPF_JIT=y and CONFIG_BPF_SYSCALL=y.
 
-    Usage:
 
-    ```bash
-    $ kubectl capture pod-name -M 45
-    ```
+    And on the analysis side, to analyze the capture file you will need to use
+    Sysdig Inspect. You can use it as docker image directly:
 
-    You can set the duration in seconds of the capture with the `-M` flag, and
-    also specify the namespace using the `-ns` or `--namespace` or use eBPF to
-    trace syscalls instead the kernel module instrumentation with `--ebpf` flag.
+    $ docker run -d -v /local/path/to/captures:/captures -p8080:3000 sysdig/sysdig-inspect:latest
   description: |
     Sysdig is a powerful open source tool for container troubleshooting,
     performance tunning and security investigation.
 
     This plugin triggers a capture in the underlying host which is running a
-    pod. A capture file is created for a duration of time and is download
-    locally in order to use it with Sysdig Inspect.
+    pod. A capture file is created for a duration of time and is downloaded
+    locally in order to use it with Sysdig Inspect. You can download Sysdig
+    Inspect in the following link: https://github.com/draios/sysdig-inspect
+
+    Finally, you can set the duration in seconds of the capture with the `-M`
+    flag, and also specify the namespace using the `-n` or `--namespace` or use
+    eBPF to trace syscalls instead the kernel module instrumentation with
+    `--ebpf` flag.
 
     Example:
 
-    ```bash
     $ kubectl capture nginx-78f5d695bd-bcbd8
     Sysdig is starting to capture system calls:
 
@@ -51,4 +57,3 @@ spec:
 
     The capture has been downloaded to your hard disk at:
     ~/captures/capture-nginx-78f5d695bd-bcbd8-1550246926.scap.gz
-    ```


### PR DESCRIPTION
This PR adds support for `kubectl-capture` plugin.

This plugin uses Sysdig under the hoods to help you troubleshooting issues or doing forensic analysis in a running pod or host.

You can check more references about its usage:

* https://github.com/sysdiglabs/kubectl-capture
* https://cloud.google.com/solutions/security-controls-and-forensic-analysis-for-GKE-apps#kubectl_sysdig_capture_sysdig_inspect
* https://sysdig.com/blog/tracing-in-kubernetes-kubectl-capture-plugin/

Thank you!

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
