### PR TITLE
Remove redundant information from `caveats`

### DIFF
--- a/plugins/bulk-action.yaml
+++ b/plugins/bulk-action.yaml
@@ -23,8 +23,6 @@ spec:
     Usage:
       kubectl bulk-action <get resourceTypes> (get|list|create|update|delete|remove|rollout) <command parameters>
 
-    Read the documentation at:
-      https://github.com/emreodabas/kubectl-plugins
     This plugin needs the following programs:
     * grep
     * sed

--- a/plugins/change-ns.yaml
+++ b/plugins/change-ns.yaml
@@ -36,6 +36,5 @@ spec:
         arch: amd64
   version: v1.0.0
   homepage: https://github.com/juanvallejo/kubectl-ns
-  caveats: This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
   shortDescription: View or change the current namespace via kubectl.
   description: View or change the current namespace in your KUBECONFIG file. Honors global config flags found in kubectl, such as `--user`, `--cluster`, `--context`, and `--namespace`.

--- a/plugins/deprecations.yaml
+++ b/plugins/deprecations.yaml
@@ -3,16 +3,16 @@ kind: Plugin
 metadata:
   name: deprecations
 spec:
-  shortDescription: >-    
+  shortDescription: >-
     Checks for deprecated objects in a cluster 
   homepage: https://github.com/rikatz/kubepug
   caveats: |
     * By default, deprecations finds deprecated object relative to the current kubernetes
     master branch. To target a different kubernetes release, use the --k8s-version
     argument.
-    
+
     * Deprecations needs permission to GET all objects in the Cluster
-  description: |     
+  description: |
     This plugin shows all the deprecated objects in a Kubernetes cluster allowing 
     the operator to verify them before upgrading the cluster. It uses the 
     swagger.json version available in master branch of Kubernetes repository

--- a/plugins/exec-cronjob.yaml
+++ b/plugins/exec-cronjob.yaml
@@ -20,15 +20,9 @@ spec:
   description: |
     Run a CronJob immediately as Job by extracting the Job spec and creating a
     Job instance thereof.
-  caveats: |
-    Usage:
-        kubectl exec-cronjob <name> [options]
 
     Options:
         -n, --namespace='': If present, the namespace scope for this CLI request
         --dry-run: If true, only print the object that would be sent, without sending it.
         -h, --help: Display this help
-
-    Read the documentation at:
-      https://github.com/thecloudnatives/kubectl-plugins#exec-cronjob
   homepage: https://github.com/thecloudnatives/kubectl-plugins#exec-cronjob

--- a/plugins/fields.yaml
+++ b/plugins/fields.yaml
@@ -36,12 +36,6 @@ spec:
         arch: amd64
   version: v1.2.3
   homepage: https://github.com/rewanth1997/kubectl-fields
-  caveats: |
-    Usage:
-      kubectl fields <RESOURCE> [options] <PATTERN>
-
-    Documentation:
-      https://github.com/rewanth1997/kubectl-fields/blob/master/README.md
   shortDescription: Grep resources hierarchy by field name
   description: |
     kubectl-fields parses specified kubectl resources to match given pattern(s).

--- a/plugins/fleet.yaml
+++ b/plugins/fleet.yaml
@@ -43,17 +43,14 @@ spec:
     bin: "fleet.exe"
   shortDescription: Shows config and resources of a fleet of clusters
   homepage: https://github.com/kubectl-plus/kcf
-  caveats: |
-    Usage:
-      $ kubectl fleet
-
-    For additional options:
-      $ kubectl fleet --help
-      or https://github.com/kubectl-plus/kcf/blob/v0.1.4/doc/USAGE.md
-
   description: |
     Allows to get an overview and details on a fleet of Kubernetes clusters.
     The top-level command lists all active clusters found in the kubeconfig provided.
     For each cluster, configuration info such as the control plane version or 
     API server endpoint are displayed, as well as select stats, for example, 
     the number of worker nodes or namespaces found in the cluster.
+
+    For additional options:
+      $ kubectl fleet --help
+      or https://github.com/kubectl-plus/kcf/blob/v0.1.4/doc/USAGE.md
+

--- a/plugins/grep.yaml
+++ b/plugins/grep.yaml
@@ -42,15 +42,6 @@ spec:
         arch: amd64
   version: v1.2.2
   homepage: https://github.com/guessi/kubectl-grep
-  caveats: |
-    This plugin requires an existing KUBECONFIG file, with a `current-context` field set.
-
-    Usage:
-
-      $ kubectl grep # output help messages
-
-    More Info:
-    - https://github.com/guessi/kubectl-grep
   shortDescription: Filter Kubernetes resources by matching their names
   description: |
     Filter Kubernetes resources by matching their names

--- a/plugins/iexec.yaml
+++ b/plugins/iexec.yaml
@@ -23,7 +23,7 @@ spec:
   shortDescription: Interactive selection tool for `kubectl exec`
   description: |
     Interactive pod and container selector for `kubectl exec`
-  caveats: |
+
     To get help run: kubectl iexec --help
     Examples:
     Run command in container:

--- a/plugins/konfig.yaml
+++ b/plugins/konfig.yaml
@@ -31,19 +31,15 @@ spec:
           os: windows
   shortDescription: Merge, split or import kubeconfig files
   homepage: https://github.com/corneliusweig/konfig
-  caveats: |
-      Usage:
-        $ kubectl konfig import --save new-cfg
-        $ kubectl konfig merge kubeconfig1 kubeconfig2 > merged
-        $ kubectl konfig export ctx1 ctx2 -k k8s.yaml,k3s.yaml > extracted
-
-      Documentation:
-        $ kubectl konfig help
-        or https://github.com/corneliusweig/konfig/blob/v0.2.2/doc/USAGE.md#usage
   description: |+2
 
       konfig helps to merge, split or import kubeconfig files
 
       This is a convenience wrapper around the `kubectl config view` command.
+
+      Usage:
+        $ kubectl konfig import --save new-cfg
+        $ kubectl konfig merge kubeconfig1 kubeconfig2 > merged
+        $ kubectl konfig export ctx1 ctx2 -k k8s.yaml,k3s.yaml > extracted
 
       More on https://github.com/corneliusweig/konfig/blob/v0.2.2/doc/USAGE.md#usage

--- a/plugins/krew.yaml
+++ b/plugins/krew.yaml
@@ -18,7 +18,7 @@ metadata:
   name: krew
 spec:
   version: "v0.3.4"
-  homepage: https://sigs.k8s.io/krew
+  homepage: https://krew.sigs.k8s.io/
   shortDescription: Package manager for kubectl plugins.
   caveats: |
     krew is now installed! To start using kubectl plugins, you need to add
@@ -36,7 +36,8 @@ spec:
     For a full list of available plugins, run:
       $ kubectl krew search
 
-    You can find documentation at https://sigs.k8s.io/krew.
+    You can find documentation at
+      https://krew.sigs.k8s.io/docs/user-guide/quickstart/
 
   platforms:
   - uri: https://github.com/kubernetes-sigs/krew/releases/download/v0.3.4/krew.tar.gz

--- a/plugins/kubesec-scan.yaml
+++ b/plugins/kubesec-scan.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   version: v1.0.0
   homepage: https://github.com/stefanprodan/kubectl-kubesec
-  caveats: |
-    Read the documentation at https://github.com/stefanprodan/kubectl-kubesec.
-    You can call this plugin like "kubectl kubesec-scan".
   shortDescription: Scan Kubernetes resources with kubesec.io.
   description: |
     This plugin uploads the specified Kubernetes resource’s API representation

--- a/plugins/kudo.yaml
+++ b/plugins/kudo.yaml
@@ -13,16 +13,16 @@ spec:
     your applications, give your users the tools they need to operate it, and
     understand how it's behaving in their environments — all without a PhD in
     Kubernetes.
-  caveats: |
-    Requires the KUDO controller to be installed:
-      kubectl kudo init
+
     Example usage:
       Install kafka:
         kubectl kudo install kafka
       List installed operator instances:
         kubectl kudo get instances
     See the documentation for more information: https://kudo.dev/docs/
-
+  caveats: |
+    Requires the KUDO controller to be installed:
+      kubectl kudo init
   platforms:
   - selector:
       matchLabels:

--- a/plugins/kuttl.yaml
+++ b/plugins/kuttl.yaml
@@ -10,9 +10,6 @@ spec:
   description: |
     The KUbernetes Test TooL (KUTTL) is a highly productive test
     toolkit for testing operators on Kubernetes.
-  caveats: |
-    See the documentation for more information: https://kuttl.dev/
-
   platforms:
   - selector:
       matchLabels:

--- a/plugins/modify-secret.yaml
+++ b/plugins/modify-secret.yaml
@@ -26,12 +26,6 @@ spec:
       to: "."
     bin: kubectl-modify-secret
   shortDescription: modify secret with implicit base64 translations
-  caveats: |
-    Usage:
-      kubectl modify-secret secret-name -n kube-system
-    
-    Read the documentation at:
-      https://github.com/rajatjindal/kubectl-modify-secret
   description: |
     Usage:
       kubectl modify-secret secret-name -n kube-system

--- a/plugins/node-shell.yaml
+++ b/plugins/node-shell.yaml
@@ -9,15 +9,11 @@ spec:
   description: |
     Start a root shell in the node's host OS running.
     You need to be able to start privileged containers for that.
+
+    Usage:
+      $ kubectl node-shell <node>
   caveats: |
-        Usage:
-
-          $ kubectl node-shell <node>
-
-        Note:
-
-          You need to be allowed to start privileged pods in the cluster
-
+      You need to be allowed to start privileged pods in the cluster
   platforms:
   - selector:
       matchExpressions:

--- a/plugins/ns.yaml
+++ b/plugins/ns.yaml
@@ -13,8 +13,6 @@ spec:
     If fzf is installed on your machine, you can interactively choose
     between the entries using the arrow keys, or by fuzzy searching
     as you type.
-
-    See https://github.com/ahmetb/kubectx for customization and details.
   platforms:
   - selector:
       matchExpressions:

--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -22,8 +22,6 @@ spec:
 
   caveats: |
     You need to setup the OIDC provider, Kubernetes API server, role binding and kubeconfig.
-    See https://github.com/int128/kubelogin for more.
-
   version: v1.19.1
   platforms:
     - uri: https://github.com/int128/kubelogin/releases/download/v1.19.1/kubelogin_linux_amd64.zip

--- a/plugins/outdated.yaml
+++ b/plugins/outdated.yaml
@@ -43,14 +43,6 @@ spec:
     bin: outdated.exe
   shortDescription: Finds outdated container images running in a cluster
   homepage: https://github.com/replicatedhq/outdated
-  caveats: |
-    Usage:
-      $ kubectl outdated
-
-    For additional options:
-      $ kubectl outdated --help
-      or https://github.com/replicatedhq/outdated/blob/master/doc/USAGE.md
-
   description: |
     The plugin will scan for all pods in all namespaces that you have at least
     read access to. It will then connect to the registry that hosts the image,
@@ -59,3 +51,8 @@ spec:
 
     The output is a list of all images, with the most out-of-date images in red,
     slightly outdated in yellow, and up-to-date in green.
+
+    For additional options:
+      $ kubectl outdated --help
+      or https://github.com/replicatedhq/outdated/blob/master/doc/USAGE.md
+

--- a/plugins/passman.yaml
+++ b/plugins/passman.yaml
@@ -100,6 +100,5 @@ spec:
   homepage: https://github.com/chrisns/kubectl-passman
   caveats: |
     This plugin needs a usable keychain or password manager
-    See usage docs https://github.com/chrisns/kubectl-passman
   description: |
     An effective way to keep your credentials somewhere better than in plain text

--- a/plugins/preflight.yaml
+++ b/plugins/preflight.yaml
@@ -43,7 +43,23 @@ spec:
     bin: preflight.exe
   shortDescription: Executes application preflight tests in a cluster
   homepage: https://github.com/replicatedhq/troubleshoot
-  caveats: |
+  description: |
+    This plugin executes application-specific preflight checks and conformance
+    tests against a cluster, prior to installation of an application.
+
+    Application developers can create and host a Preflight manifest that
+    defines the minimum and desired Kubernetes environment for an application.
+    Before installing the application, a cluster admin can use this plugin to
+    execute the application preflight checksto identify any missing
+    components, configuration or incompatibilities between the cluster and the
+    desired environment.
+
+    When executing Preflight tests, the test results will be displayed in a
+    terminal-based UI on the workstation that executed the command.
+
+    For information on creating a Preflight manifest, view the documentation
+    at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/
+
     Usage:
       $ kubectl preflight <uri/path>
 
@@ -63,19 +79,3 @@ spec:
       For application developers writing collectors and analyzers:
       https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
 
-  description: |
-    This plugin executes application-specific preflight checks and conformance
-    tests against a cluster, prior to installation of an application.
-
-    Application developers can create and host a Preflight manifest that
-    defines the minimum and desired Kubernetes environment for an application.
-    Before installing the application, a cluster admin can use this plugin to
-    execute the application preflight checksto identify any missing
-    components, configuration or incompatibilities between the cluster and the
-    desired environment.
-
-    When executing Preflight tests, the test results will be displayed in a
-    terminal-based UI on the workstation that executed the command.
-
-    For information on creating a Preflight manifest, view the documentation
-    at https://help.replicated.com/docs/troubleshoot/kubernetes/analysis/

--- a/plugins/prompt.yaml
+++ b/plugins/prompt.yaml
@@ -20,7 +20,6 @@ spec:
   caveats: |
     This plugin requires bash.
     When removing this plugin, delete the line beginning with `function kubectl()` and `KUBECTL_*_PROMPT` in your ~/.bash_profile.
-    See `https://github.com/jordanwilson230/kubectl-plugins#kubectl-prompt` for documentation.
   shortDescription: Prompts for user confirmation when executing commands in critical namespaces or clusters, i.e., production.
   description: |
     Protect your production environments!

--- a/plugins/prune-unused.yaml
+++ b/plugins/prune-unused.yaml
@@ -21,7 +21,7 @@ spec:
     Prune unused configmaps/secret resources from a given namespace. It
     checks against all resources from mounted volumes, env and envFrom and
     imagePullSecrets.
-  caveats: |
+
     Usage:
         kubectl prune-unused <configmaps|secrets> [options]
 
@@ -29,7 +29,4 @@ spec:
         -n, --namespace='': If present, the namespace scope for this CLI request
         --dry-run: If true, only print the object that would be pruned, without deleting it.
         -h, --help='': Display this help
-
-    Read the documentation at:
-      https://github.com/thecloudnatives/kubectl-plugins
   homepage: https://github.com/thecloudnatives/kubectl-plugins

--- a/plugins/rbac-view.yaml
+++ b/plugins/rbac-view.yaml
@@ -8,7 +8,6 @@ spec:
   shortDescription: A tool to visualize your RBAC permissions.
   caveats: |
     Run "kubectl rbac-view" to open a browser with an html view of your permissions.
-    You can find documentation at https://github.com/jasonrichardsmith/rbac-view.
   platforms:
   - uri: https://github.com/jasonrichardsmith/rbac-view/releases/download/v0.2.1/rbac-view.v0.2.1.darwin.tar.gz
     sha256: 0a042551e9fa8255227292a5ff74073ea67efd98fde9bab4f4c0709e1f3d19c1

--- a/plugins/schemahero.yaml
+++ b/plugins/schemahero.yaml
@@ -47,16 +47,15 @@ spec:
     SchemaHero requires is an in-cluster operator. To install the operator run:
 
       $ kubectl schemahero install
-
-    To learn more, try the tutorial at https://schemahero.io/tutorial/
-    
   description: |
     SchemaHero is a database schema migration tool that converts a schema 
     definition into migration scripts to applied to a database engine 
     (with current support for Postgres, Mysql and CockroachDB). 
-    
+
     SchemaHero allows developers to define a database table schema as a 
     declarative Kubernetes object and then apply the definition to the 
     cluster. The SchemaHero operator will then query the current database 
     schema and generate (and optionally apply) the necessary SQL 
     statements to update the database to the desired schema.
+
+    To learn more, try the tutorial at https://schemahero.io/tutorial/

--- a/plugins/snap.yaml
+++ b/plugins/snap.yaml
@@ -23,13 +23,6 @@ spec:
 
     Currently, if there are pods that have failed or completed, they may get 
     deleted and you may lose debug/log data. 
-
-    Documentation:
-
-      See https://github.com/honk-ci/kubectl-snap or
-
-      $ kubectl snap -h
-
   description: |
     This plugin will delete half of the pods in a namespace or the whole 
     cluster. It is indiscriminate and may delete all pods under a deployment.

--- a/plugins/ssm-secret.yaml
+++ b/plugins/ssm-secret.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   version: v1.2.2
   homepage: https://github.com/pr8kerl/kubectl-ssm-secret
-  caveats: |
-    Read the documentation at https://github.com/pr8kerl/kubectl-ssm-secret.
-    You can call this plugin with "kubectl ssm-secret --help".
   shortDescription: Import/export secrets from/to AWS SSM param store
   description: |
     This plugin can import (create/update) a kubernetes secret with key/values 

--- a/plugins/status.yaml
+++ b/plugins/status.yaml
@@ -43,13 +43,10 @@ spec:
     bin: "status.exe"
   shortDescription: Show status details of a given resource.
   homepage: https://github.com/bergerx/kubectl-status
-  caveats: |
-    Usage:
-      $ kubectl status
+  description: |
+    Show status details of a given resource. Most useful when debugging Pod issues.
 
     For additional options:
       $ kubectl status --help
       or https://github.com/bergerx/kubectl-status/blob/master/doc/USAGE.md
 
-  description: |
-    Show status details of a given resource. Most useful when debugging Pod issues.

--- a/plugins/support-bundle.yaml
+++ b/plugins/support-bundle.yaml
@@ -43,7 +43,20 @@ spec:
     bin: support-bundle.exe
   shortDescription: Creates support bundles for off-cluster analysis
   homepage: https://github.com/replicatedhq/troubleshoot
-  caveats: |
+  description: |
+    This plugin collects information about the cluster, and automatically
+    redacts sensitive data from being collected. This can optionally include
+    application-specific data.  The plugin writes the collected files into a
+    single archive named support-bundle.tar.gz. This archive can be manually
+    inspected or uploaded to https://vendor.replicated.com for automated
+    analysis.
+
+    Application developers can create and host a Collector manifest that
+    defines information to be collected.
+
+    For information on creating a Collector manifest, view the documentation
+    at https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
+
     Usage:
       $ kubectl support-bundle <uri>
 
@@ -63,16 +76,3 @@ spec:
       For application developers writing collectors and analyzers:
       https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/
 
-  description: |
-    This plugin collects information about the cluster, and automatically
-    redacts sensitive data from being collected. This can optionally include
-    application-specific data.  The plugin writes the collected files into a
-    single archive named support-bundle.tar.gz. This archive can be manually
-    inspected or uploaded to https://vendor.replicated.com for automated
-    analysis.
-
-    Application developers can create and host a Collector manifest that
-    defines information to be collected.
-
-    For information on creating a Collector manifest, view the documentation
-    at https://help.replicated.com/docs/troubleshoot/kubernetes/collectors/defining-collectors/

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -37,7 +37,7 @@ spec:
     Stream logs from all matched containers of all matched pods.  Match pods by service,
     replicaset, deployment, and others.  Adjusts to a changing cluster - pods are
     added and removed from logging as they fall in or out of the selection.
-  caveats: |
+
     Documentation:
 
       See https://github.com/boz/kail or

--- a/plugins/tail.yaml
+++ b/plugins/tail.yaml
@@ -31,7 +31,7 @@ spec:
       to: .
   homepage: https://github.com/boz/kail
   shortDescription: Stream logs from multiple pods and containers using simple, dynamic source selection.
-  description: -|
+  description: |-
     Kail https://github.com/boz/kail - "Just show me the logs"
 
     Stream logs from all matched containers of all matched pods.  Match pods by service,

--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -58,22 +58,16 @@ spec:
   caveats: |
     virt plugin is a wrapper for virtctl originating from the KubeVirt project. In order to use virtctl you will
     need to have KubeVirt installed on your Kubernetes cluster to use it. See https://kubevirt.io/ for details
+  description: |
+    virt plugin is a wrapper for virtctl originating from the KubeVirt project. KubeVirt is a virtualization add-on to
+    Kubernetes, i.e. it enables to run existing virtual machines on Kubernetes clusters. virtctl controls virtual
+    machine related operations on your Kubernetes cluster like connecting to the serial and VNC consoles.
 
     Run
 
       kubectl virt help
 
     to get an overview of the available commands
-
-    See
-
-      https://kubevirt.io/user-guide/docs/latest/using-virtual-machines/graphical-and-console-access.html
-
-    for a usage example
-  description: |
-    virt plugin is a wrapper for virtctl originating from the KubeVirt project. KubeVirt is a virtualization add-on to
-    Kubernetes, i.e. it enables to run existing virtual machines on Kubernetes clusters. virtctl controls virtual
-    machine related operations on your Kubernetes cluster like connecting to the serial and VNC consoles.
 
     Kubevirt documentation:
       Overview:

--- a/plugins/warp.yaml
+++ b/plugins/warp.yaml
@@ -36,7 +36,5 @@ spec:
       to: .
     bin: ./kubectl-warp
   caveats: |
-    Read the documentation: https://github.com/ernoaapa/kubectl-warp
-
     This plugin needs the following programs:
     * rsync

--- a/plugins/who-can.yaml
+++ b/plugins/who-can.yaml
@@ -21,12 +21,12 @@ spec:
 
     $ kubectl who-can delete pods --namespace foo
     $ kubectl who-can delete nodes
-  caveats: |
-    The plugin requires the rights to list (Cluster)Role and (Cluster)RoleBindings.
 
     For usage or examples, run:
 
     $ kubectl who-can -h
+  caveats: |
+    The plugin requires the rights to list (Cluster)Role and (Cluster)RoleBindings.
   platforms:
     - selector:
         matchLabels:

--- a/plugins/whoami.yaml
+++ b/plugins/whoami.yaml
@@ -29,11 +29,8 @@ spec:
   shortDescription: Show the subject that's currently authenticated as.
   caveats: |
     This plugin has only been tested with RBAC token, ServiceAccount token, and BasicAuth. 
-    
+
     It will be great if we can get volunteers to test it with other Auth providers.
-    
-    Read the documentation at:
-      https://github.com/rajatjindal/kubectl-whoami
   description: |
     This plugin show the subject that's currently authenticated as.
 


### PR DESCRIPTION
Krew shows homepage and how to call the plugin by default after install.
Many plugins used to put these instructions into their caveats section,
but this is redundant now. This PR cleans up the manifests. The
`caveats` section is now really reserved for dependency information or
warnings.

Close #367
