### PR TITLE
Update virt (KubeVirt virtctl plugin package) to v0.24.0

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -9,31 +9,37 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/dhiller/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-darwin-amd64.tar.gz"
-      sha256: "a4a8dd9b25c6abe83ed544e4262661805cef3d8353ba2ed03c7b7c8fb061a3a3"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-darwin-amd64.tar.gz"
+      sha256: "798543894bdfce93c991e56d035dc50689db77bb0b47079a91f3d655d7e1080f"
       files:
         - from: "/virtctl/virtctl-darwin-amd64"
           to: "virtctl"
+        - from: virtctl/LICENSE
+          to: .
       bin: "virtctl"
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/dhiller/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-linux-amd64.tar.gz"
-      sha256: "45dee1e962164ea69c0a8c8d300d258007380f1e2b9d292e414719eacb69837e"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-linux-amd64.tar.gz"
+      sha256: "f631d10d8b40e71762a8aea9f0cd70be0627e02b9b7cc04ec9cbc3859a66ee1e"
       files:
         - from: "/virtctl/virtctl-linux-amd64"
           to: "virtctl"
+        - from: virtctl/LICENSE
+          to: .
       bin: "virtctl"
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: "https://github.com/dhiller/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-windows-amd64.exe.tar.gz"
-      sha256: "6f0ffea42f5ca4670e1912f993560d95ecf5d65f482b4115d96d972ef2f027cd"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-windows-amd64.exe.tar.gz"
+      sha256: "715a627096d94f61669b97cda1cf17d8200750113d4aa7e268a680b06273feb5"
       files:
         - from: "/virtctl/virtctl-windows-amd64.exe"
           to: "virtctl.exe"
+        - from: virtctl/LICENSE
+          to: .
       bin: "virtctl.exe"
   shortDescription: Control KubeVirt virtual machines using virtctl
   homepage: https://kubevirt.io


### PR DESCRIPTION
See https://github.com/kubevirt/kubevirt/releases/tag/v0.24.0

Needed to update the package as the release urls have changed for migration of kubectl-virt-plugin repo to kubevirt org.

Fixes kubernetes-sigs/krew-index#390