### PR TITLE
Print validated files to stderr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ install: true # skip go get ./...
 script:
   - export PATH="$PATH:$HOME/.krew/bin";
     git diff --name-only --diff-filter=AM $TRAVIS_BRANCH...HEAD |
-      grep -E 'plugins/.*' |
+      grep -E 'plugins/.*' | tee /dev/stderr |
       xargs -I _ $HOME/bin/validate-krew-manifest -manifest _


### PR DESCRIPTION
Adding a pipe to tee /dev/stderr so that we can see which files are being
passed to validate-krew-manifest. Though, we print all files before validating
any of them, but still useful since mostly 1 plugin is updated at a time.