### PR TITLE
bump kubectl-neat to v2.0.1

### DIFF
--- a/plugins/neat.yaml
+++ b/plugins/neat.yaml
@@ -9,7 +9,7 @@ spec:
     removing default values, runtime information, and other internal fields.
     Examples:
     `$ kubectl get pod mypod -o yaml | kubectl neat`
-    `$ kubectl neat get pod mypod -o yaml`
+    `$ kubectl neat get -- pod mypod -o yaml`
   homepage: https://github.com/itaysk/kubectl-neat
   platforms:
   - bin: ./kubectl-neat
@@ -20,8 +20,8 @@ spec:
       matchLabels:
         arch: amd64
         os: darwin
-    sha256: f774231d5e41dd398e48a79920325cbb56d0697969b11be1ceae9f4778509215
-    uri: https://github.com/itaysk/kubectl-neat/releases/download/v2.0.0/kubectl-neat_darwin.tar.gz
+    sha256: c1e8ac967232173f9a2cadfb40af342363f9d2cf9e8bad02e025da6300468f84
+    uri: https://github.com/itaysk/kubectl-neat/releases/download/v2.0.1/kubectl-neat_darwin.tar.gz
   - bin: ./kubectl-neat
     files:
     - from: /*
@@ -30,7 +30,7 @@ spec:
       matchLabels:
         arch: amd64
         os: linux
-    sha256: 3d0328b29bdf8d333e6280ba5707be63287e63614c097a0be02aa37a0264c879
-    uri: https://github.com/itaysk/kubectl-neat/releases/download/v2.0.0/kubectl-neat_linux.tar.gz
+    sha256: ef3d52f35eb2dbd7ee99a4503eafdc080e61c5d722458a9c46941dac73bc3da0
+    uri: https://github.com/itaysk/kubectl-neat/releases/download/v2.0.1/kubectl-neat_linux.tar.gz
   shortDescription: Remove clutter from Kubernetes manifests to make them more readable.
-  version: v2.0.0
+  version: v2.0.1


### PR DESCRIPTION
as a quick workaround to an issue introduced by the recently released v2.0.0, I've also updated the usage example