### PR TITLE
Update view-secret to v0.4.0

### DIFF
--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: view-secret
 spec:
-  version: "v0.3.0"
+  version: "v0.4.0"
   homepage: https://github.com/elsesiy/kubectl-view-secret
   shortDescription: Decode Kubernetes secrets
   description: |+2
@@ -21,6 +21,9 @@ spec:
     # print keys for secret in different namespace
     $ kubectl view-secret <secret> -n/--namespace foo
 
+    # print keys for secret in different context
+    $ kubectl view-secret <secret> -c/--context ctx
+
     # suppress info output
     $ kubectl view-secret <secret> -q/--quiet
   platforms:
@@ -28,8 +31,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.3.0/kubectl-view-secret_0.3.0_Darwin_x86_64.tar.gz
-      sha256: "36ef260835d35814d0e18c7fb1792a61686f0e584373ee0e04554f4d675a76ee"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.4.0/kubectl-view-secret_0.4.0_Darwin_x86_64.tar.gz
+      sha256: "d0d3ed3e3435cd67090c6b76e148010e27d32e4f0acebf0caa9aaedf75739064"
       files:
         - from: kubectl-view-secret
           to: .
@@ -40,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.3.0/kubectl-view-secret_0.3.0_Linux_x86_64.tar.gz
-      sha256: "5886e5350dac40c38e904c126161e252f832df45b87bf60da7320bbdde0f56c7"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.4.0/kubectl-view-secret_0.4.0_Linux_x86_64.tar.gz
+      sha256: "becdd79fcb6693883581c9876e93d800374f270986d5ae5c99c182799c3c5259"
       files:
         - from: kubectl-view-secret
           to: .
@@ -52,8 +55,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.3.0/kubectl-view-secret_0.3.0_Windows_x86_64.tar.gz
-      sha256: "baa0bf9110d6ff443e34a7900220e3d3072d8c267be6d0ff50ee989989953497"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.4.0/kubectl-view-secret_0.4.0_Windows_x86_64.tar.gz
+      sha256: "7323a194aa37ffa7a146b38ffc516568fbb6e7c9dad1198d068da4b757c48eaf"
       files:
         - from: kubectl-view-secret.exe
           to: .


### PR DESCRIPTION
This PR updates the `view-secret` plugin to a new version `v0.4.0`.