### PR TITLE
Bump auth-proxy to v1.1.0

### DIFF
--- a/plugins/auth-proxy.yaml
+++ b/plugins/auth-proxy.yaml
@@ -16,10 +16,10 @@ spec:
     You need to configure authentication in the kubeconfig.
     See https://github.com/int128/kauthproxy for more.
 
-  version: v1.0.1
+  version: v1.1.0
   platforms:
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.1/kauthproxy_linux_amd64.zip
-      sha256: "71b232f2e8e953321b29eb6076305e2504479dc342ffe307e4e81be61c25b168"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.0/kauthproxy_linux_amd64.zip
+      sha256: "3d8024b232b660609de7ba3851915cdc4a33f479c89b347973c6406b0c7e0b98"
       bin: kauthproxy
       files:
         - from: kauthproxy
@@ -30,8 +30,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.1/kauthproxy_darwin_amd64.zip
-      sha256: "096aaa92eb423a7b40b18e034d13bb13bdd68266535369900db32b8ec415cb07"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.0/kauthproxy_darwin_amd64.zip
+      sha256: "628bfae223f47f94747a9dd1503298bd3d203bc4550e56a5dd0b16805f320641"
       bin: kauthproxy
       files:
         - from: kauthproxy
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.0.1/kauthproxy_windows_amd64.zip
-      sha256: "fb14dcb059e95dcebd4c7d8591eb93d89052ee1919e896be7a396eefa839ef21"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.0/kauthproxy_windows_amd64.zip
+      sha256: "8fd3d97099f5d4ee9d51cdd1f2a0318d56fcaea040ca042b2cc4f22bedd6f7e5"
       bin: kauthproxy.exe
       files:
         - from: kauthproxy.exe


### PR DESCRIPTION
This will bump the version of auth-proxy to https://github.com/int128/kauthproxy/releases/tag/v1.1.0.
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
