### PR TITLE
Update view-secrets to v0.6.0

### DIFF
--- a/plugins/view-secret.yaml
+++ b/plugins/view-secret.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: view-secret
 spec:
-  version: "v0.5.0"
+  version: "v0.6.0"
   homepage: https://github.com/elsesiy/kubectl-view-secret
   shortDescription: Decode Kubernetes secrets
   description: |+2
@@ -24,6 +24,9 @@ spec:
     # print keys for secret in different context
     $ kubectl view-secret <secret> -c/--context ctx
 
+    # print keys for secret by providing kubeconfig
+    $ kubectl view-secret <secret> -k/--kubeconfig <cfg>
+
     # suppress info output
     $ kubectl view-secret <secret> -q/--quiet
   platforms:
@@ -31,8 +34,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.5.0/kubectl-view-secret_0.5.0_Darwin_x86_64.tar.gz
-      sha256: "de6d819f28bce729070f1698973aa0a007a270d944f3486d8454833bf60e4e63"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.6.0/kubectl-view-secret_0.6.0_Darwin_x86_64.tar.gz
+      sha256: "5c0190d56df68c19fc6af7d9a9e0593b594aa83a0f2d5567e4385058a09cba9a"
       files:
         - from: kubectl-view-secret
           to: .
@@ -43,8 +46,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.5.0/kubectl-view-secret_0.5.0_Linux_x86_64.tar.gz
-      sha256: "f691c690efa04427ab128849283dc7f0a170cd2fb0a9bcf7341ea6849ba32ce1"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.6.0/kubectl-view-secret_0.6.0_Linux_x86_64.tar.gz
+      sha256: "d49b796a212a3eab8de75291c7321de738140b6f24be5f350706bbd563ef414d"
       files:
         - from: kubectl-view-secret
           to: .
@@ -55,8 +58,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.5.0/kubectl-view-secret_0.5.0_Windows_x86_64.tar.gz
-      sha256: "e3f6f7e6c201480263030838f17a68f9253f8e7872dad0cb44e514feff2bd9f4"
+      uri: https://github.com/elsesiy/kubectl-view-secret/releases/download/v0.6.0/kubectl-view-secret_0.6.0_Windows_x86_64.tar.gz
+      sha256: "330cfaddc44fdf110860866da07f45ceb4e3c59a11b9c11483fd24968d32bfb1"
       files:
         - from: kubectl-view-secret.exe
           to: .


### PR DESCRIPTION
This PR updates the `view-secret` plugin to a new version `v0.6.0`.