### PR TITLE
Update virt (KubeVirt virtctl plugin package) to v0.32.0

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: virt
 spec:
-  version: "v0.31.0"
+  version: "v0.32.0"
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.31.0/virtctl-darwin-amd64.tar.gz"
-      sha256: "e914ac5fe962a4a1b09d13f1eaa068ab996d23ec71715cb2af520d2ed7f0f921"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.32.0/virtctl-darwin-amd64.tar.gz"
+      sha256: "c980facd7b9939e2634a3aaad5d2d34a7d8108ee9a9f3270fb061440998db0d7"
       files:
         - from: "/virtctl/virtctl-darwin-amd64"
           to: "virtctl"
@@ -21,8 +21,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.31.0/virtctl-linux-amd64.tar.gz"
-      sha256: "b46fdf0a79506e41c3dd9ed5bb177ac3eff209490625b60ba44c7e6b273e5f78"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.32.0/virtctl-linux-amd64.tar.gz"
+      sha256: "b89d178c13b399ab2d5c3146b188f1b06b68f112252a180e86f5fd040d8086a9"
       files:
         - from: "/virtctl/virtctl-linux-amd64"
           to: "virtctl"
@@ -31,22 +31,10 @@ spec:
       bin: "virtctl"
     - selector:
         matchLabels:
-          os: linux
-          arch: 386
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.31.0/virtctl-linux-x86_64.tar.gz"
-      sha256: "291a5affbe1ece8e586de7401c08cf5e7e5367aadb438b17d43f0c100cdcaf96"
-      files:
-        - from: "/virtctl/virtctl-linux-x86_64"
-          to: "virtctl"
-        - from: virtctl/LICENSE
-          to: .
-      bin: "virtctl"
-    - selector:
-        matchLabels:
           os: windows
           arch: amd64
-      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.31.0/virtctl-windows-amd64.exe.tar.gz"
-      sha256: "01fa725f19665e1cd133230421265ac34e0bb282db2cb7f6d261728b1dc86416"
+      uri: "https://github.com/kubevirt/kubectl-virt-plugin/releases/download/v0.32.0/virtctl-windows-amd64.exe.tar.gz"
+      sha256: "0f2ff2b776bcfc674ca0077bbf65aa63065372aef3c25890dc86f17c1839900b"
       files:
         - from: "/virtctl/virtctl-windows-amd64.exe"
           to: "virtctl.exe"


### PR DESCRIPTION
See https://github.com/kubevirt/kubevirt/releases/tag/v0.32.0