### PR TITLE
new plugin: net-forward

### DIFF
--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -23,12 +23,17 @@ spec:
     uri: https://github.com/antitree/krew-net-forward/releases/download/v1.0.3/net-forward_v1.0.3.tar.gz
     sha256: "645adb05d9ad68ecc91d9034cb80b1e2fe4762864323c12de0f2bc5afe20baa0"
     bin: "net-forward"  
-  shortDescription: "Setup a true forwarder from your local machine to any TCP service accessible from within the cluster."
+  shortDescription: "Extend the functionality of port-forward connect to any IP and port (not just Pods and Services)."
   homepage: https://github.com/antitree/krew-net-forward
   caveats: |
-    This plugin needs the alpine:socat image available to the node:
+    This plugin needs the alpine:socat image available to the node.
   description: |     
-    Deploy a socat listener that allows you to forward to any IP/Port that's 
-    accessible in the cluster. Similar to `kubectl port-forward` but without
-    requiring a Pod/Service to connect to.
+    Similar to kubectl port-forward but without requiring users to enter a 
+    Pod or Svc object in the cluster. Instead you can choose any IP address
+    and port of your choosing. You could for example use it to test whether
+    a Namespace is able to access a Pod's private IP in a different Namespace.
+    Or use it to connect to a service located on an adjacent subnet outside
+    of the cluster itself. It does this (similar to port-forward) by deploying
+    a socat Pod and listener you can port-forward to you, which auto-proxies
+    to the IP and port users supplied.
 

--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -1,15 +1,3 @@
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
@@ -23,17 +11,17 @@ spec:
     uri: https://github.com/antitree/krew-net-forward/releases/download/v1.0.3/net-forward_v1.0.3.tar.gz
     sha256: "645adb05d9ad68ecc91d9034cb80b1e2fe4762864323c12de0f2bc5afe20baa0"
     bin: "net-forward"  
-  shortDescription: "Extend the functionality of port-forward connect to any IP and port (not just Pods and Services)."
+  shortDescription: "Proxy to arbitrary TCP services on a cluster network"
   homepage: https://github.com/antitree/krew-net-forward
   caveats: |
     This plugin needs the alpine:socat image available to the node.
   description: |     
-    Similar to kubectl port-forward but without requiring users to enter a 
-    Pod or Svc object in the cluster. Instead you can choose any IP address
-    and port of your choosing. You could for example use it to test whether
-    a Namespace is able to access a Pod's private IP in a different Namespace.
-    Or use it to connect to a service located on an adjacent subnet outside
-    of the cluster itself. It does this (similar to port-forward) by deploying
-    a socat Pod and listener you can port-forward to you, which auto-proxies
-    to the IP and port users supplied.
-
+    A plugin similar to kubectl port-forward but without requiring users to
+    enter a Pod or Svc object existing the cluster. Instead you can choose any
+    IP address and port of your choosing. You could for example use it to test
+    whether a Namespace is able to access a Pod's private IP in a different
+    Namespace. Or use it to connect to a non-k8s service located on an adjacent
+    subnet outside of the cluster itself. It does this (similar to port-forward)
+    by deploying a socat Pod and listener that you can port-forward to you to
+    create a local listener service (default 127.0.0.1:9999), which
+    auto-forwards to the IP and port the users supplies.

--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -10,38 +10,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-command: ./kubectl-net_forward
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: net-forward
 spec:
-  version: "v1.0.2"       # required, must be in semver format, prefixed with "v"
+  version: "v1.0.3"       
   platforms:
-  # specify installation script for linux 
-  - selector:             # a regular Kubernetes selector
+  - selector:
       matchLabels:
         os: linux
-    # url for downloading the package archive:
-    uri: https://github.com/antitree/krew-tools/releases/download/0.0.2/krew-tools_v1.0.2.tar.gz
-    # sha256sum of the above archive file:
-    sha256: "2248c140613ce9a4796332744de6c37e82352929270bbd06b2ad6fde6e7c7f1c"
-    # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
-    files:
-      - from: "net-forward/*"
-        to: "."
-    bin: "kubectl-net_forward"  # path to the plugin executable after copying files above
+    uri: https://github.com/antitree/krew-net-forward/releases/download/v1.0.3/net-forward_v1.0.3.tar.gz
+    sha256: "645adb05d9ad68ecc91d9034cb80b1e2fe4762864323c12de0f2bc5afe20baa0"
+    bin: "net-forward"  
   shortDescription: "Setup a true forwarder from your local machine to any TCP service accessible from within the cluster."
-  homepage: https://github.com/antitree/krew-tools
-  # (optional) use caveats field to show post-installation recommendations
+  homepage: https://github.com/antitree/krew-net-forward
   caveats: |
     This plugin needs the alpine:socat image available to the node:
-  description: |     # should print nicely on standard 80 char wide terminals
+  description: |     
     Deploy a socat listener that allows you to forward to any IP/Port that's 
     accessible in the cluster. Similar to `kubectl port-forward` but without
-    the requiring a kubernetes to connect to.
-    
-    Examples:
-      kubectl net-forward
-      kubectl net-forward -i kubernetes.default -p 443
-      kubectl net-forward -n testnamespace -i 10.24.0.1 -p 443 -l 9999
+    requiring a Pod/Service to connect to.
+

--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -1,0 +1,47 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+command: ./kubectl-net_forward
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: net-forward
+spec:
+  version: "v1.0.2"       # required, must be in semver format, prefixed with "v"
+  platforms:
+  # specify installation script for linux 
+  - selector:             # a regular Kubernetes selector
+      matchLabels:
+        os: linux
+    # url for downloading the package archive:
+    uri: https://github.com/antitree/krew-tools/releases/download/0.0.2/krew-tools_v1.0.2.tar.gz
+    # sha256sum of the above archive file:
+    sha256: "2248c140613ce9a4796332744de6c37e82352929270bbd06b2ad6fde6e7c7f1c"
+    # copy the used files out of the zip archive, defaults to `[{from: "*", to: "."}]`
+    files:
+      - from: "net-forward/*"
+        to: "."
+    bin: "kubectl-net_forward"  # path to the plugin executable after copying files above
+  shortDescription: "Setup a true forwarder from your local machine to any TCP service accessible from within the cluster."
+  homepage: https://github.com/antitree/krew-tools
+  # (optional) use caveats field to show post-installation recommendations
+  caveats: |
+    This plugin needs the alpine:socat image available to the node:
+  description: |     # should print nicely on standard 80 char wide terminals
+    Deploy a socat listener that allows you to forward to any IP/Port that's 
+    accessible in the cluster. Similar to `kubectl port-forward` but without
+    the requiring a kubernetes to connect to.
+    
+    Examples:
+      kubectl net-forward
+      kubectl net-forward -i kubernetes.default -p 443
+      kubectl net-forward -n testnamespace -i 10.24.0.1 -p 443 -l 9999


### PR DESCRIPTION
adding the net-forward plugin which lets you create a local forwarder from your machine to arbitrary services accessible within the cluster. Description below:

Description:
   This plugin allows you to forward to adjacent network services exposed within the cluster.  It can also help find services for you and help you forward to them.


    kubectl net_forward [-i DESTIP] [-p DESTPORT] [-l LISTENPORT] [-n NAMESPACE] 

    
 - To choose a specific namespace to connect from run:
	kubectl net_forward -n YOURNAMESPACE
    
 - To choose an IP to connect to run:
	kubectl net_forward -i 10.24.0.1
    
 - To choose a port to connect to run:
	kubectl net_forward -p 80
    
 - Set IP, port, and local listening port: 
	kubect net_forward -i 10.24.0.1 -p 443 -l 8888

