### PR TITLE
Revert "Update virt (KubeVirt virtctl plugin package) to v0.27.0 (#530)"

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: virt
 spec:
-  version: "v0.27.0"
+  version: "v0.26.0"
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.27.0/virtctl-darwin-amd64.tar.gz"
-      sha256: "2c048dd3b82847f1ac12fe8bf71e1c8b0be20e1a422c8339a68420fccc9e2f6e"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.26.0/virtctl-darwin-amd64.tar.gz"
+      sha256: "c721fa63eff318752d96b99d176e2b5d73719625b3630b7fcdb5e42b45b7a347"
       files:
         - from: "/virtctl/virtctl-darwin-amd64"
           to: "virtctl"
@@ -21,8 +21,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.27.0/virtctl-linux-amd64.tar.gz"
-      sha256: "6a1379c6d0265761b25dbf4b6e28aa5c5ad177c36533d44272125c8ccfda11a3"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.26.0/virtctl-linux-amd64.tar.gz"
+      sha256: "6abdec38f18830916634b4190e170c9cb57d1728e156ac2b0a6693077ad4e15e"
       files:
         - from: "/virtctl/virtctl-linux-amd64"
           to: "virtctl"
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.27.0/virtctl-windows-amd64.exe.tar.gz"
-      sha256: "5854cc18bca849844c8341b001d5d66607e61820a7bf87882879ad780164e8d9"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.26.0/virtctl-windows-amd64.exe.tar.gz"
+      sha256: "2cb0606c7aaad130c70ff754c91bf1e89889f2d043680254e09c34c7152e3ef4"
       files:
         - from: "/virtctl/virtctl-windows-amd64.exe"
           to: "virtctl.exe"


### PR DESCRIPTION
This reverts commit 060708e5e2d843858770f76e8c16b36277850a99.

The package for linux is broken, we have to regenerate it. Will add some
more validation and tests for pre-upload.

Sorry for the hassle.