### PR TITLE
Bump 'kubectl-topology' to v0.1.1.

### DIFF
--- a/plugins/topology.yaml
+++ b/plugins/topology.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: topology
 spec:
-  version: v0.1.0
+  version: v0.1.1
   shortDescription: Explore region topology for nodes or pods
   homepage: https://github.com/bmcstdio/kubectl-topology
   description: |
@@ -31,8 +31,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.0/kubectl-topology_v0.1.0_darwin_amd64.tar.gz
-    sha256: "f6930bf851405bbf35b23078aafe61732752c27d1801c12d07a083f1012bd7be"
+    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.1/kubectl-topology_v0.1.1_darwin_amd64.tar.gz
+    sha256: "a8c9740329481dcff64a93697820bdef375d4fbc30cfe8df2869df948e923f0d"
     files:
     - from: kubectl-topology
       to: .
@@ -43,8 +43,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.0/kubectl-topology_v0.1.0_linux_amd64.tar.gz
-    sha256: "4d1e24fe48bef45354b464aa80e4d80cd86c3af12210de8f179fddf7b2f1e774"
+    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.1/kubectl-topology_v0.1.1_linux_amd64.tar.gz
+    sha256: "3aa1ecd9ab4c13e9f1bc88f1a171bd28835863c4abfd038756e5ca39bd6929af"
     files:
     - from: kubectl-topology
       to: .
@@ -55,8 +55,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.0/kubectl-topology_v0.1.0_windows_amd64.tar.gz
-    sha256: "e69f18979f9661c089079128d5e91133e6ecd0a7a80d3924534cb390e15fc406"
+    uri: https://github.com/bmcstdio/kubectl-topology/releases/download/v0.1.1/kubectl-topology_v0.1.1_windows_amd64.tar.gz
+    sha256: "545dbc904ef25388621ca12b080aa174fd6c724f62443490aa30515152dcd4ab"
     files:
     - from: kubectl-topology.exe
       to: .


### PR DESCRIPTION
This PR bumps `kubectl-topology` to v0.1.1 (I'll look at automating this step in the future).