### PR TITLE
wd v0.0.1

### DIFF
--- a/plugins/wd.yaml
+++ b/plugins/wd.yaml
@@ -1,0 +1,25 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: wd
+spec:
+  version: "v0.0.1"
+  homepage: https://github.com/smsilva/kubernetes/tree/master/krew/plugins/wd
+  shortDescription: "Waits for all Deployment Replicas become Ready"
+  description: |
+    Waits for all Deployment Replicas become Ready.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - linux
+    uri: https://github.com/smsilva/kubernetes/releases/download/v0.0.1/kubectl-wd-0.0.1.tar.gz
+    sha256: a309f654cf7f568cf99c981ece2143cadda9e9f72d6cbf78aa4fd23303aacd7c
+    files:
+    - from: "wd.sh"
+      to: "kubectl-wd.sh"
+    - from: "LICENSE"
+      to: "."
+    bin: kubectl-wd.sh


### PR DESCRIPTION
Hi,

This is my first attempt to contribute and this plugin waits for a Deployment becomes with All Replicas Ready.

So, for example, let's say you are installing **Minikube** and wants to wait until all the Deployments on **kube-system** namespace becomes ready to proceed with script like that:

```
export MINIKUBE_IN_STYLE=false

minikube start \
  --kubernetes-version v1.18.6 \
  --driver=docker \
  --network-plugin=cni

kubectl config use-context minikube

kubectl apply -f https://docs.projectcalico.org/manifests/calico.yaml

kubectl wd \
  --namespace kube-system

kubectl create namespace dev

kubectl config set-context minikube --namespace dev

kubectl delete -f . &> /dev/null

kubectl apply -f .

kubectl wd \
  --namespace dev \
  --deployments nginx \
  --attempts 30 \
  --interval 3

kubectl -n dev get deploy,rs,pods,svc
```
