### PR TITLE
Add new plugin, `kubectl resources`

### DIFF
--- a/plugins/resources.yaml
+++ b/plugins/resources.yaml
@@ -1,0 +1,26 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: resources
+spec:
+  version: "v0.1.0"
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+        arch: amd64
+      uri: https://github.com/howardjohn/kubectl-resources/releases/download/v0.1.0/kubectl-resources_0.1.0_Darwin_x86_64.tar.gz
+      sha256: f27cc3474df627d0d9b55eee6514a9d7c7858d1a878af75c07ad15b3a5272d75
+      bin: kubectl-resources
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/howardjohn/kubectl-resources/releases/download/v0.1.0/kubectl-resources_0.1.0_Linux_x86_64.tar.gz
+      sha256: ad3d1a126b106a38fb92ae76bb728b00ed8b4ef02eef574456b73f21c28affb3
+      bin: kubectl-resources
+  shortDescription: >-
+    Access Kubernetes resource requests, limits, and usage.
+  homepage: https://github.com/howardjohn/kubectl-resources
+  description: |
+    Access Kubernetes resource requests, limits, and usage.

--- a/plugins/resources.yaml
+++ b/plugins/resources.yaml
@@ -20,7 +20,8 @@ spec:
       sha256: ad3d1a126b106a38fb92ae76bb728b00ed8b4ef02eef574456b73f21c28affb3
       bin: kubectl-resources
   shortDescription: >-
-    Access Kubernetes resource requests, limits, and usage.
+    Overview of Kubernetes resource requests, limits, and usage.
   homepage: https://github.com/howardjohn/kubectl-resources
   description: |
-    Access Kubernetes resource requests, limits, and usage.
+    Overview of Kubernetes resource requests, limits, and usage. This plugin aggregates resource usage, similar to `kubectl top`,
+    alongside resource requests and limits to easily identify resourcing issues.


### PR DESCRIPTION
Fixes https://github.com/howardjohn/kubectl-resources/issues/24

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
