### PR TITLE
Bump open-svc to v2.4.1

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: open-svc
 spec:
   platforms:
-  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.0/kubectl-open_svc-darwin-amd64.zip"
-    sha256: "eb340925fa2b2b97f9920386894668d184adf87b15dd3fec395078e880dc73f5"
+  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.1/kubectl-open_svc-darwin-amd64.zip"
+    sha256: "61c1a01630a601c003fd8fb3c57bb1bb9d148814488c4e4bb91461d1468bf31b"
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.0/kubectl-open_svc-linux-amd64.zip"
-    sha256: "1c9e939dd4f00b41b989fdac2cac3df4495e49dc33b7db36cf7f0402d64be038"
+  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.1/kubectl-open_svc-linux-amd64.zip"
+    sha256: "0b91cbdb3a5860b510c1cc2838eaea19a83c327be1a182d68541084fb86793ac"
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -28,7 +28,19 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  version: "v2.4.0"
+  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.1/kubectl-open_svc-windows-amd64.zip"
+    sha256: "a4991b89971570f44e863eb1aecd1556ed6c8eb77ec79812318187b788422028"
+    bin: kubectl-open_svc.exe
+    files:
+    - from: kubectl-open_svc.exe
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+  version: "v2.4.1"
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser.


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR bumps open-svc to v2.4.1.