### PR TITLE
new version v1.2.0 of node-shell

### DIFF
--- a/plugins/node-shell.yaml
+++ b/plugins/node-shell.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: node-shell
 spec:
-  version: "v1.1.4"
+  version: "v1.2.0"
   homepage: https://github.com/kvaps/kubectl-node-shell
   shortDescription: Spawn a root shell on a node via kubectl 
   description: |
@@ -11,7 +11,18 @@ spec:
     You need to be able to start privileged containers for that.
 
     Usage:
+
+      Get standard bash shell:
       $ kubectl node-shell <node>
+      
+      Execute custom command:
+      $ kubectl node-shell <node> -- echo 123
+      
+      Use stdin:
+      $ cat /etc/passwd | kubectl node-shell <node> -- sh -c 'cat > /tmp/passwd'
+      
+      Run oneliner script:
+      $ kubectl node-shell <node> -- sh -c 'cat /tmp/passwd; rm -f /tmp/passwd'
   caveats: |
       You need to be allowed to start privileged pods in the cluster
   platforms:
@@ -22,8 +33,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/kvaps/kubectl-node-shell/archive/v1.1.4.tar.gz
-    sha256: "5035deecc2e17d39c8942854d840cc6d093a68b3466469113986a64956dae4f9"
+    uri: https://github.com/kvaps/kubectl-node-shell/archive/v1.2.0.tar.gz
+    sha256: "5a6a2d656014546a6ea69e09b89feb6830c85cd5758a0eaa56002586e2b06f1a"
     files:
     - from: kubectl-node-shell-*/kubectl-node_shell
       to: .


### PR DESCRIPTION
The new version was greatly improved:

-    Support for long flags with = (equals)
-    Allow specifying custom command after --
-    Piped stdin / stdout support
-    Handle exit codes
-    Always remove created container by trap
