### PR TITLE
Add cert-manager kubectl plugin to index

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -7,9 +7,10 @@ spec:
   homepage: https://github.com/jetstack/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
-    A plugin accompanying cert-manger, a Kubernetes add-on to automate the management
-    and issuance of TLS certificates. Allows for direct interaction with cert-manager resources
-    e.g. manual renewal of Certificate resources.
+    The official plugin accompanying cert-manger, a Kubernetes add-on to
+    automate the management and issuance of TLS certificates. Allows for
+    direct interaction with cert-manager resources e.g. manual renewal of
+    Certificate resources.
   platforms:
   - selector:
       matchLabels:
@@ -17,9 +18,6 @@ spec:
         arch: amd64
     uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-darwin-amd64.tar.gz
     sha256: 8cf4386e60c3cd866a53c782cccb36227e7f94a62472c1137a8a6d90c8945e21
-    files:
-      - from: "*"
-        to: "."
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
@@ -27,9 +25,6 @@ spec:
         arch: amd64
     uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-amd64.tar.gz
     sha256: 25bd96a6c88bee8dd1b549cb851c1df280c27d5039e1a6ffbc9c5755805eb402
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
@@ -37,9 +32,6 @@ spec:
         arch: arm
     uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-arm.tar.gz
     sha256: 79bc8e20d53df855e5a0d225f2350b8d465074aae8580ac309cc3ac72b7e6998
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
@@ -47,9 +39,6 @@ spec:
         arch: arm64
     uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-arm64.tar.gz
     sha256: 65237e3c4b154f469cce1d01db89ca489ff67914783f27412c704d954feda3be
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
@@ -57,7 +46,4 @@ spec:
         arch: amd64
     uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-windows-amd64.tar.gz
     sha256: dee38af3381057d0f870d385ed6658a350b8c67d66e76bb9228cfbeb83ff439e
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-cert_manager

--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v0.16.0-alpha.0
+  version: v0.16.0-alpha.1
   homepage: https://github.com/jetstack/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -16,34 +16,34 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 8cf4386e60c3cd866a53c782cccb36227e7f94a62472c1137a8a6d90c8945e21
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: 2fd3917fd3d32130f5e0be551bd81c993b1907020f8e282bc5aba84d8210acd1
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: 25bd96a6c88bee8dd1b549cb851c1df280c27d5039e1a6ffbc9c5755805eb402
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 70c2e64c643e9cd944d9b0e2f3c4ea7f26d62664ce73c691b8298b8661dfa688
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 79bc8e20d53df855e5a0d225f2350b8d465074aae8580ac309cc3ac72b7e6998
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 4fea727dca9197d9fee37b1d0b98714d1fae970419f838f0822c9156ac68ce63
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 65237e3c4b154f469cce1d01db89ca489ff67914783f27412c704d954feda3be
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 867cb7ca6f38e55cf286a0c90ce84d0bec1056a72cddbafa9ad3b7bd788b2999
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-windows-amd64.tar.gz
-    sha256: dee38af3381057d0f870d385ed6658a350b8c67d66e76bb9228cfbeb83ff439e
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-windows-amd64.tar.gz
+    sha256: 81b032ee1aae5815c446cfa26c7ae40b32caf389de2aa9b138777324ed96d42b
     bin: kubectl-cert_manager

--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -53,26 +53,6 @@ spec:
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
-        os: linux
-        arch: ppc64le
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-ppc64le.tar.gz
-    sha256: 26c4b892b21fd72eac40795710f6e4a98b64e55b214e2eaf0cfcf4c94bbc43bc
-    files:
-    - from: "*"
-      to: "."
-    bin: kubectl-cert_manager
-  - selector:
-      matchLabels:
-        os: linux
-        arch: s390x
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-s390x.tar.gz
-    sha256: 6078c5c2241e8f5e3d5891b39981b0df53a2ff7e9faf7d894d3acc6624268983
-    files:
-    - from: "*"
-      to: "."
-    bin: kubectl-cert_manager
-  - selector:
-      matchLabels:
         os: windows
         arch: amd64
     uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-windows-amd64.tar.gz

--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -1,0 +1,83 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cert-manager
+spec:
+  version: v0.16.0-alpha.0
+  homepage: https://github.com/jetstack/cert-manager
+  shortDescription: Manage cert-manager resources inside your cluster
+  description: |
+    A plugin accompanying cert-manger, a Kubernetes add-on to automate the management
+    and issuance of TLS certificates. Allows for direct interaction with cert-manager resources
+    e.g. manual renewal of Certificate resources.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: 8cf4386e60c3cd866a53c782cccb36227e7f94a62472c1137a8a6d90c8945e21
+    files:
+      - from: "*"
+        to: "."
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 25bd96a6c88bee8dd1b549cb851c1df280c27d5039e1a6ffbc9c5755805eb402
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 79bc8e20d53df855e5a0d225f2350b8d465074aae8580ac309cc3ac72b7e6998
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 65237e3c4b154f469cce1d01db89ca489ff67914783f27412c704d954feda3be
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: ppc64le
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-ppc64le.tar.gz
+    sha256: 26c4b892b21fd72eac40795710f6e4a98b64e55b214e2eaf0cfcf4c94bbc43bc
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: s390x
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-linux-s390x.tar.gz
+    sha256: 6078c5c2241e8f5e3d5891b39981b0df53a2ff7e9faf7d894d3acc6624268983
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.0/kubectl-cert_manager-windows-amd64.tar.gz
+    sha256: dee38af3381057d0f870d385ed6658a350b8c67d66e76bb9228cfbeb83ff439e
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-cert_manager


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

A kubectl plugin for cert-manager, a Kubernetes add-on to automate the management and issuance of TLS certificates.