### PR TITLE
Add node-rolling plugin

### DIFF
--- a/plugins/node-rolling.yaml
+++ b/plugins/node-rolling.yaml
@@ -1,0 +1,29 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: node-rolling
+spec:
+  version: "v1.0.0"
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/yogeek/kubectl-node-rolling/releases/download/v1.0.0/v1.0.0.zip
+    sha256: "9e9e22724016724765419354509f9238f34ec1f7bb6dc9eeb55af248a559bf93"
+    files:
+    - from: "*.sh"
+      to:  "."
+    - from: "LICENSE"
+      to: "."
+    bin: "node-rolling.sh"
+  shortDescription: >-
+    Shutdown cluster nodes sequentially & gracefully
+  homepage: https://github.com/yogeek/kubectl-node-rolling
+  caveats: |
+    Execution of this plugin requires Kubernetes cluster-admin Rolebindings
+    and the ability to schedule Privileged Pods.
+  description: |
+    This plugin performs a sequential, rolling shutdown of selected nodes by first
+    draining each node, then running a Kubernetes Job to shutdown each node, and
+    finally waiting for the node to be replaced by a new one 
+    by an external component (like an AutoScaling Group). 


### PR DESCRIPTION
This PR aims to add [node-rolling](https://github.com/yogeek/kubectl-node-rolling) plugin to krew index.

As explained in the README of the plugin directory, I had a need similar to the [node-restart](https://github.com/MnrGreg/kubectl-node-restart) plugin but in a context where a restart was not enough to update the node : as they were managed by an AWS ASG, I needed to shutdown the nodes to allow the ASG to replace them by a new version (new AMI in Launch Template).

I originally thought of a more generic version where the command to execute (restart, shutdown, etc.) would be a parameter of the plugin but I did not see use cases for other command and this would imply the deprecation of the original plugin... but I am open to suggestions to ease the user experience !