### PR TITLE
Bump oidc-login to v1.19.1

### DIFF
--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -24,10 +24,10 @@ spec:
     You need to setup the OIDC provider, Kubernetes API server, role binding and kubeconfig.
     See https://github.com/int128/kubelogin for more.
 
-  version: v1.19.0
+  version: v1.19.1
   platforms:
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.0/kubelogin_linux_amd64.zip
-      sha256: "501ad0e02f6b7575233ae0cfa9b02811eb37dfde41977993e44d3589f8ca12db"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.1/kubelogin_linux_amd64.zip
+      sha256: "3bfe06b8d1935f4276335c7c7d08945f5fcb5735b9d74701663f88908e7edef7"
       bin: kubelogin
       files:
         - from: kubelogin
@@ -38,8 +38,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.0/kubelogin_darwin_amd64.zip
-      sha256: "1f379d57a14024995ba7ec5d2ce4f5aba8448c117189e9f505cf22cf85a01638"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.1/kubelogin_darwin_amd64.zip
+      sha256: "51806d291e69cd4dce54af7bb03adf76a55397741ea00fee4d845718a171ddc0"
       bin: kubelogin
       files:
         - from: kubelogin
@@ -50,8 +50,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.0/kubelogin_windows_amd64.zip
-      sha256: "ada93f259972d4b2db01fd121513511a5bd3c8a2416d0bbfef8adaacfdc6078e"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.1/kubelogin_windows_amd64.zip
+      sha256: "25a8ae07b2761cf9ebd6a11ad47d530fed8360e7bf2cd19a2746a409c9a152b3"
       bin: kubelogin.exe
       files:
         - from: kubelogin.exe
@@ -62,8 +62,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.0/kubelogin_linux_arm.zip
-      sha256: "60e2992c93dfdf29e5e04f21b6796ff0100b9d5524e52947f9f67778206fe9ce"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.1/kubelogin_linux_arm.zip
+      sha256: "1d98627f0c40172253e38a6f7a85ae0f37aafaee2f0ed98520ea59bccde69c7c"
       bin: kubelogin
       files:
         - from: kubelogin
@@ -74,8 +74,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.0/kubelogin_linux_arm64.zip
-      sha256: "a540ae00f83346029d0996837fc913f9c1177cd1da7361c4bbf0022446ccf6ee"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.19.1/kubelogin_linux_arm64.zip
+      sha256: "774e4c3b6d1fbf5bff32e4d882893b179038996934e7acb93bc8a9ec5b1e8af5"
       bin: kubelogin
       files:
         - from: kubelogin


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
