### PR TITLE
Add HNS plugin

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -50,6 +50,7 @@ Name | Description | Stars
 [gopass](https://github.com/gopasspw/kubectl-gopass) | Imports secrets from gopass | ![GitHub stars](https://img.shields.io/github/stars/gopasspw/kubectl-gopass.svg?label=stars&logo=github)
 [grep](https://github.com/guessi/kubectl-grep) | Filter Kubernetes resources by matching their names | ![GitHub stars](https://img.shields.io/github/stars/guessi/kubectl-grep.svg?label=stars&logo=github)
 [gs](https://github.com/giantswarm/kubectl-gs) | Handle custom resources with Giant Swarm | ![GitHub stars](https://img.shields.io/github/stars/giantswarm/kubectl-gs.svg?label=stars&logo=github)
+[hns](https://github.com/kubernetes-sigs/multi-tenancy/tree/master/incubator/hnc) | Manage hierarchical namespaces (part of HNC) | ![GitHub stars](https://img.shields.io/github/stars/kubernetes-sigs/multi-tenancy.svg?label=stars&logo=github)
 [iexec](https://github.com/gabeduke/kubectl-iexec) | Interactive selection tool for `kubectl exec` | ![GitHub stars](https://img.shields.io/github/stars/gabeduke/kubectl-iexec.svg?label=stars&logo=github)
 [images](https://github.com/chenjiandongx/kubectl-images) | Show container images used in the cluster. | ![GitHub stars](https://img.shields.io/github/stars/chenjiandongx/kubectl-images.svg?label=stars&logo=github)
 [ingress-nginx](https://kubernetes.github.io/ingress-nginx/kubectl-plugin/) | Interact with ingress-nginx | ![GitHub stars](https://img.shields.io/github/stars/kubernetes/ingress-nginx.svg?label=stars&logo=github)

--- a/plugins/hns.yaml
+++ b/plugins/hns.yaml
@@ -1,0 +1,35 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: hns
+spec:
+  shortDescription: Manage hierarchical namespaces (part of HNC)
+  description: |
+    Manipulates hierarchical namespaces provided by the Hierarchical Namespace Controller (HNC).
+  version: v0.5.3-rc1
+  homepage: https://github.com/kubernetes-sigs/multi-tenancy/tree/master/incubator/hnc/docs/user-guide
+  platforms:
+  - uri: https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3-rc1/kubectl-hns.tar.gz
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    sha256: b605ad56083f0f9190fadbc502c7eb1f81b27c9acae297d593a2ac75bd807565
+    files:
+      - from: "kubectl/kubectl-hns_linux_amd64"
+        to: "."
+      - from: "kubectl/LICENSE"
+        to: "."
+    bin: "./kubectl-hns_linux_amd64"
+  - uri: https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3-rc1/kubectl-hns.tar.gz
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    sha256: b605ad56083f0f9190fadbc502c7eb1f81b27c9acae297d593a2ac75bd807565
+    files:
+      - from: "kubectl/kubectl-hns_darwin_amd64"
+        to: "."
+      - from: "kubectl/LICENSE"
+        to: "."
+    bin: "./kubectl-hns_darwin_amd64"


### PR DESCRIPTION
This adds the initial Hierarchical Namespace plugin, tied to HNC v0.5.3
RC1 (I'll update it when we release HNC v0.5.3).

Tested: `kubectl krew install --manifest=hns.yaml` works correctly. Docs
staged at https://github.com/adrianludwin/krew-index/blob/hns/plugins.md
and all links work.