### PR TITLE
add sick-pods plugin

### DIFF
--- a/plugins/diagnose.yaml
+++ b/plugins/diagnose.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.1.1
   homepage: https://github.com/alecjacobs5401/kubectl-diagnose
-  shortDescription: Find and debug Kubernetes Pods that are "Not Ready"
+  shortDescription: Find and debug Pods that are "Not Ready"
   description: |
     This plugin shows finds and displays debugging information for Pods that are "Not Ready" in the current namespace.
     In addition, you can filter which pods you want to show based on labels or field selectors (as well as by pod name(s)).

--- a/plugins/diagnose.yaml
+++ b/plugins/diagnose.yaml
@@ -1,0 +1,51 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: diagnose
+spec:
+  version: v0.1.1
+  homepage: https://github.com/alecjacobs5401/kubectl-diagnose
+  shortDescription: Find and debug Kubernetes Pods that are "Not Ready" (that have failing Pod Conditions or Containers)
+  description: |
+    This plugin shows finds and displays debugging information for Pods that are "Not Ready" in the current namespace.
+    In addition, you can filter which pods you want to show based on labels or field selectors (as well as by pod name(s)).
+    Use --help to see all supported flags.
+  caveats: |
+    * The -A/--all-namespaces flag is currently not supported
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/alecjacobs5401/kubectl-diagnose/releases/download/v0.1.1/kubectl-diagnose_0.1.1_darwin_amd64.tar.gz
+    sha256: a61ab7faa2b73db1cd52397330c1bccaec0ccf1909c3db059377749a248007bb
+    files:
+    - from: LICENSE
+      to: .
+    - from: kubectl-diagnose
+      to: .
+    bin: kubectl-diagnose
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/alecjacobs5401/kubectl-diagnose/releases/download/v0.1.1/kubectl-diagnose_0.1.1_linux_amd64.tar.gz
+    sha256: 2cf1a20ff8607a3e729aa86b67188beb9aab1146da532b03be03fc9841860249
+    files:
+    - from: LICENSE
+      to: .
+    - from: kubectl-diagnose
+      to: .
+    bin: kubectl-diagnose
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/alecjacobs5401/kubectl-diagnose/releases/download/v0.1.1/kubectl-diagnose_0.1.1_windows_amd64.tar.gz
+    sha256: deb96ab4acf683073b70ef9d2f3a259212ba3c48ba712c064a9e3d3980a82fdf
+    files:
+    - from: LICENSE
+      to: .
+    - from: kubectl-diagnose.exe
+      to: .
+    bin: kubectl-diagnose.exe

--- a/plugins/diagnose.yaml
+++ b/plugins/diagnose.yaml
@@ -5,11 +5,10 @@ metadata:
 spec:
   version: v0.1.1
   homepage: https://github.com/alecjacobs5401/kubectl-diagnose
-  shortDescription: Find and debug Kubernetes Pods that are "Not Ready" (that have failing Pod Conditions or Containers)
+  shortDescription: Find and debug Kubernetes Pods that are "Not Ready"
   description: |
     This plugin shows finds and displays debugging information for Pods that are "Not Ready" in the current namespace.
     In addition, you can filter which pods you want to show based on labels or field selectors (as well as by pod name(s)).
-    Use --help to see all supported flags.
   caveats: |
     * The -A/--all-namespaces flag is currently not supported
   platforms:

--- a/plugins/diagnose.yaml
+++ b/plugins/diagnose.yaml
@@ -7,8 +7,12 @@ spec:
   homepage: https://github.com/alecjacobs5401/kubectl-diagnose
   shortDescription: Find and debug Pods that are "Not Ready"
   description: |
-    This plugin shows finds and displays debugging information for Pods that are "Not Ready" in the current namespace.
-    In addition, you can filter which pods you want to show based on labels or field selectors (as well as by pod name(s)).
+    This plugin shows finds and displays debugging information for Pods
+    that are "Not Ready" in the current namespace.
+    Pods are deemed as "Not Ready" if they have any failing Pod Conditions
+    or have any containers that do not have a "Ready" value.
+    In addition, you can filter which pods you want to show based on labels
+    or field selectors (as well as by pod name(s)).
   caveats: |
     * The -A/--all-namespaces flag is currently not supported
   platforms:

--- a/plugins/sick-pods.yaml
+++ b/plugins/sick-pods.yaml
@@ -1,13 +1,13 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: diagnose
+  name: sick-pods
 spec:
   version: v0.1.1
   homepage: https://github.com/alecjacobs5401/kubectl-diagnose
   shortDescription: Find and debug Pods that are "Not Ready"
   description: |
-    This plugin shows finds and displays debugging information for Pods
+    This plugin finds and displays debugging information for Pods
     that are "Not Ready" in the current namespace.
     Pods are deemed as "Not Ready" if they have any failing Pod Conditions
     or have any containers that do not have a "Ready" value.
@@ -26,8 +26,8 @@ spec:
     - from: LICENSE
       to: .
     - from: kubectl-diagnose
-      to: .
-    bin: kubectl-diagnose
+      to: kubectl-sick-pods
+    bin: kubectl-sick-pods
   - selector:
       matchLabels:
         os: linux
@@ -38,8 +38,8 @@ spec:
     - from: LICENSE
       to: .
     - from: kubectl-diagnose
-      to: .
-    bin: kubectl-diagnose
+      to: kubectl-sick-pods
+    bin: kubectl-sick-pods
   - selector:
       matchLabels:
         os: windows
@@ -50,5 +50,5 @@ spec:
     - from: LICENSE
       to: .
     - from: kubectl-diagnose.exe
-      to: .
-    bin: kubectl-diagnose.exe
+      to: kubectl-sick-pods.exe
+    bin: kubectl-sick-pods.exe


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Adds `kubectl diagnose` plugin.

This has been split into its own branch as recommended in https://github.com/kubernetes-sigs/krew-index/pull/631
