### PR TITLE
Bump the version of view-serviceaccount-kubeconfig to v2.2.3

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,8 +4,8 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.2/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
-    sha256: "dc43a16225081b0483a3d2e40175897f408fc4c2ca45a55fc6e20bd6bd4ef332"
+  - uri: "https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.3/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip"
+    sha256: "56dd1fa1cdfeec1839eeac24c3585a98065b84a09fec0b7ded254df2427fb24d"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: kubectl-view_serviceaccount_kubeconfig
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.2/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
-    sha256: "8be2a4a0aca5c8e1d59dadcdab1ccb2a441674603a0e100d865d5efdfaa8223f"
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.3/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: "ae29880b8e6fd229e39f7dc7855f6e04d07be06d7e020f3980ee6d0350d85769"
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: kubectl-view_serviceaccount_kubeconfig
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.2/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
-    sha256: "b958a641c9b0deece228b34dfb6c2f1d09b84e55c6fffc2e032a500a71ce54c7"
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.3/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
+    sha256: "4015bac146e44aac81edc34e206e377be65c76bf946194d58c6a34726905550e"
     bin: kubectl-view_serviceaccount_kubeconfig.exe
     files:
     - from: kubectl-view_serviceaccount_kubeconfig.exe
@@ -40,7 +40,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.2.2"
+  version: "v2.2.3"
   homepage: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
This PR bumps up the version of view-serviceaccount-kubeconfig to v2.2.3.