### PR TITLE
Add new plugin - `kubectl sshd`

### DIFF
--- a/plugins/sshd.yaml
+++ b/plugins/sshd.yaml
@@ -1,0 +1,30 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: sshd
+spec:
+  version: "v0.1.0"
+  platforms:
+  - uri: https://github.com/ottoyiu/kubectl-sshd/archive/v0.1.0.tar.gz
+    sha256: 592dbf172f4bd35317b6632e120056c803e29c5713a28d876b69baf2f9955dba
+    bin: kubectl-sshd
+    files:
+    - from: "./*/bin/static-dropbear"
+      to: .
+    - from: "./*/bin/kubectl-sshd"
+      to: .
+    - from: "./*/LICENSE"
+      to: .
+    selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+  caveats: |
+    This plugin requires that the 'tar' binary to be present in your container.
+  description: |
+    This plugin allows users to run a SSH server (Dropbear) in a running Pod.
+    Running a temporary SSH server can be useful to execute applications
+    that rely on SSH as a protocol, such as scp, rsync and rdiff-backup.
+    However, this plugin should not be used as a replacement for `kubectl exec`
+    and `kubectl cp`.
+  shortDescription: Run SSH server in a Pod
+  homepage: https://github.com/ottoyiu/kubectl-sshd


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Requesting to add a new plugin: `kubectl sshd`.

Thanks for the consideration :)

```
A kubectl plugin that utilize dropbear to run a temporary SSH server on any Running Pod in your Kubernetes cluster.

It can be useful to run a SSH server in an existing Pod to securely copy files off the Pod itself using scp or rsync, without having to re-deploy a Pod with a SSH sidecar.

The use of this plugin should eventually be deprecated in favour of Ephemeral Containers (alpha since Kubernetes v1.16): https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/

Caution: In most cases, using SSH to gain access to a Pod is considered an anti-pattern. Please consider using kubectl exec for executing commands and kubectl cp for copying files between a Pod and your local workstation.
```