### PR TITLE
Update: kubectl-images release new verion v.0.2.0

### DIFF
--- a/plugins/images.yaml
+++ b/plugins/images.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: images
 spec:
-  version: v0.1.0
+  version: v0.2.0
   homepage: https://github.com/chenjiandongx/kubectl-images
   shortDescription: Show container images used in the cluster.
   description: |
@@ -15,20 +15,20 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.1.0/kubectl-images_darwin_amd64.tar.gz
-    sha256: 885bfd428a8cb09189f7c3da1b9bff2a0f8dc13a47707ec98b4071ce6f7a92d1
+    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_darwin_amd64.tar.gz
+    sha256: 7b3751496a87596b820ab9794ea5bb3e21ce590d1409380badcf60629a98764d
     bin: kubectl-images
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.1.0/kubectl-images_linux_amd64.tar.gz
-    sha256: 1c42a4f2e4e803f3b9b2d736b095193f7c47a7c7853f337e9f4f82798cf404d2
+    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_linux_amd64.tar.gz
+    sha256: 11b415a711cd0a501e89e9a8b7322eba8277f45443385fc20a409600d081306c4
     bin: kubectl-images
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.1.0/kubectl-images_windows_amd64.tar.gz
-    sha256: e35aa6023df73d8b8218e8891643a90da91f2113e0366c2839876a0e1e4d6e82
+    uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_windows_amd64.tar.gz
+    sha256: 28b2caae745cfa7867b6617de65cd1ca1ca75096f2d96c30de91b8a23facb665
     bin: kubectl-images

--- a/plugins/images.yaml
+++ b/plugins/images.yaml
@@ -23,7 +23,7 @@ spec:
         os: linux
         arch: amd64
     uri: https://github.com/chenjiandongx/kubectl-images/releases/download/v0.2.0/kubectl-images_linux_amd64.tar.gz
-    sha256: 11b415a711cd0a501e89e9a8b7322eba8277f45443385fc20a409600d081306c4
+    sha256: 1b415a711cd0a501e89e9a8b7322eba8277f45443385fc20a409600d081306c4
     bin: kubectl-images
   - selector:
       matchLabels:


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Release tag: https://github.com/chenjiandongx/kubectl-images/releases/tag/v0.2.0