### PR TITLE
Bump oidc-login to v1.20.1

### DIFF
--- a/plugins/oidc-login.yaml
+++ b/plugins/oidc-login.yaml
@@ -22,10 +22,10 @@ spec:
 
   caveats: |
     You need to setup the OIDC provider, Kubernetes API server, role binding and kubeconfig.
-  version: v1.20.0
+  version: v1.20.1
   platforms:
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.0/kubelogin_linux_amd64.zip
-      sha256: "c0063f8060e969fa8c8fcfb4e37f2bbe35e7537cdbc82dd0535c96098953c6a6"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.1/kubelogin_linux_amd64.zip
+      sha256: "1a61572dc76b6ec23c01ab15c7874ce6ae0e8ff470c7c1e7369ff3b2fe3dcdc0"
       bin: kubelogin
       files:
         - from: kubelogin
@@ -36,8 +36,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.0/kubelogin_darwin_amd64.zip
-      sha256: "1ce071a80aa8aa6cd2c80a6c900e109d1a7b451907952854330bc252e4196bf3"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.1/kubelogin_darwin_amd64.zip
+      sha256: "3c8dd763474428c871579bad00d8af55b2151d5260c6b7db350fd563f754ff7a"
       bin: kubelogin
       files:
         - from: kubelogin
@@ -48,8 +48,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.0/kubelogin_windows_amd64.zip
-      sha256: "3808427604113dde620f35f9d3735a7820472bcd6fc2dd27e62da22064596595"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.1/kubelogin_windows_amd64.zip
+      sha256: "b0e2a7480201451af4a0c3efabc5086e7b5b930e90accdcda3b88ccdc3cf3d5f"
       bin: kubelogin.exe
       files:
         - from: kubelogin.exe
@@ -60,8 +60,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.0/kubelogin_linux_arm.zip
-      sha256: "50d3f031dd5c5d9b42bd5f1c6b5c2d308d1472062e676b8bb138e68bc1ed4f5e"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.1/kubelogin_linux_arm.zip
+      sha256: "8b5c7d213cac20de41a9a194d3ffbca90b7159552de5c939eb438ec44393124b"
       bin: kubelogin
       files:
         - from: kubelogin
@@ -72,8 +72,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm
-    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.0/kubelogin_linux_arm64.zip
-      sha256: "274d5a5a4a39e9096ccfc85f6067cc80f628cea8f1a0335a5230e47abdf73454"
+    - uri: https://github.com/int128/kubelogin/releases/download/v1.20.1/kubelogin_linux_arm64.zip
+      sha256: "4880970fb4b7b1dc20ac1f57d4e14a49a6b9272c587e968b91c98ddfa244073e"
       bin: kubelogin
       files:
         - from: kubelogin


### PR DESCRIPTION
Release https://github.com/int128/kubelogin/releases/tag/v1.20.1.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
