### PR TITLE
Fix manifest validation in GitHub actions pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
       with:
         fetch-depth: 0  # disable shallow clones
 
-    - name: Fetch origin/master
+    - name: Fetch base branch
       run: |
-        git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}
 
     - name: Install kubectl
       run: |
@@ -51,7 +51,7 @@ jobs:
         set -x
         set -euo pipefail
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-        git diff --name-only --diff-filter=AM origin/master ${{ github.sha }} -- plugins/ |
+        git diff --name-only --diff-filter=AM origin/${GITHUB_BASE_REF} ${{ github.sha }} -- plugins/ |
           tee /dev/stderr |
           xargs -I _ $HOME/bin/validate-krew-manifest -manifest _
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,27 +6,31 @@ jobs:
   build:
     name: Build and Tags
     runs-on: ubuntu-latest
-    env: 
+    env:
       KREW_VERSION: v0.3.3
       GO111MODULE: on
     steps:
-    
+
     - name: Set up Go 1.13
       uses: actions/setup-go@v1
       with:
         go-version: 1.13
       id: go
 
-    - name: Check out code into the Go module directory
+    - name: Check out PR branch
       uses: actions/checkout@v2
       with:
         fetch-depth: 0  # disable shallow clones
+
+    - name: Fetch origin/master
+      run: |
+        git fetch --no-tags --prune --depth=1 origin +refs/heads/master:refs/remotes/origin/master
 
     - name: Install kubectl
       run: |
         set -euo pipefail
         sudo curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.13.1/bin/linux/amd64/kubectl
-        sudo chmod +x /usr/bin/kubectl        
+        sudo chmod +x /usr/bin/kubectl
 
     - name: Install krew
       run: |
@@ -35,19 +39,19 @@ jobs:
         curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew.{tar.gz,yaml}"
         tar zxvf krew.tar.gz
         ./krew-linux_amd64 install --manifest=krew.yaml --archive=krew.tar.gz
-        
+
     - name: Install validate-krew-manifest plugin
       run : |
         set -euo pipefail
         export GOBIN=$HOME/bin
         go get sigs.k8s.io/krew/cmd/validate-krew-manifest@${KREW_VERSION}
-      
+
     - name: Validate updated plugin manifests
       run : |
         set -x
         set -euo pipefail
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-        git diff --name-only --diff-filter=AM ${{ github.sha }} -- plugins/ |
+        git diff --name-only --diff-filter=AM origin/master ${{ github.sha }} -- plugins/ |
           tee /dev/stderr |
           xargs -I _ $HOME/bin/validate-krew-manifest -manifest _
-        
+


### PR DESCRIPTION

    Previously, the changed manifests were determined by a git command
    equivalent to `git diff <commit>`. This checks for dirty files in the
    working directory, so this never detects any changes in the CI where
    everything is clean.
    
    Instead, we need to run a command `git diff origin/master <commit>` to
    detect all changes that are new in the current branch and are not
    present in ref origin/master. For that to work, the master branch needs
    to be pulled explicitly.


This fixes a problem that was introduced in #476.

