### PR TITLE
Update virt (KubeVirt virtctl plugin package) to v0.25.0-rc.0

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: virt
 spec:
-  version: "v0.24.0"
+  version: "v0.25.0-rc.0"
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-darwin-amd64.tar.gz"
-      sha256: "798543894bdfce93c991e56d035dc50689db77bb0b47079a91f3d655d7e1080f"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.25.0-rc.0/virtctl-darwin-amd64.tar.gz"
+      sha256: "fa360b4f7b946e738c6bca469c8363028486b0326570a312b948f542b8ece6b1"
       files:
         - from: "/virtctl/virtctl-darwin-amd64"
           to: "virtctl"
@@ -21,8 +21,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-linux-amd64.tar.gz"
-      sha256: "f631d10d8b40e71762a8aea9f0cd70be0627e02b9b7cc04ec9cbc3859a66ee1e"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.25.0-rc.0/virtctl-linux-amd64.tar.gz"
+      sha256: "eb120286e8b485b1ba428620e11f8ff8031cf21853f07d18b4ff0bb8ca3af537"
       files:
         - from: "/virtctl/virtctl-linux-amd64"
           to: "virtctl"
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.24.0/virtctl-windows-amd64.exe.tar.gz"
-      sha256: "715a627096d94f61669b97cda1cf17d8200750113d4aa7e268a680b06273feb5"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.25.0-rc.0/virtctl-windows-amd64.exe.tar.gz"
+      sha256: "607ef66689fe3fd99d010e7bf9b9f4781300b7006e6a494939e335da4b1900e9"
       files:
         - from: "/virtctl/virtctl-windows-amd64.exe"
           to: "virtctl.exe"


### PR DESCRIPTION
See https://github.com/kubevirt/kubevirt/releases/tag/v0.25.0-rc.0