### PR TITLE
Add tmux-exec to index

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -85,6 +85,7 @@ Name | Description | Stars
 [sudo](https://github.com/postfinance/kubectl-sudo) | Run Kubernetes commands impersonated as group system:masters | ![GitHub stars](https://img.shields.io/github/stars/postfinance/kubectl-sudo.svg?label=stars&logo=github)
 [support-bundle](https://github.com/replicatedhq/troubleshoot) | Creates support bundles for off-cluster analysis | ![GitHub stars](https://img.shields.io/github/stars/replicatedhq/troubleshoot.svg?label=stars&logo=github)
 [tail](https://github.com/boz/kail) | Stream logs from multiple pods and containers using simple, dynamic source selection. | ![GitHub stars](https://img.shields.io/github/stars/boz/kail.svg?label=stars&logo=github)
+[tmux-exec](https://github.com/predatorray/kubectl-tmux-exec) | An exec multiplexer using Tmux | ![GitHub stars](https://img.shields.io/github/stars/predatorray/kubectl-tmux-exec.svg?label=stars&logo=github)
 [topology](https://github.com/bmcstdio/kubectl-topology) | Explore region topology for nodes or pods | ![GitHub stars](https://img.shields.io/github/stars/bmcstdio/kubectl-topology.svg?label=stars&logo=github)
 [tree](https://github.com/ahmetb/kubectl-tree) | Show a tree of object hierarchies through ownerReferences | ![GitHub stars](https://img.shields.io/github/stars/ahmetb/kubectl-tree.svg?label=stars&logo=github)
 [view-allocations](https://github.com/davidB/kubectl-view-allocations) | List allocations per resources, nodes, pods. | ![GitHub stars](https://img.shields.io/github/stars/davidB/kubectl-view-allocations.svg?label=stars&logo=github)

--- a/plugins/tmux-exec.yaml
+++ b/plugins/tmux-exec.yaml
@@ -1,0 +1,37 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: tmux-exec
+spec:
+  version: "v0.0.2"
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/predatorray/kubectl-tmux-exec/releases/download/v0.0.2/kubectl-tmux-exec-0.0.2.tar.gz
+    sha256: "1699e634a19777ad8dc1e78e2f36893b11ca5c3cf0ac1f83f641af47d8060f81"
+    bin: "bin/kubectl-tmux_exec"
+  shortDescription: >- 
+    An exec multiplexer using Tmux
+  homepage: https://github.com/predatorray/kubectl-tmux-exec
+  caveats: |
+    This plugin needs the following programs:
+    * tmux(1)
+    * gnu-getopt(1)
+
+    Since the `getopt` in GNU-Linux is by default the GNU's one,
+    it is not required to install `gnu-getopt` again.
+
+    But, if you are using Mac, please follow the instruction below.
+    1. `brew install gnu-getopt`, or download it from its website
+       and install it manually.
+    2. Either add `export GNU_GETOPT_PREFIX="$(brew --prefix gnu-getopt)"`
+       to your profile file, which is RECOMMENDED.
+       Or, replace the `getopt` with `gnu-getopt` by adding it to
+       the head of `$PATH` env, like
+       `export PATH="$(brew --prefix gnu-getopt)/bin:$PATH"`.
+  description: |
+    This plugin uses Tmux to multiplex commands to pods.
+    Instead of `exec bash` into multiple pod's containers one-at-a-time,
+    you can now do it at the same time by opening multiple panes in a window.
+    Run 'kubectl tmux-exec --help' for more information on the plugin.


### PR DESCRIPTION
This plugin provides the ability to operate (eg, `exec bash`) multiple pods by using Tmux.