### PR TITLE
Add 'kubectl-topology'.

### DIFF
--- a/plugins/topology.yaml
+++ b/plugins/topology.yaml
@@ -1,0 +1,65 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: topology
+spec:
+  version: v0.1.0
+  shortDescription: Explore region topology for nodes or pods
+  homepage: https://github.com/bmcstdio/kubectl-topology
+  description: |
+    Provides insight into the topology of a Kubernetes cluster (i.e. into the
+    distribution of nodes and pods per region and zone).
+
+    NOTE: Requires nodes to be adequately labeled with the
+    'topology.kubernetes.io/{region,zone}' labels or their deprecated
+    equivalents, 'failure-domain.beta.kubernetes.io/{region,zone}'.
+
+    # List all pods across all namespaces and the zones and regions they are in.
+    $ kubectl-topology pod --all-namespaces
+    NAMESPACE     NAME                                     NODE                          REGION         ZONE
+    kube-system   kube-dns-5f886bf8d8-s7pcc                gke-gke-1-p-1-50120dfc-26gm   europe-west1   europe-west1-d
+    kube-system   kube-dns-5f886bf8d8-zhm42                gke-gke-1-p-1-8e1077f6-17st   europe-west1   europe-west1-b
+    kube-system   kube-dns-autoscaler-8687c64fc-d5jvm      gke-gke-1-p-1-8e1077f6-17st   europe-west1   europe-west1-b
+    kube-system   kube-proxy-gke-gke-1-p-1-50120dfc-26gm   gke-gke-1-p-1-50120dfc-26gm   europe-west1   europe-west1-d
+    kube-system   kube-proxy-gke-gke-1-p-1-7023cbca-cz4b   gke-gke-1-p-1-7023cbca-cz4b   europe-west1   europe-west1-c
+    kube-system   kube-proxy-gke-gke-1-p-1-8e1077f6-17st   gke-gke-1-p-1-8e1077f6-17st   europe-west1   europe-west1-b
+    kube-system   l7-default-backend-8f479dd9-dkspg        gke-gke-1-p-1-50120dfc-26gm   europe-west1   europe-west1-d
+    kube-system   metrics-server-v0.3.1-5c6fbf777-z7jxq    gke-gke-1-p-1-8e1077f6-17st   europe-west1   europe-west1-b
+    ns-1          nginx                                    gke-gke-1-p-1-7023cbca-cz4b   europe-west1   europe-west1-c
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.0/kubectl-topology_v0.1.0_darwin_amd64.tar.gz
+    sha256: "f6930bf851405bbf35b23078aafe61732752c27d1801c12d07a083f1012bd7be"
+    files:
+    - from: kubectl-topology
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-topology
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.0/kubectl-topology_v0.1.0_linux_amd64.tar.gz
+    sha256: "4d1e24fe48bef45354b464aa80e4d80cd86c3af12210de8f179fddf7b2f1e774"
+    files:
+    - from: kubectl-topology
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-topology
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.0/kubectl-topology_v0.1.0_windows_amd64.tar.gz
+    sha256: "e69f18979f9661c089079128d5e91133e6ecd0a7a80d3924534cb390e15fc406"
+    files:
+    - from: kubectl-topology.exe
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-topology.exe


### PR DESCRIPTION
This PR adds the first version of `kubectl-topology`, a plugin meant to provide insights into the topology of Kubernetes clusters (i.e. into the distribution of nodes and pods per region and zone).