### PR TITLE
add plugin: kubectl node-restart

### DIFF
--- a/plugins/node-restart.yaml
+++ b/plugins/node-restart.yaml
@@ -17,11 +17,12 @@ spec:
       to: "."
     bin: "node-restart.sh"
   shortDescription: >-
-    Restart Kubernetes Nodes sequentially & gracefully
+    Restart cluster nodes sequentially & gracefully
   homepage: https://github.com/mnrgreg/kubectl-node-restart
   caveats: |
-    Execution of this plugin requires Kubernetes cluster-admin Rolebindings.
+    Execution of this plugin requires Kubernetes cluster-admin Rolebindings
+    and the ability to schedule Privileged Pods.
   description: |
     This plugin performs a sequential, rolling restart of selected nodes by first
-    Draining each node, then running a Kubernetes Job to reboot each node, and
-    finally Uncordoning each node when Ready. 
+    draining each node, then running a Kubernetes Job to reboot each node, and
+    finally uncordoning each node when Ready. 

--- a/plugins/node-restart.yaml
+++ b/plugins/node-restart.yaml
@@ -1,0 +1,27 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: node-restart
+spec:
+  version: "v0.0.2"
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/MnrGreg/kubectl-node-restart/releases/download/v0.0.2/v0.0.2.zip
+    sha256: "44db0eee9603085652837d26c5352287864f158b557f78ae19325724640535f8"
+    files:
+    - from: "*.sh"
+      to:  "."
+    - from: "LICENSE"
+      to: "."
+    bin: "node-restart.sh"
+  shortDescription: >-
+    Restart Kubernetes Nodes sequentially & gracefully
+  homepage: https://github.com/mnrgreg/kubectl-node-restart
+  caveats: |
+    Execution of this plugin requires Kubernetes cluster-admin Rolebindings.
+  description: |
+    This plugin performs a sequential, rolling restart of selected nodes by first
+    Draining each node, then running a Kubernetes Job to reboot each node, and
+    finally Uncordoning each node when Ready. 


### PR DESCRIPTION
This plugin provides cluster-admins with the ability to perform graceful, rolling restarts of Kubernetes cluster Nodes.

