### PR TITLE
Add plugin: pod-dive

### DIFF
--- a/plugins/pod-dive.yaml
+++ b/plugins/pod-dive.yaml
@@ -3,15 +3,17 @@ kind: Plugin
 metadata:
   name: pod-dive
 spec:
-  version: "v0.1.2"
+  version: "v0.1.3"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.2/pod-dive-amd64-linux.tar.gz
-    sha256: "508a96f1b63484e0ff2790c5a3fa04938466ef7b47103e026cbc2a0ec049e0b2"
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.3/pod-dive-amd64-linux.tar.gz
+    sha256: "c3840fb646a1d44d18253ae327442716a6860a7403dc285053073fcf735cc33f"
     files:
+    - from: "./LICENSE"
+      to: "."
     - from: "./pod-dive-amd64-linux"
       to: "."
     bin: "pod-dive-amd64-linux"
@@ -19,9 +21,11 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.2/pod-dive-amd64-darwin.tar.gz
-    sha256: "b243737915199a356130c3867241c0c47313d69855e3e419f6c51cf24c34ff04"
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.3/pod-dive-amd64-darwin.tar.gz
+    sha256: "09ea32512080d7a1ad54314b19f6135893ace638434f71b5fc0113da011dfb46"
     files:
+    - from: "./LICENSE"
+      to: "."
     - from: "./pod-dive-amd64-darwin"
       to: "."
     bin: "pod-dive-amd64-darwin"
@@ -29,16 +33,26 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.2/pod-dive-amd64-windows.exe.zip
-    sha256: "e470c3a86611c3545fa7f5e75479d5f873f3ede6356bf6166bf5a6063703c1d0"
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.3/pod-dive-amd64-windows.exe.zip
+    sha256: "cd20a105c60482fdd0fd369c2af7506f00ec60bdcacebdddf8ad6c5a5f3d904e"
     files:
+    - from: "./LICENSE"
+      to: "."
     - from: "./pod-dive-amd64-windows.exe"
       to: "."
     bin: "pod-dive-amd64-windows.exe"
-  shortDescription: A kubectl Krew plugin to dive into your Kubernetes nodes workloads
+  shortDescription: Shows a pod's workload tree and info inside a node
   homepage: https://github.com/caiobegotti/pod-dive
   description: |
-    A kubectl Krew plugin to dive into your Kubernetes nodes workloads
+    Dives into a node after the desired pod and returns data associated
+    with the pod no matter where it is running, such as its origin workload,
+    namespace, the node where it is running and its node pod siblings, as
+    well basic health status of it all.
+
+    The purpose is to have meaningful pod info at a glance without needing to
+    run multiple kubectl commands to see what else is running next to your
+    pod in a given node inside a huge cluster, because sometimes all
+    you've got from an alert is the pod name. 
 
     Usage
       $ kubectl pod-dive [pod name]

--- a/plugins/pod-dive.yaml
+++ b/plugins/pod-dive.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: pod-dive
+spec:
+  version: "v0.1.2"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.2/pod-dive-amd64-linux.tar.gz
+    sha256: "508a96f1b63484e0ff2790c5a3fa04938466ef7b47103e026cbc2a0ec049e0b2"
+    files:
+    - from: "./pod-dive-amd64-linux"
+      to: "."
+    bin: "pod-dive-amd64-linux"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.2/pod-dive-amd64-darwin.tar.gz
+    sha256: "b243737915199a356130c3867241c0c47313d69855e3e419f6c51cf24c34ff04"
+    files:
+    - from: "./pod-dive-amd64-darwin"
+      to: "."
+    bin: "pod-dive-amd64-darwin"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/caiobegotti/pod-dive/releases/download/v0.1.2/pod-dive-amd64-windows.exe.zip
+    sha256: "e470c3a86611c3545fa7f5e75479d5f873f3ede6356bf6166bf5a6063703c1d0"
+    files:
+    - from: "./pod-dive-amd64-windows.exe"
+      to: "."
+    bin: "pod-dive-amd64-windows.exe"
+  shortDescription: A kubectl Krew plugin to dive into your Kubernetes nodes workloads
+  homepage: https://github.com/caiobegotti/pod-dive
+  description: |
+    A kubectl Krew plugin to dive into your Kubernetes nodes workloads
+
+    Usage
+      $ kubectl pod-dive [pod name]
+
+    For additional options
+      $ kubectl pod-dive --help


### PR DESCRIPTION
This PR will enable users to install [pod-dive](https://github.com/caiobegotti/Pod-Dive) directly from Krew, hopefully ❤️

Its installation has been tested locally just fine, as well fetching the remote binaries only using a local manifest. I have some minors stuff in my TODO list for the plugin but it already works great for the use cases described in its README.

My CNCF CLA is from a few years ago before I changed my Github e-mail and username so I tried re-adding my old e-mail to my profile just so it matches what's in the Linux Foundation ID portal, I have no idea if the CLA bot will be happy with it, fingers crossed!