### PR TITLE
Add gs plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -44,6 +44,7 @@ Name | Description | Stars
 [gke-credentials](https://github.com/danisla/kubefunc) | Fetch credentials for GKE clusters | ![GitHub stars](https://img.shields.io/github/stars/danisla/kubefunc.svg?label=stars&logo=github)
 [gopass](https://github.com/gopasspw/kubectl-gopass) | Imports secrets from gopass | ![GitHub stars](https://img.shields.io/github/stars/gopasspw/kubectl-gopass.svg?label=stars&logo=github)
 [grep](https://github.com/guessi/kubectl-grep) | Filter Kubernetes resources by matching their names | ![GitHub stars](https://img.shields.io/github/stars/guessi/kubectl-grep.svg?label=stars&logo=github)
+[gs](https://github.com/giantswarm/kubectl-gs) | Handle custom resources with Giant Swarm | ![GitHub stars](https://img.shields.io/github/stars/giantswarm/kubectl-gs.svg?label=stars&logo=github)
 [iexec](https://github.com/gabeduke/kubectl-iexec) | Interactive selection tool for `kubectl exec` | ![GitHub stars](https://img.shields.io/github/stars/gabeduke/kubectl-iexec.svg?label=stars&logo=github)
 [images](https://github.com/chenjiandongx/kubectl-images) | Show container images used in the cluster. | ![GitHub stars](https://img.shields.io/github/stars/chenjiandongx/kubectl-images.svg?label=stars&logo=github)
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/kubectl-plugin/) | Interact with ingress-nginx | ![GitHub stars](https://img.shields.io/github/stars/kubernetes/ingress-nginx.svg?label=stars&logo=github)

--- a/plugins/gs.yaml
+++ b/plugins/gs.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.5.0
   homepage: https://github.com/giantswarm/kubectl-gs
-  shortDescription: Giant Swarm plug-in for kubectl
+  shortDescription: Handle custom resources with Giant Swarm
   description: |
     Simplifies creating clusters and node pools via Giant Swarm Kubernetes
     control planes, as well as installing app catalogs and apps.

--- a/plugins/gs.yaml
+++ b/plugins/gs.yaml
@@ -16,9 +16,6 @@ spec:
         arch: amd64
     uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_darwin_amd64.tar.gz
     sha256: "40ea6f92f70482e74688798d89af472d2c4c5b11a444c271aa5bf4d1cd322f33"
-    files:
-    - from: kubectl-gs
-      to: .
     bin: ./kubectl-gs
   - selector:
       matchLabels:
@@ -26,9 +23,6 @@ spec:
         arch: "386"
     uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_darwin_386.tar.gz
     sha256: "5dcb8ff00a317c6dbc11464fc66a273e1edb7f94d7edc5290f7e9e157023e071"
-    files:
-    - from: kubectl-gs
-      to: .
     bin: ./kubectl-gs
   - selector:
       matchLabels:
@@ -36,9 +30,6 @@ spec:
         arch: amd64
     uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_linux_amd64.tar.gz
     sha256: "eb0d28e84782fe12128a599c4dd86c1cd3c5d83254d928085cff5510b6bf5dde"
-    files:
-    - from: kubectl-gs
-      to: .
     bin: ./kubectl-gs
   - selector:
       matchLabels:
@@ -46,7 +37,4 @@ spec:
         arch: "386"
     uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_linux_386.tar.gz
     sha256: "a26b77677be18e5fcfbf373288e1a793faf375c34cee7287763ce29a0ed7b186"
-    files:
-    - from: kubectl-gs
-      to: .
     bin: ./kubectl-gs

--- a/plugins/gs.yaml
+++ b/plugins/gs.yaml
@@ -1,0 +1,52 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gs
+spec:
+  version: v0.5.0
+  homepage: https://github.com/giantswarm/kubectl-gs
+  shortDescription: Giant Swarm plug-in for kubectl
+  description: |
+    Simplifies creating clusters and node pools via Giant Swarm Kubernetes
+    control planes, as well as installing app catalogs and apps.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_darwin_amd64.tar.gz
+    sha256: "40ea6f92f70482e74688798d89af472d2c4c5b11a444c271aa5bf4d1cd322f33"
+    files:
+    - from: kubectl-gs
+      to: .
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: "386"
+    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_darwin_386.tar.gz
+    sha256: "5dcb8ff00a317c6dbc11464fc66a273e1edb7f94d7edc5290f7e9e157023e071"
+    files:
+    - from: kubectl-gs
+      to: .
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_linux_amd64.tar.gz
+    sha256: "eb0d28e84782fe12128a599c4dd86c1cd3c5d83254d928085cff5510b6bf5dde"
+    files:
+    - from: kubectl-gs
+      to: .
+    bin: ./kubectl-gs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: "386"
+    uri: https://github.com/giantswarm/kubectl-gs/releases/download/v0.5.0/kubectl-gs_0.5.0_linux_386.tar.gz
+    sha256: "a26b77677be18e5fcfbf373288e1a793faf375c34cee7287763ce29a0ed7b186"
+    files:
+    - from: kubectl-gs
+      to: .
+    bin: ./kubectl-gs


### PR DESCRIPTION
`kubectl-gs` (or, in krew naming: `gs`) is on the way to become a multi-purpose helper for users of the [Giant Swarm](https://www.giantswarm.io/) Kubernetes platform. On the platform, users use the Kubernetes API in a Cluster-API-like style to create and manage clusters.

## Purpose

The major challenge for our users is that one cluster can comprise a number of custom resources. To create one fully functional cluster with worker nodes, six custom resources must be created, were identifiers are used to interlink them. When listing clusters and inspecting a cluster's details, again the interlinked resources are to be displayed together to give users full information and save them from having to navigate from resource to resource.

## Usage example

```nohighlight
kubectl gs template cluster \
  --master-az="eu-central-1a" \
  --domain="gauss.eu-central-1.aws.gigantic.io" \
  --external-snat=true \
  --name="Cluster #2" \
  --pods-cidr="10.2.0.0/16" \
  --owner="giantswarm" \
  --credential="credential-34hg5" \
  --release="11.2.1" \
  --region="eu-central-1"
```

## Tested locally

On darwin:

```nohighlight
kubectl krew install --manifest=plugins/gs.yaml
Installing plugin: gs
Installed plugin: gs
```