### PR TITLE
bump kubectl-fuzzy to v1.8.0

### DIFF
--- a/plugins/fuzzy.yaml
+++ b/plugins/fuzzy.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fuzzy
 spec:
   platforms:
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.7.0/kubectl-fuzzy_1.7.0_darwin_amd64.tar.gz"
-    sha256: "b1f306beca30ac38b989526a6b20300f28c25b5930b6de524cbe541cebe1cf25"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.0/kubectl-fuzzy_1.8.0_darwin_amd64.tar.gz"
+    sha256: "ab5f3a13f784e92680f8091f7c6f853337fb758f3af0d3f3444e3698ca6a1fd7"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.7.0/kubectl-fuzzy_1.7.0_linux_amd64.tar.gz"
-    sha256: "ee97c7606aa85e2d8d104f31779c49843c50812f9585308ab445c74368a2ab0f"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.0/kubectl-fuzzy_1.8.0_linux_amd64.tar.gz"
+    sha256: "a8d9e47c648bd5b3faccd45e299c8564a7ed07860f5bc46bbe3b0303dfab5d5a"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.7.0/kubectl-fuzzy_1.7.0_windows_amd64.tar.gz"
-    sha256: "80638d3ebfed8e69cca35b1c532d6dc7bf4c9190f196f1e6cd765ba15d9380db"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.0/kubectl-fuzzy_1.8.0_windows_amd64.tar.gz"
+    sha256: "8a8d52362967fd57f1b768e61999f2b7f56e47ec653424867a666c75039cb190"
     bin: kubectl-fuzzy.exe
     files:
     - from: kubectl-fuzzy.exe
@@ -40,7 +40,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v1.7.0"
+  version: "v1.8.0"
   shortDescription: Fuzzy and partial string search for kubectl
   description: |
     This tool uses fzf(1)-like fuzzy-finder to do partial or fuzzy search of Kubernetes resources.


### PR DESCRIPTION
https://github.com/d-kuro/kubectl-fuzzy/releases/tag/v1.8.0
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
