### PR TITLE
add plugin: advise-psp (kube-psp-advisor)

### DIFF
--- a/plugins/advise-psp.yaml
+++ b/plugins/advise-psp.yaml
@@ -22,5 +22,6 @@ spec:
     bin: kubectl-advise-psp
   shortDescription: Suggests PodSecurityPolicies for cluster.
   description: |
-    Suggests PodSecurityPolicies based on the security context of cluster.
+    Suggests PSPs based on the required capabilities of the currently running 
+    workloads or a given manifest.
 

--- a/plugins/advise-psp.yaml
+++ b/plugins/advise-psp.yaml
@@ -1,0 +1,37 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: advise-psp
+spec:
+  version: v1.4.0
+  homepage: https://github.com/sysdiglabs/kube-psp-advisor
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/sysdiglabs/kube-psp-advisor/releases/download/1.4.0/kubectl-advise-psp_v1.4.0_darwin_amd64.tar.gz
+    sha256: 55f852fd02b62ddbe59e8f1c00550d305201765beef900111c4c0819c85b64df 
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-advise-psp
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/sysdiglabs/kube-psp-advisor/releases/download/1.4.0/kubectl-advise-psp_v1.4.0_linux_amd64.tar.gz
+    sha256: dd496e46bff10bf5ca8b01b2e9e7626354cdba0dcab0aa7ddf72b2b809f9ad72 
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-advise-psp
+  shortDescription: Suggest pod security policies for Kubernetes cluster.
+  caveats: |
+    This plugin requires the privileges to get workloads (deployment, daemonset etc.)
+    
+    Read the documentation at:
+      https://github.com/sysdiglabs/kube-psp-advisor
+  description: |
+    This plugin suggest pod security policies based on the security context of Kubernetes cluster.
+

--- a/plugins/advise-psp.yaml
+++ b/plugins/advise-psp.yaml
@@ -12,9 +12,6 @@ spec:
         arch: amd64
     uri: https://github.com/sysdiglabs/kube-psp-advisor/releases/download/1.4.0/kubectl-advise-psp_v1.4.0_darwin_amd64.tar.gz
     sha256: 55f852fd02b62ddbe59e8f1c00550d305201765beef900111c4c0819c85b64df 
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-advise-psp
   - selector:
       matchLabels:
@@ -22,16 +19,8 @@ spec:
         arch: amd64
     uri: https://github.com/sysdiglabs/kube-psp-advisor/releases/download/1.4.0/kubectl-advise-psp_v1.4.0_linux_amd64.tar.gz
     sha256: dd496e46bff10bf5ca8b01b2e9e7626354cdba0dcab0aa7ddf72b2b809f9ad72 
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-advise-psp
-  shortDescription: Suggest pod security policies for Kubernetes cluster.
-  caveats: |
-    This plugin requires the privileges to get workloads (deployment, daemonset etc.)
-    
-    Read the documentation at:
-      https://github.com/sysdiglabs/kube-psp-advisor
+  shortDescription: Suggest PodSecurityPolicies for cluster.
   description: |
-    This plugin suggest pod security policies based on the security context of Kubernetes cluster.
+    This plugin suggest PodSecurityPolicies based on the security context of cluster.
 

--- a/plugins/advise-psp.yaml
+++ b/plugins/advise-psp.yaml
@@ -20,7 +20,7 @@ spec:
     uri: https://github.com/sysdiglabs/kube-psp-advisor/releases/download/1.4.0/kubectl-advise-psp_v1.4.0_linux_amd64.tar.gz
     sha256: dd496e46bff10bf5ca8b01b2e9e7626354cdba0dcab0aa7ddf72b2b809f9ad72 
     bin: kubectl-advise-psp
-  shortDescription: Suggest PodSecurityPolicies for cluster.
+  shortDescription: Suggests PodSecurityPolicies for cluster.
   description: |
-    This plugin suggest PodSecurityPolicies based on the security context of cluster.
+    Suggests PodSecurityPolicies based on the security context of cluster.
 


### PR DESCRIPTION
Signed-off-by: kaizhe <derek0405@gmail.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Done test on both MacOS and Linux (x86)
```
Kaizhes-MacBook-Pro:plugins kaizhehuang$ kubectl advise-psp 
A way to generate K8s PodSecurityPolicy objects from a live K8s environment or individual K8s objects containing pod specifications

Usage:
  kube-psp-advisor [command]

Available Commands:
  convert     Generate a PodSecurityPolicy from a single K8s Yaml file
  help        Help about any command
  inspect     Inspect a live K8s Environment to generate a PodSecurityPolicy

Flags:
  -h, --help           help for kube-psp-advisor
      --level string   Log level (default "info")

Use "kube-psp-advisor [command] --help" for more information about a command.
```
```
ubuntu@ip-172-31-27-217:~$ kubectl advise-psp inspect -n psp-test
apiVersion: policy/v1beta1
kind: PodSecurityPolicy
metadata:
  creationTimestamp: null
  name: pod-security-policy-psp-test-20200115193241
spec:
  allowedCapabilities:
  - SYS_ADMIN
  - NET_ADMIN
  allowedHostPaths:
  - pathPrefix: /usr/bin
    readOnly: true
  - pathPrefix: /bin
    readOnly: true
  - pathPrefix: /tmp
    readOnly: true
  - pathPrefix: /usr/sbin
    readOnly: true
  fsGroup:
    rule: RunAsAny
  hostIPC: true
  hostNetwork: true
  hostPID: true
  privileged: true
  runAsUser:
    rule: RunAsAny
  seLinux:
    rule: RunAsAny
  supplementalGroups:
    rule: RunAsAny
  volumes:
  - hostPath
  - secret
  - configMap
```
