### PR TITLE
Add kubepug (kubectl deprecations)

### DIFF
--- a/plugins/deprecations.yaml
+++ b/plugins/deprecations.yaml
@@ -1,0 +1,43 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: deprecations
+spec:
+  shortDescription: >-    
+    Checks for deprecated objects in a cluster 
+  homepage: https://github.com/rikatz/kubepug
+  caveats: |
+    * By default, deprecations finds deprecated object relative to the current kubernetes
+    master branch. To target a different kubernetes release, use the --k8s-version
+    argument.
+    
+    * Deprecations needs permission to GET all objects in the Cluster
+  description: |     
+    This plugin shows all the deprecated objects in a Kubernetes cluster allowing 
+    the operator to verify them before upgrading the cluster. It uses the 
+    swagger.json version available in master branch of Kubernetes repository
+    (github.com/kubernetes/kubernetes) as a reference. The branch can be changed 
+    to some other desired Kubernetes version
+  version: "v0.2.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/rikatz/kubepug/releases/download/v0.2.0/kubepug_darwin_amd64.tar.gz
+    sha256: "647a56e53b81ea4349fee6a515173bf9cfbef1173f20f591cb91ead6a77b1002"
+    bin: "kubepug" 
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/rikatz/kubepug/releases/download/v0.2.0/kubepug_linux_amd64.tar.gz
+    sha256: "82f83df4a2896e6b12a62fc8d6a2f295cb926ca1ee29085ba83d54ca12a5018e"
+    bin: "kubepug" 
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/rikatz/kubepug/releases/download/v0.2.0/kubepug_windows_amd64.zip
+    sha256: "4a26e35e6b6a84c679fc73beaaa9ee4e169ae25eb750d886dd0559d9a0d9934c"
+    bin: "kubepug.exe" 


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Kubepug (Pre UpGrade check) is a plugin that validates existing Kubernetes objects against a versioned swagger.json from k/k repo. 

It's useful to verify if some existing object will be discontinued / deprecated or even removed in a future Kubernetes version