### PR TITLE
Add gadget plugin

### DIFF
--- a/plugins/gadget.yaml
+++ b/plugins/gadget.yaml
@@ -1,0 +1,42 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gadget
+spec:
+  version: v0.1.0
+  homepage: https://github.com/kinvolk/inspektor-gadget
+  shortDescription: Gadgets for debugging and introspecting
+  description: |
+    Inspektor Gadget is a collection of tools (or gadgets) for developers of
+    Kubernetes applications.
+
+    Inspektor Gadget is deployed to each node as a privileged DaemonSet.
+    It uses in-kernel BPF helper programs to monitor events mainly related to
+    syscalls from userspace programs in a pod. The BPF programs are run by
+    the kernel and gather the log data. Inspektor Gadget's userspace utilities
+    fetch the log data from ring buffers and display it. What BPF programs are
+    and how Inspektor Gadget uses them is briefly explained in the architecture
+    document:
+    https://github.com/kinvolk/inspektor-gadget/blob/master/Documentation/architecture.md
+  caveats: |
+    Inspektor Gadget needs to be deployed to each node:
+
+    $ kubectl gadget deploy | kubectl apply -f -
+
+    Read the documentation available at https://github.com/kinvolk/inspektor-gadget
+    to get more information about the server side installation process.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/kinvolk/inspektor-gadget/releases/download/v0.1.0/inspektor-gadget-linux-amd64.tar.gz
+    sha256: b0f6078d37d96e7efbf946d893c12007d4e09fcc8b0ed2cf77912ff2e661513f
+    bin: kubectl-gadget
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/kinvolk/inspektor-gadget/releases/download/v0.1.0/inspektor-gadget-darwin-amd64.tar.gz
+    sha256: e32708a3e9704cdc98190a1500d9eaf1e7850d68f2f7ce81984c70905fca4277
+    bin: kubectl-gadget


### PR DESCRIPTION
[Inspektor Gadget](https://github.com/kinvolk/inspektor-gadget) is a collection of tools (gadgets) for debugging and
introspecting Kubernetes applications.

More info is at https://github.com/kinvolk/inspektor-gadget.

- [x] Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
