### PR TITLE
Upgrade cert-manager plugin to v1.0.0-beta.0

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v0.16.0
+  version: v1.0.0-beta.0
   homepage: https://github.com/jetstack/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -16,34 +16,34 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 4dca521fb94322d95fed03b6aec8d5e03d5c333f63bcc4645bc6964b3238c95c
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.0.0-beta.0/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: c3b72f1433439f9e57cca710631d2584afb8572ee2ad58a318802ce38e2ccd87
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: c7e0a35e5362c06c978a0ae4ce0fb1b339e734d906fa2e2c3799acbff58aba74
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.0.0-beta.0/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 6505fa76d724166bdb1632f63a259d22fec1e329400145918b0223326345135e
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 1b379631bf1243e64ef9b9648ef709d4d8794864e6400aea4168eec67c44a525
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.0.0-beta.0/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 6073ca25f4904185929e425181ed7fc047de1d2e562c2bf76cd614b13964bce1
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 8764fed951af6255e75d92460bd26c5ff661e5e6f69e2642a9c861d310ab22a7
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.0.0-beta.0/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 1c9120314a35dc995553758e2eeff31b5a9ff315a6d584c43864cec6d41e583e
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v0.16.0/kubectl-cert_manager-windows-amd64.tar.gz
-    sha256: fb6b390e267e969b75bff754ea2e021ff3a5ae7371dad9fa04e001429fabd22f
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.0.0-beta.0/kubectl-cert_manager-windows-amd64.tar.gz
+    sha256: 675cb0f752979bd69b6c02fed501e3b3eb69bf12d5be5a056a923911dbf26816
     bin: kubectl-cert_manager


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Upgrade cert-manager plugin to v1.0.0-beta.0
