### PR TITLE
Update cert-manager plugin to v0.16.0

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v0.16.0-alpha.1
+  version: v0.16.0
   homepage: https://github.com/jetstack/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -16,34 +16,34 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 2fd3917fd3d32130f5e0be551bd81c993b1907020f8e282bc5aba84d8210acd1
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: 4dca521fb94322d95fed03b6aec8d5e03d5c333f63bcc4645bc6964b3238c95c
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: 70c2e64c643e9cd944d9b0e2f3c4ea7f26d62664ce73c691b8298b8661dfa688
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: c7e0a35e5362c06c978a0ae4ce0fb1b339e734d906fa2e2c3799acbff58aba74
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 4fea727dca9197d9fee37b1d0b98714d1fae970419f838f0822c9156ac68ce63
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 1b379631bf1243e64ef9b9648ef709d4d8794864e6400aea4168eec67c44a525
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 867cb7ca6f38e55cf286a0c90ce84d0bec1056a72cddbafa9ad3b7bd788b2999
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 8764fed951af6255e75d92460bd26c5ff661e5e6f69e2642a9c861d310ab22a7
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0-alpha.1/kubectl-cert_manager-windows-amd64.tar.gz
-    sha256: 81b032ee1aae5815c446cfa26c7ae40b32caf389de2aa9b138777324ed96d42b
+    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-windows-amd64.tar.gz
+    sha256: fb6b390e267e969b75bff754ea2e021ff3a5ae7371dad9fa04e001429fabd22f
     bin: kubectl-cert_manager


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
