### PR TITLE
Bump the version of view-serviceaccount-kubeconfig to v2.2.2

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,8 +4,8 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.1/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
-    sha256: "92900758b87b1c35591a326bfd5bf9cd83992e7bb2a4f649d728fdf0162120ec"
+  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.2/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
+    sha256: "dc43a16225081b0483a3d2e40175897f408fc4c2ca45a55fc6e20bd6bd4ef332"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: kubectl-view_serviceaccount_kubeconfig
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.1/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
-    sha256: "f15ba94d5892aa0467847e8de4bbbe382f5a4daf3192399ffda46aa5900ee3aa"
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.2/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: "8be2a4a0aca5c8e1d59dadcdab1ccb2a441674603a0e100d865d5efdfaa8223f"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: kubectl-view_serviceaccount_kubeconfig
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.1/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
-    sha256: "98d1af57a033aab61891594357d4db671b30e4d982263a4f4a56a387c74184e9"
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.2/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
+    sha256: "b958a641c9b0deece228b34dfb6c2f1d09b84e55c6fffc2e032a500a71ce54c7"
     bin: kubectl-view_serviceaccount_kubeconfig.exe
     files:
     - from: kubectl-view_serviceaccount_kubeconfig.exe
@@ -40,7 +40,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.2.1"
+  version: "v2.2.2"
   homepage: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
This PR bumps up the version of view-serviceaccount-kubeconfig to v2.2.2.