### PR TITLE
Update virt (KubeVirt virtctl plugin package) to v0.29.0

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: virt
 spec:
-  version: "v0.28.0"
+  version: "v0.29.0"
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.28.0/virtctl-darwin-amd64.tar.gz"
-      sha256: "28c84c16c0524a206b91dc59d8fdebaa7db95da4cfda6d40b38ebbdbb08fa573"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.29.0/virtctl-darwin-amd64.tar.gz"
+      sha256: "f583bcfe5534fcf0e8cf52590f656cb834060dec7574e069614dcaf343ebaff6"
       files:
         - from: "/virtctl/virtctl-darwin-amd64"
           to: "virtctl"
@@ -21,8 +21,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.28.0/virtctl-linux-amd64.tar.gz"
-      sha256: "3a274f89c14c6d9d60c7cada1ff7f300a09027da98e6094d4ce382362cee91f5"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.29.0/virtctl-linux-amd64.tar.gz"
+      sha256: "7a9aa8661dbd17540a45370984ea2012692a148d979a65547a8e80a102ca2fc1"
       files:
         - from: "/virtctl/virtctl-linux-amd64"
           to: "virtctl"
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: linux
           arch: 386
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.28.0/virtctl-linux-x86_64.tar.gz"
-      sha256: "00406b8553d4fd3f4d53163528a7e164185a14706e62cf3b77032eb99c9d5827"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.29.0/virtctl-linux-x86_64.tar.gz"
+      sha256: "03a8a15f8b24bf39e180ce31a9df732c0b8b1fcee73d5ef502b78a584a26a3f8"
       files:
         - from: "/virtctl/virtctl-linux-x86_64"
           to: "virtctl"
@@ -45,8 +45,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.28.0/virtctl-windows-amd64.exe.tar.gz"
-      sha256: "bceb0000fa89ca7fbd8bc91aa6a46610fe8605819ac91b44e6873a0612bc8cb3"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.29.0/virtctl-windows-amd64.exe.tar.gz"
+      sha256: "0d2609dea45ae9047f46ee6e14dde6db2c306d46ce7f2e5d447eb58568f8da20"
       files:
         - from: "/virtctl/virtctl-windows-amd64.exe"
           to: "virtctl.exe"


### PR DESCRIPTION
See https://github.com/kubevirt/kubevirt/releases/tag/v0.29.0