### PR TITLE
Added kubectl-ansible-playbook

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -15,6 +15,7 @@ Name | Description | Stars
 ---- | ----------- | -----
 [access-matrix](https://github.com/corneliusweig/rakkess) | Show an RBAC access matrix for server resources | ![GitHub stars](https://img.shields.io/github/stars/corneliusweig/rakkess.svg?label=stars&logo=github)
 [advise-psp](https://github.com/sysdiglabs/kube-psp-advisor) | Suggests PodSecurityPolicies for cluster. | ![GitHub stars](https://img.shields.io/github/stars/sysdiglabs/kube-psp-advisor.svg?label=stars&logo=github)
+[ansible-playbook](https://github.com/Akasurde/kubectl-ansible-playbook) | Execute Ansible Playbooks on Pods. | ![GitHub stars](https://img.shields.io/github/stars/Akasurde/kubectl-ansible-playbook.svg?label=stars&logo=github)
 [apparmor-manager](https://github.com/sysdiglabs/kube-apparmor-manager) | Manage AppArmor profiles for cluster. | ![GitHub stars](https://img.shields.io/github/stars/sysdiglabs/kube-apparmor-manager.svg?label=stars&logo=github)
 [auth-proxy](https://github.com/int128/kauthproxy) | Authentication proxy to a pod or service | ![GitHub stars](https://img.shields.io/github/stars/int128/kauthproxy.svg?label=stars&logo=github)
 [bulk-action](https://github.com/emreodabas/kubectl-plugins#kubectl-bulk) | Do bulk actions on Kubernetes resources. | ![GitHub stars](https://img.shields.io/github/stars/emreodabas/kubectl-plugins.svg?label=stars&logo=github)

--- a/plugins/ansible-playbook.yaml
+++ b/plugins/ansible-playbook.yaml
@@ -1,0 +1,30 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ansible-playbook
+spec:
+  homepage: https://github.com/Akasurde/kubectl-ansible-playbook
+  shortDescription: Run Ansible Playbooks on Kubernetes Pods
+  version: v0.2.0
+  description: |
+    Use Ansible K8S dynamic inventory plugin and kubectl connection plugin to run
+    Ansible playbooks on the given pods.
+  caveats: |
+    You need to install Ansible>=2.9.10 and Ansible kubernetes community collection
+    (community.kubernetes) before hand to run this plugin.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/Akasurde/kubectl-ansible-playbook/archive/v0.2.0.tar.gz
+    sha256: 1542d195cde94b0aa4452c822c020938cc733607b4cf5621d2865c378d28dc8c
+    bin: "./kubectl-ansible_playbook"
+    files:
+      - from: "./*/kubectl-ansible_playbook"
+        to: .
+      - from: "./*/LICENSE"
+        to: .


### PR DESCRIPTION
Added support for new Kubectl plugin. With this
plugin user can execute Ansible Playbooks on Kubernetes Pods
with help of Ansible K8S dynamic inventory and kubectl connection
plugin.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
