### PR TITLE
Add kubectl trace v0.1.0-rc.1

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -101,6 +101,7 @@ Name | Description | Stars
 [tap](https://soluble-ai.github.io/kubetap/) | Interactively proxy Kubernetes Services with ease | ![GitHub stars](https://img.shields.io/github/stars/soluble-ai/kubetap.svg?label=stars&logo=github)
 [tmux-exec](https://github.com/predatorray/kubectl-tmux-exec) | An exec multiplexer using Tmux | ![GitHub stars](https://img.shields.io/github/stars/predatorray/kubectl-tmux-exec.svg?label=stars&logo=github)
 [topology](https://github.com/bmcustodio/kubectl-topology) | Explore region topology for nodes or pods | ![GitHub stars](https://img.shields.io/github/stars/bmcustodio/kubectl-topology.svg?label=stars&logo=github)
+[trace](https://github.com/iovisor/kubectl-trace) | Schedule bpftrace programs on your kubernetes cluster using the kubectl | ![GitHub stars](https://img.shields.io/github/stars/iovisor/kubectl-trace.svg?label=stars&logo=github)
 [tree](https://github.com/ahmetb/kubectl-tree) | Show a tree of object hierarchies through ownerReferences | ![GitHub stars](https://img.shields.io/github/stars/ahmetb/kubectl-tree.svg?label=stars&logo=github)
 [unused-volumes](https://github.com/dirathea/kubectl-unused-volumes) | List unused PVCs | ![GitHub stars](https://img.shields.io/github/stars/dirathea/kubectl-unused-volumes.svg?label=stars&logo=github)
 [view-allocations](https://github.com/davidB/kubectl-view-allocations) | List allocations per resources, nodes, pods. | ![GitHub stars](https://img.shields.io/github/stars/davidB/kubectl-view-allocations.svg?label=stars&logo=github)

--- a/plugins/trace.yaml
+++ b/plugins/trace.yaml
@@ -19,7 +19,7 @@ metadata:
 spec:
   version: "v0.3.4"
   homepage: https://github.com/iovisor/kubectl-trace
-  shortDescription: bpftrace programs on the kubectl
+  shortDescription: bpftrace programs in a cluster
   description: |
     kubectl trace is now installed! 
 

--- a/plugins/trace.yaml
+++ b/plugins/trace.yaml
@@ -1,0 +1,80 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: trace
+spec:
+  version: "v0.3.4"
+  homepage: https://github.com/iovisor/kubectl-trace
+  shortDescription: bpftrace programs on the kubectl
+  description: |
+    kubectl trace is now installed! 
+
+    Examples:
+
+      # Count system calls using tracepoints on a specific node
+      kubectl trace run node/kubernetes-node-emt8.c.myproject.internal -e 'kprobe:do_sys_open { printf("%s: %s\n", comm, str(arg1)) }'
+
+      # Execute a bpftrace program from file on a specific node
+      kubectl trace run node/kubernetes-node-emt8.c.myproject.internal -f read.bt
+
+      # Run an bpftrace inline program on a pod container
+      kubectl trace run pod/nginx -c nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
+      kubectl trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
+
+      # Run a bpftrace inline program on a pod container with a custom image for the init container responsible to fetch linux headers 
+      kubectl trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --init-imagename=quay.io/custom-init-image-name --fetch-headers"
+
+      # Run a bpftrace inline program on a pod container with a custom image for the bpftrace container that will run your program in the cluster
+      kubectl trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --imagename=quay.io/custom-bpftrace-image-name"
+
+  platforms:
+    - uri: https://github.com/iovisor/kubectl-trace/releases/download/v0.1.0-rc.1/kubectl-trace_0.1.0-rc.1_darwin_amd64.tar.gz
+      sha256: 52344e307daccb7aee559268c972bfd5b06de514066647ed6d4205aa0239df40
+      bin: kubectl-trace
+      files:
+        - from: ./kubectl-trace
+          to: kubectl-trace
+        - from: ./LICENSE
+          to: .
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - uri: https://github.com/iovisor/kubectl-trace/releases/download/v0.1.0-rc.1/kubectl-trace_0.1.0-rc.1_linux_amd64.tar.gz
+      sha256: cd151705bb5e8964aef5f4f8a6443dcdaef5ea66f5960371404e18b47edd485f
+      bin: kubectl-trace
+      files:
+        - from: ./kubectl-trace
+          to: kubectl-trace
+        - from: ./LICENSE
+          to: .
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - uri: https://github.com/iovisor/kubectl-trace/releases/download/v0.1.0-rc.1/kubectl-trace_0.1.0-rc.1_windows_amd64.zip
+      sha256: 0d16f1e00ec990833986d3be4b2997ac48fd036fc3b30834b23eca30ee327853
+      bin: kubectl-trace.exe
+      files:
+        - from: ./kubectl-trace.exe
+          to: kubectl-trace.exe
+        - from: ./LICENSE
+          to: .
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64

--- a/plugins/trace.yaml
+++ b/plugins/trace.yaml
@@ -21,25 +21,23 @@ spec:
   homepage: https://github.com/iovisor/kubectl-trace
   shortDescription: bpftrace programs in a cluster
   description: |
-    kubectl trace is now installed! 
+    kubectl trace is a kubectl plugin that allows you to schedule the
+    execution of bpftrace programs in your Kubernetes cluster.
 
     Examples:
 
       # Count system calls using tracepoints on a specific node
-      kubectl trace run node/kubernetes-node-emt8.c.myproject.internal -e 'kprobe:do_sys_open { printf("%s: %s\n", comm, str(arg1)) }'
+      kubectl trace run node/kubernetes-8.myproject.internal \
+        -e 'kprobe:do_sys_open { printf("%s: %s\n", comm, str(arg1)) }'
 
       # Execute a bpftrace program from file on a specific node
-      kubectl trace run node/kubernetes-node-emt8.c.myproject.internal -f read.bt
+      kubectl trace run node/kubernetes-8.myproject.internal -f read.bt
 
       # Run an bpftrace inline program on a pod container
-      kubectl trace run pod/nginx -c nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
-      kubectl trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
-
-      # Run a bpftrace inline program on a pod container with a custom image for the init container responsible to fetch linux headers 
-      kubectl trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --init-imagename=quay.io/custom-init-image-name --fetch-headers"
-
-      # Run a bpftrace inline program on a pod container with a custom image for the bpftrace container that will run your program in the cluster
-      kubectl trace run pod/nginx nginx -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); } --imagename=quay.io/custom-bpftrace-image-name"
+      kubectl trace run pod/nginx -c nginx \
+        -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
+      kubectl trace run pod/nginx nginx \
+        -e "tracepoint:syscalls:sys_enter_* { @[probe] = count(); }"
 
   platforms:
     - uri: https://github.com/iovisor/kubectl-trace/releases/download/v0.1.0-rc.1/kubectl-trace_0.1.0-rc.1_darwin_amd64.tar.gz


### PR DESCRIPTION
Happy to submit kubectl trace to the krew index as per the discussions happening one year ago  in https://github.com/iovisor/kubectl-trace/issues/17

Sorry if it took a long time!

Adding a wip since I didn't test the manifest on all platforms yet.

If anyone can test it on windows before I do and report here I'll be grateful.


Signed-off-by: Lorenzo Fontana <lo@linux.com>
