### PR TITLE
add kubectl node-pod plugin

### DIFF
--- a/plugins/node-pod.yaml
+++ b/plugins/node-pod.yaml
@@ -1,0 +1,55 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: node-pod
+spec:
+  version: "v0.1.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/mattfenwick/krew-node-pod/releases/download/v0.1.0/kubectl-node_pod_linux_amd64.tar.gz
+    sha256: "c21488a37c7a29b43c22cf078c772858f1380d7836eaddeaf34a171fa405a821"
+    files:
+    - from: "./kubectl-node_pod"
+      to: "node-pod"
+    - from: LICENSE
+      to: "."
+    bin: "node-pod"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/mattfenwick/krew-node-pod/releases/download/v0.1.0/kubectl-node_pod_darwin_amd64.tar.gz
+    sha256: "1a7357f9532dd0cae163a938f0bde483567093f489b508547fac4bccdc725306"
+    files:
+    - from: "./kubectl-node_pod"
+      to: "node-pod"
+    - from: LICENSE
+      to: "."
+    bin: "node-pod"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/mattfenwick/krew-node-pod/releases/download/v0.1.0/kubectl-node_pod_windows_amd64.zip
+    sha256: "fde3fc66ffb7f0128748a4156ce26bbaf02d63fa9cc9d7d5f6bccc33bda7b8f3"
+    files:
+    - from: "/kubectl-node_pod.exe"
+      to: "node-pod.exe"
+    - from: LICENSE
+      to: "."
+    bin: "node-pod.exe"
+  shortDescription: Shows assignment of pods to nodes.
+  homepage: https://github.com/mattfenwick/krew-node-pod
+  caveats: |
+    Usage:
+      $ kubectl node-pod
+
+    For additional options:
+      $ kubectl node-pod --help
+      or https://github.com/mattfenwick/krew-node-pod/blob/v0.1.0/doc/USAGE.md
+
+  description: |
+    This plugin shows the assignment of pods to nodes.


### PR DESCRIPTION
This plugin shows the assignment of pods, containers, and jobs to nodes.  

I haven't found something else to do this, and it's been a handy tool for having a node-centric view of what's going on in my k8s clusters.

If this isn't a good fit for a krew plugin, I'm open to suggestions for how to address that, as well as suggestions on how to make this more useful!

#### PLUGIN DEVELOPERS: If you are submitting a new plugin

- [x] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/

- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
  - I tested the install by running `kubectl krew install --manifest=./deploy/krew/node-pod.yaml` from a checkout of https://github.com/mattfenwick/krew-node-pod
