### PR TITLE
Add copy-to-ns plugin

### DIFF
--- a/plugins/copy-to-ns.yaml
+++ b/plugins/copy-to-ns.yaml
@@ -1,0 +1,30 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: copy-to-ns
+spec:
+  homepage: https://github.com/naseemkullah/kubectl-plugins
+  shortDescription: Copy an object from one namespace to another
+  version: v0.0.1
+  description: |
+    Copy a resource from one namespace to another.
+  caveats: |
+    Requires jq to be installed.
+    Currently only supports secrets and configmaps and
+    a single destination namespace.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/naseemkullah/kubectl-plugins/archive/v0.0.1.tar.gz
+    sha256: 00f49edbce6a70ec73a68245d854a4c8e20934d52b2a8e46f2dcc74bf29ce00d
+    bin: kubectl-copy_to_ns.sh
+    files:
+    - from: kubectl-plugins-*/copy-to-ns/*
+      to: .
+    - from: kubectl-plugins-*/LICENSE
+      to: .


### PR DESCRIPTION
Copies a secret or configmap from one namespace to another.
Requires that jq be installed.


