### PR TITLE
Eksporter v1.3.0 release

### DIFF
--- a/plugins/eksporter.yaml
+++ b/plugins/eksporter.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: eksporter
 spec:
-  version: "v1.1.0"
+  version: "v1.3.0"
   platforms:
   - selector:
       matchExpressions:
@@ -13,8 +13,8 @@ spec:
         - darwin
         - linux
         - windows
-    uri: https://github.com/Kyrremann/kubectl-eksporter/releases/download/v1.2.0/eksporter.tar.gz
-    sha256: "9a34657e6254fcb50a05334ba6f68eb77d0f8c4adadfe726f3baf0bf727ebadc"
+    uri: https://github.com/Kyrremann/kubectl-eksporter/releases/download/v1.3.0/eksporter.tar.gz
+    sha256: "3b37fb6f619b870a3da12e728f36679e85cb6b7934de2da6c365c16d8fb64fd0"
     files:
     - from: "/eksporter.rb"
       to: "."


### PR DESCRIPTION
Will now also remove clusterIP from resources.

Fixes https://github.com/Kyrremann/kubectl-eksporter/issues/3
