### PR TITLE
Bump KUDO to version 0.16

### DIFF
--- a/plugins/kudo.yaml
+++ b/plugins/kudo.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kudo
 spec:
-  version: "v0.15.0"
+  version: "v0.16.0"
 
   shortDescription: Declaratively build, install, and run operators using KUDO.
   homepage: https://kudo.dev/
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: "linux"
         arch: "amd64"
-    uri: https://github.com/kudobuilder/kudo/releases/download/v0.15.0/kudo_0.15.0_linux_x86_64.tar.gz
-    sha256: "1b2ec7835b6a1a28e97ee25f0939a694636db884991fb6d7c62ddb47bc087544"
+    uri: https://github.com/kudobuilder/kudo/releases/download/v0.16.0/kudo_0.16.0_linux_x86_64.tar.gz
+    sha256: "febefc474bcbaf65231ecb9725add324e90b07e2a0827520b0aeb0c8728ebf7e"
     bin: "./kubectl-kudo"
     files:
     - from: "*"
@@ -38,8 +38,8 @@ spec:
       matchLabels:
         os: "linux"
         arch: "386"
-    uri: https://github.com/kudobuilder/kudo/releases/download/v0.15.0/kudo_0.15.0_linux_i386.tar.gz
-    sha256: "1dfc1de43de1486af9ad63694ab0eb0c9ae320ca5dd072c71688d558e23b6fc2"
+    uri: https://github.com/kudobuilder/kudo/releases/download/v0.16.0/kudo_0.16.0_linux_i386.tar.gz
+    sha256: "2f6568b37cb099492ae4151f52aa4dc5ce4a016a17aa3cec1304c0c558ec1df3"
     bin: "./kubectl-kudo"
     files:
     - from: "*"
@@ -48,8 +48,8 @@ spec:
       matchLabels:
         os: "darwin"
         arch: "amd64"
-    uri: https://github.com/kudobuilder/kudo/releases/download/v0.15.0/kudo_0.15.0_darwin_x86_64.tar.gz
-    sha256: "7f29baa21ad80038f825761338438ae7dcbf29dca63565ed63b3cf4a18ef1fa5"
+    uri: https://github.com/kudobuilder/kudo/releases/download/v0.16.0/kudo_0.16.0_darwin_x86_64.tar.gz
+    sha256: "a3d1bad02e2c20c552d63c9fbb3cf3430195eb3ba1c21f9cc984c69ca7eea82d"
     bin: "./kubectl-kudo"
     files:
     - from: "*"


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Updates the existing KUDO plugin to use KUDO 0.16.0.
