### PR TITLE
Upgrade HNS to v0.5.3 final

### DIFF
--- a/plugins/hns.yaml
+++ b/plugins/hns.yaml
@@ -5,28 +5,60 @@ metadata:
 spec:
   shortDescription: Manage hierarchical namespaces (part of HNC)
   description: |
-    Manipulates hierarchical namespaces provided by the Hierarchical Namespace Controller (HNC).
-  version: v0.5.3-rc1
+    Manipulates hierarchical namespaces provided by the Hierarchical Namespace
+    Controller (HNC).
+
+    HNC allows you to arrange your namespaces into hierarchies, which enables
+    two key benefits:
+    * Users without cluster-level permissions to create namespaces can create
+      restricted "subnamespaces" instead.
+    * Owners of parent namespaces can create policies that are enforced on
+      all descendant namespaces.
+
+    HNC is controlled via regular Kubernetes objects, but this plugin makes it
+    easy to create subnamespaces, arrange regular (full) namespaces into
+    hierarchies, and configure HNC to propagate different kinds of objects.
+  version: v0.5.3
+  caveats: |
+    This plugin requires HNC v0.5.x on your cluster. Get it at
+
+      https://github.com/kubernetes-sigs/multi-tenancy/releases/tag/hnc-v0.5.3
+
+    or via:
+
+      kubectl apply -f https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3/hnc-manager.yaml
+
+    This version of the plugin uses the HNC v1alpha1 API, and is compatible
+    with HNC v0.5.x. Later versions of HNC will not support v1alpha1, so if you
+    are running any later version of HNC, you must upgrade to a compatible
+    version of this plugin.
+
+    Watch out for the following common misconceptions when using HNC:
+
+    * Not all child namespaces are subnamespaces!
+    * Only RBAC Roles and RoleBindings are propagated by default, but you can configure more
+
+    The user guide contains much more information.
   homepage: https://github.com/kubernetes-sigs/multi-tenancy/tree/master/incubator/hnc/docs/user-guide
   platforms:
-  - uri: https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3-rc1/kubectl-hns.tar.gz
+  - uri: https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3/kubectl-hns.tar.gz
     selector:
       matchLabels:
         os: linux
         arch: amd64
-    sha256: b605ad56083f0f9190fadbc502c7eb1f81b27c9acae297d593a2ac75bd807565
+    sha256: c80da0c77d5cf052abd302e6862dab3f1254d9ceb0cb9b39e0d64b71ebfd4647
     files:
       - from: "kubectl/kubectl-hns_linux_amd64"
         to: "."
       - from: "kubectl/LICENSE"
         to: "."
     bin: "./kubectl-hns_linux_amd64"
-  - uri: https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3-rc1/kubectl-hns.tar.gz
+  - uri: https://github.com/kubernetes-sigs/multi-tenancy/releases/download/hnc-v0.5.3/kubectl-hns.tar.gz
     selector:
       matchLabels:
         os: darwin
         arch: amd64
-    sha256: b605ad56083f0f9190fadbc502c7eb1f81b27c9acae297d593a2ac75bd807565
+    sha256: c80da0c77d5cf052abd302e6862dab3f1254d9ceb0cb9b39e0d64b71ebfd4647
     files:
       - from: "kubectl/kubectl-hns_darwin_amd64"
         to: "."


### PR DESCRIPTION
Added more documentation as requested in #828 and upgrade to the final
version of the v0.5.3 plugin (from v0.5.3-rc1, which was mainly for
testing purposes).

Tested: ran `kubectl krew install --manifest=plugins/hns.yaml` and got a
nice-looking "caveats" message. I'm not sure how to test the
"description" but it's wrapped now so I'm hoping it looks good.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
