### PR TITLE
Update view-secrets to v0.5.0

### DIFF
--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: view-secret
 spec:
-  version: "v0.4.0"
+  version: "v0.5.0"
   homepage: https://github.com/elsesiy/kubectl-view-secret
   shortDescription: Decode Kubernetes secrets
   description: |+2
@@ -31,8 +31,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.4.0/kubectl-view-secret_0.4.0_Darwin_x86_64.tar.gz
-      sha256: "d0d3ed3e3435cd67090c6b76e148010e27d32e4f0acebf0caa9aaedf75739064"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.5.0/kubectl-view-secret_0.5.0_Darwin_x86_64.tar.gz
+      sha256: "de6d819f28bce729070f1698973aa0a007a270d944f3486d8454833bf60e4e63"
       files:
         - from: kubectl-view-secret
           to: .
@@ -43,8 +43,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.4.0/kubectl-view-secret_0.4.0_Linux_x86_64.tar.gz
-      sha256: "becdd79fcb6693883581c9876e93d800374f270986d5ae5c99c182799c3c5259"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.5.0/kubectl-view-secret_0.5.0_Linux_x86_64.tar.gz
+      sha256: "f691c690efa04427ab128849283dc7f0a170cd2fb0a9bcf7341ea6849ba32ce1"
       files:
         - from: kubectl-view-secret
           to: .
@@ -55,8 +55,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.4.0/kubectl-view-secret_0.4.0_Windows_x86_64.tar.gz
-      sha256: "7323a194aa37ffa7a146b38ffc516568fbb6e7c9dad1198d068da4b757c48eaf"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.5.0/kubectl-view-secret_0.5.0_Windows_x86_64.tar.gz
+      sha256: "e3f6f7e6c201480263030838f17a68f9253f8e7872dad0cb44e514feff2bd9f4"
       files:
         - from: kubectl-view-secret.exe
           to: .


### PR DESCRIPTION
This PR updates the `view-secret` plugin to a new version `v0.5.0`.