### PR TITLE
Bump 'kubectl-cilium' to v0.1.1.

### DIFF
--- a/plugins/cilium.yaml
+++ b/plugins/cilium.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cilium
 spec:
-  version: v0.1.0
+  version: v0.1.1
   shortDescription: Easily interact with Cilium agents.
   homepage: https://github.com/bmcstdio/kubectl-cilium
   description: |
@@ -21,8 +21,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/bmcstdio/kubectl-cilium/releases/download/v0.1.0/kubectl-cilium_v0.1.0_darwin_amd64.tar.gz
-    sha256: "c8466c94337db34f0cee5be60a0715682bfabf5b5dc041d1a30b4cd9eaae0b11"
+    uri: https://github.com/bmcstdio/kubectl-cilium/releases/download/v0.1.1/kubectl-cilium_v0.1.1_darwin_amd64.tar.gz
+    sha256: "9d8ffa78491c881557d79bff25d733236c12158f569008d97db325855b6c43b9"
     files:
     - from: kubectl-cilium
       to: .
@@ -33,8 +33,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/bmcstdio/kubectl-cilium/releases/download/v0.1.0/kubectl-cilium_v0.1.0_linux_amd64.tar.gz
-    sha256: "4173139333fd1e8993dcfdc747ae11b54ccd123ae9668296bdb67c3d90521f0b"
+    uri: https://github.com/bmcstdio/kubectl-cilium/releases/download/v0.1.1/kubectl-cilium_v0.1.1_linux_amd64.tar.gz
+    sha256: "7f77a47d0d173946883257a045c8221ebd84bbcafa4041d3d90087697081aca7"
     files:
     - from: kubectl-cilium
       to: .
@@ -45,8 +45,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/bmcstdio/kubectl-cilium/releases/download/v0.1.0/kubectl-cilium_v0.1.0_windows_amd64.tar.gz
-    sha256: "801d66d8fc06c04ac8f7ea0a243c1a742166eef8e1c97caf3ec322f30de92a38"
+    uri: https://github.com/bmcstdio/kubectl-cilium/releases/download/v0.1.1/kubectl-cilium_v0.1.1_windows_amd64.tar.gz
+    sha256: "98e3747bff0603f8838f93c3f807da676ed7b3abb730839b35044b1d870da69d"
     files:
     - from: kubectl-cilium.exe
       to: .


### PR DESCRIPTION
This PR bumps `kubectl-cilium` to v0.1.1, which fixes an important issue.
