### PR TITLE
Bump view_serviceaccount_kubeconfig to v2.2.1

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,8 +4,8 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.0/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
-    sha256: "8f5fe855865e377eaa65313f23ccdcbdb8c60bf3e2dec755b1abc102f0a1aaa4"
+  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.1/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
+    sha256: "92900758b87b1c35591a326bfd5bf9cd83992e7bb2a4f649d728fdf0162120ec"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: kubectl-view_serviceaccount_kubeconfig
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.0/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
-    sha256: "3569fb1dba38377b70bb0d57c74f1e49831f2bd2bddbc7daba3d0b9368626052"
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.1/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: "f15ba94d5892aa0467847e8de4bbbe382f5a4daf3192399ffda46aa5900ee3aa"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: kubectl-view_serviceaccount_kubeconfig
@@ -28,7 +28,19 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  version: "v2.2.0"
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.1/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
+    sha256: "98d1af57a033aab61891594357d4db671b30e4d982263a4f4a56a387c74184e9"
+    bin: kubectl-view_serviceaccount_kubeconfig.exe
+    files:
+    - from: kubectl-view_serviceaccount_kubeconfig.exe
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+  version: "v2.2.1"
   homepage: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR bumps view_serviceaccount_kubeconfig to v2.2.1.
