### PR TITLE
Add profefe plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -58,6 +58,7 @@ Name | Description | Stars
 [pod-logs](https://github.com/danisla/kubefunc) | Display a list of pods to get logs from | ![GitHub stars](https://img.shields.io/github/stars/danisla/kubefunc.svg?label=stars&logo=github)
 [pod-shell](https://github.com/danisla/kubefunc) | Display a list of pods to execute a shell in | ![GitHub stars](https://img.shields.io/github/stars/danisla/kubefunc.svg?label=stars&logo=github)
 [preflight](https://github.com/replicatedhq/troubleshoot) | Executes application preflight tests in a cluster | ![GitHub stars](https://img.shields.io/github/stars/replicatedhq/troubleshoot.svg?label=stars&logo=github)
+[profefe](https://github.com/profefe/kube-profefe) | Gather and manage pprof profiles from running pods. | ![GitHub stars](https://img.shields.io/github/stars/profefe/kube-profefe.svg?label=stars&logo=github)
 [prompt](https://github.com/jordanwilson230/kubectl-plugins/tree/krew#kubectl-prompt) | Prompts for user confirmation when executing commands in critical namespaces or clusters, i.e., production. | ![GitHub stars](https://img.shields.io/github/stars/jordanwilson230/kubectl-plugins.svg?label=stars&logo=github)
 [prune-unused](https://github.com/thecloudnatives/kubectl-plugins) | Prune unused resources | ![GitHub stars](https://img.shields.io/github/stars/thecloudnatives/kubectl-plugins.svg?label=stars&logo=github)
 [rbac-lookup](https://github.com/reactiveops/rbac-lookup) | Reverse lookup for RBAC | ![GitHub stars](https://img.shields.io/github/stars/reactiveops/rbac-lookup.svg?label=stars&logo=github)

--- a/plugins/profefe.yaml
+++ b/plugins/profefe.yaml
@@ -1,0 +1,38 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: profefe
+spec:
+  version: v0.9.0
+  homepage: https://github.com/profefe/kube-profefe
+  shortDescription: Gather and manage pprof profiles from running pods
+  description: |
+    This plugin helps to manage pprof profiles via Profefe. It allows to
+    collect profiles from running pods with Profefe and retrieve or inspect
+    profiles stored in Profefe. For more information about Profefe, visit
+    https://profefe.dev
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: "https://github.com/profefe/kube-profefe/releases/download/v0.0.9/kube-profefe_0.0.9_Darwin_x86_64.tar.gz"
+    sha256: a2dd151fcaf3b7e4341986c6cc2726e0dccc69d634fc96a0ac97f8b03ad930a5
+    bin: kubectl-profefe
+    files:
+        - from: kubectl-profefe
+          to: .
+        - from: LICENSE
+          to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: "https://github.com/profefe/kube-profefe/releases/download/v0.0.9/kube-profefe_0.0.9_Linux_x86_64.tar.gz"
+    sha256: b68479389df557dd29abd42268fdd9fc22b522a1dfe97458bfb5f804da1f6445
+    bin: kubectl-profefe
+    files:
+        - from: kubectl-profefe
+          to: .
+        - from: LICENSE
+          to: .


### PR DESCRIPTION
`kubectl-profefe` is a plugin I developed to bring the continuous
profile open source project called profefe close to kubernetes.

At the moment it severs capabilities that helps you do:

* Gather profiles from a running pod based on label selection and
annotations (to configure where the pprof http server is). Those
profiles can be saved locally or pushed to profefe.
* You can lookup and filter profiles stored in Profefe via kubectl.
* You can push to profefe pprof profiles you have locally.

Profefe is an open source project available here:

https://github.com/profefe/profefe

more about it here:

https://medium.com/@tvii/continuous-profiling-and-go-6c0ab4d2504b
https://gianarb.it/blog/go-continuous-profiling-profefe

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>