### PR TITLE
adding kubectl duck to krew index.

### DIFF
--- a/plugins/duck.yaml
+++ b/plugins/duck.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   version: v0.0.1
   homepage: https://github.com/n3wscott/kubectl-duck
-  shortDescription: Ducktype support for kubectl.
+  shortDescription: List custom resources with ducktype support
   description: |
-    This plugin allows you to list and get custom resources based on ducktype labels on CRDs.
+    This plugin allows you to list and get custom resources based on ducktype
+    labels on CRDs.
   caveats: |
     * Ducktype labels are currenly hardcoded to known types from Knative.
   platforms:
@@ -19,7 +20,6 @@ spec:
     sha256: 86294517e15b77297eeeafcb515ed7dd5f1c0ea13f6bfa4e1ecdc9d8096ab009
     files:
     - from: "*"
-      to: "."
     bin: kubectl-duck
   - selector:
       matchLabels:
@@ -29,7 +29,6 @@ spec:
     sha256: 47cc0bce7b01ca4fcde89ea30d9dad862591477e0647e30eb3367606968069e0
     files:
     - from: "*"
-      to: "."
     bin: kubectl-duck
   - selector:
       matchLabels:
@@ -39,5 +38,4 @@ spec:
     sha256: e48aa627f39d338a3b86f7c08d45885b800df70b759a267cb120f11957cbfe9b
     files:
     - from: "*"
-      to: "."
     bin: kubectl-duck.exe

--- a/plugins/duck.yaml
+++ b/plugins/duck.yaml
@@ -18,8 +18,6 @@ spec:
         arch: amd64
     uri: https://github.com/n3wscott/kubectl-duck/releases/download/v0.0.1/kubectl-duck_v0.0.1_darwin_amd64.tar.gz
     sha256: 86294517e15b77297eeeafcb515ed7dd5f1c0ea13f6bfa4e1ecdc9d8096ab009
-    files:
-    - from: "*"
     bin: kubectl-duck
   - selector:
       matchLabels:
@@ -27,8 +25,6 @@ spec:
         arch: amd64
     uri: https://github.com/n3wscott/kubectl-duck/releases/download/v0.0.1/kubectl-duck_v0.0.1_linux_amd64.tar.gz
     sha256: 47cc0bce7b01ca4fcde89ea30d9dad862591477e0647e30eb3367606968069e0
-    files:
-    - from: "*"
     bin: kubectl-duck
   - selector:
       matchLabels:
@@ -36,6 +32,4 @@ spec:
         arch: amd64
     uri: https://github.com/n3wscott/kubectl-duck/releases/download/v0.0.1/kubectl-duck_v0.0.1_windows_amd64.tar.gz
     sha256: e48aa627f39d338a3b86f7c08d45885b800df70b759a267cb120f11957cbfe9b
-    files:
-    - from: "*"
     bin: kubectl-duck.exe

--- a/plugins/duck.yaml
+++ b/plugins/duck.yaml
@@ -1,0 +1,43 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: duck
+spec:
+  version: v0.0.1
+  homepage: https://github.com/n3wscott/kubectl-duck
+  shortDescription: Ducktype support for kubectl.
+  description: |
+    This plugin allows you to list and get custom resources based on ducktype labels on CRDs.
+  caveats: |
+    * Ducktype labels are currenly hardcoded to known types from Knative.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/n3wscott/kubectl-duck/releases/download/v0.0.1/kubectl-duck_v0.0.1_darwin_amd64.tar.gz
+    sha256: 86294517e15b77297eeeafcb515ed7dd5f1c0ea13f6bfa4e1ecdc9d8096ab009
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-duck
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/n3wscott/kubectl-duck/releases/download/v0.0.1/kubectl-duck_v0.0.1_linux_amd64.tar.gz
+    sha256: 47cc0bce7b01ca4fcde89ea30d9dad862591477e0647e30eb3367606968069e0
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-duck
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/n3wscott/kubectl-duck/releases/download/v0.0.1/kubectl-duck_v0.0.1_windows_amd64.tar.gz
+    sha256: e48aa627f39d338a3b86f7c08d45885b800df70b759a267cb120f11957cbfe9b
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-duck.exe


### PR DESCRIPTION
- Named duck, stands for ducktype, main work is spinning out of Knative.
- Verified I can install via `kubectl krew install --manifest=plugins/duck.yaml`
