### PR TITLE
new version v1.1.0 of node-shell

### DIFF
--- a/plugins/node-shell.yaml
+++ b/plugins/node-shell.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: node-shell
 spec:
-  version: "v1.0.1"
+  version: "v1.1.0"
   homepage: https://github.com/kvaps/kubectl-node-shell
   shortDescription: Spawn a root shell on a node via kubectl 
   description: |
@@ -26,8 +26,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/kvaps/kubectl-node-shell/archive/v1.0.1.tar.gz
-    sha256: "1843c25981dae4976bd73c7fe75a39071f37e6e74514d15b89693faa1e756a4d"
+    uri: https://github.com/kvaps/kubectl-node-shell/archive/v1.1.0.tar.gz
+    sha256: "391bacaeda78f25b478efaa4644e3af99fec7e13a379418cc54463124f5c43af"
     files:
     - from: kubectl-node-shell-*/kubectl-node_shell
       to: .


### PR DESCRIPTION
This version includes the next changes:

- fix: Use FQDN for docker hub registry ([#6](https://github.com/kvaps/kubectl-node-shell/pull/6)) 
- Adds support for passing through context and kubeconfig flags ([#4](https://github.com/kvaps/kubectl-node-shell/pull/4))