### PR TITLE
chore: updating starboard to v0.2.2

### DIFF
--- a/plugins/starboard.yaml
+++ b/plugins/starboard.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: starboard
 spec:
-  version: "v0.2.1"
+  version: "v0.2.2"
   homepage: https://github.com/aquasecurity/starboard
   shortDescription: >-
     Toolkit for finding risks in kubernetes resources
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/aquasecurity/starboard/releases/download/v0.2.1/starboard_darwin_x86_64.tar.gz
-      sha256: "4852ba4635f1255f1bba441f6cfc01620aa8d1d4b6b0d21ae604a5fcebb4db8a"
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.2.2/starboard_darwin_x86_64.tar.gz
+      sha256: "ccbf5fa00685142cdf7fcbfedd56f3d798b8c868fc4bf488d33a49086b3b04e0"
       files:
         - from: starboard
           to: .
@@ -35,8 +35,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/aquasecurity/starboard/releases/download/v0.2.1/starboard_linux_x86_64.tar.gz
-      sha256: "1ae60786950910622cbfd34957a8a3a1a9b0746364a6c7cc59591b140a4ec25b"
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.2.2/starboard_linux_x86_64.tar.gz
+      sha256: "db900e0e1711c0e17ef84cc73bd4892ec4da4f9c12a474f473dc6d9e38f4f388"
       files:
         - from: starboard
           to: .
@@ -47,8 +47,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/aquasecurity/starboard/releases/download/v0.2.1/starboard_windows_x86_64.zip
-      sha256: "6a60319f427ac082d939db91620672ef490ef726e57398d702fd7081a12c91b3"
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.2.2/starboard_windows_x86_64.zip
+      sha256: "722c9f44f17749d65da936174e41cff8fa076bf457e83a86b757bf6a3cf77fe3"
       files:
         - from: starboard.exe
           to: .


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://sigs.k8s.io/krew/docs/NAMING_GUIDE.md
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Updating [Starboard](https://github.com/aquasecurity/starboard) to new release [v0.2.2](https://github.com/aquasecurity/starboard/releases/tag/v0.2.2)