### PR TITLE
Bump fuzzy to v1.6.0

### DIFF
--- a/plugins/fuzzy.yaml
+++ b/plugins/fuzzy.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fuzzy
 spec:
   platforms:
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.5.2/kubectl-fuzzy_1.5.2_darwin_amd64.tar.gz"
-    sha256: "c20acf750427e1cec3e42dffe2092d544a2a89b94ead4be26ad3f9f67624a903"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.6.0/kubectl-fuzzy_1.6.0_darwin_amd64.tar.gz"
+    sha256: "baad4b17408f2cd2d5d6aa74c859807c758d0f150abe50de23a6a48885543b3d"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.5.2/kubectl-fuzzy_1.5.2_linux_amd64.tar.gz"
-    sha256: "bf1d6659965ab9b8e1583b55e380ca682aee25552a5673d587091741c81dccd1"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.6.0/kubectl-fuzzy_1.6.0_linux_amd64.tar.gz"
+    sha256: "fc0336325d8f9c2755584fabe9dea04756930dc490f9476089c9d496e52b9ba0"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.5.2/kubectl-fuzzy_1.5.2_windows_amd64.tar.gz"
-    sha256: "d3569b62ec003bb0bcd1434f78383fcd5bb6aa46be3eb1342d71aa3dc2362ba1"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.6.0/kubectl-fuzzy_1.6.0_windows_amd64.tar.gz"
+    sha256: "eb16d9bbae9691af1198231ca38e5ab21d1f63a8a075a951918aba4ee509ba1e"
     bin: kubectl-fuzzy.exe
     files:
     - from: kubectl-fuzzy.exe
@@ -40,7 +40,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v1.5.2"
+  version: "v1.6.0"
   shortDescription: Fuzzy and partial string search for kubectl
   description: |
     This tool uses fzf(1)-like fuzzy-finder to do partial or fuzzy search of Kubernetes resources.


### PR DESCRIPTION
https://github.com/d-kuro/kubectl-fuzzy/releases/tag/v1.6.0

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
