### PR TITLE
adding support for mac for net-forward plugin

### DIFF
--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: net-forward
 spec:
-  version: "v1.0.3"       
+  version: "v1.1.0"       
   platforms:
   - selector:
       matchExpressions:

--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -6,8 +6,8 @@ spec:
   version: "v1.0.3"       
   platforms:
   - selector:
-      matchLabels:
-        os: linux
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
     uri: https://github.com/antitree/krew-net-forward/releases/download/v1.0.3/net-forward_v1.0.3.tar.gz
     sha256: "645adb05d9ad68ecc91d9034cb80b1e2fe4762864323c12de0f2bc5afe20baa0"
     bin: "net-forward"  


### PR DESCRIPTION
This is a simple change to the manifest that adds support for Darwin. I've tested it and we don't need to change the code itself. Fixes #755 