### PR TITLE
Bump konfig to v0.2.3

### DIFF
--- a/plugins/konfig.yaml
+++ b/plugins/konfig.yaml
@@ -3,10 +3,10 @@ kind: Plugin
 metadata:
   name: konfig
 spec:
-  version: "v0.2.2"
+  version: "v0.2.3"
   platforms:
-    - uri: https://github.com/corneliusweig/konfig/releases/download/v0.2.2/bundle.tar.gz
-      sha256: 69ee54d2fa509417e26a393c7f13fa7b7127d5370a975acc585455af0576677f
+    - uri: https://github.com/corneliusweig/konfig/releases/download/v0.2.3/bundle.tar.gz
+      sha256: d72de1b08b9a7ea3499c5b2a032e82ae5b0036d454b3be9beb0d8b2bb8e68f4f
       bin: konfig-krew
       files:
         - from: ./konfig-krew
@@ -18,17 +18,6 @@ spec:
           - key: os
             operator: In
             values: ["darwin", "linux"]
-    - uri: https://github.com/corneliusweig/konfig/releases/download/v0.2.2/bundle.tar.gz
-      sha256: 69ee54d2fa509417e26a393c7f13fa7b7127d5370a975acc585455af0576677f
-      bin: konfig-krew.exe
-      files:
-        - from: ./konfig-krew
-          to: konfig-krew.exe
-        - from: LICENSE
-          to: .
-      selector:
-        matchLabels:
-          os: windows
   shortDescription: Merge, split or import kubeconfig files
   homepage: https://github.com/corneliusweig/konfig
   description: |+2
@@ -42,4 +31,4 @@ spec:
         $ kubectl konfig merge kubeconfig1 kubeconfig2 > merged
         $ kubectl konfig export ctx1 ctx2 -k k8s.yaml,k3s.yaml > extracted
 
-      More on https://github.com/corneliusweig/konfig/blob/v0.2.2/doc/USAGE.md#usage
+      More on https://github.com/corneliusweig/konfig/blob/master/doc/USAGE.md#konfig


### PR DESCRIPTION
- Drops the Windows installation, because shell plugins are broken on
  Windows.
- Usage instructions now link to the docs at HEAD to be more friendly to
  krew's auto-approver.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
