### PR TITLE
release exec-cronjob and prune-unused to v0.6.0

### DIFF
--- a/plugins/exec-cronjob.yaml
+++ b/plugins/exec-cronjob.yaml
@@ -3,13 +3,13 @@ kind: Plugin
 metadata:
   name: exec-cronjob
 spec:
-  version: v0.5.1
+  version: v0.6.0
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.5.1.zip
-    sha256: d382659a4d47cdfc4eb1a7dde9e45ba33cabce87157d309d904909709e939c84
+    uri: https://github.com/FikaWorks/kubectl-plugins/archive/v0.6.0.zip
+    sha256: b92740c91efe7c7101c4d51fb456c08c8fc4014621cac2144a30895c257b6559
     files:
     - from: kubectl-plugins-*/exec-cronjob/*
       to: .
@@ -18,6 +18,11 @@ spec:
     bin: kubectl-exec_cronjob.sh
   shortDescription: Run a CronJob immediately as Job
   description: |
+    DEPRECATION NOTICE:
+    This plugin isn't necessary anymore, the kubectl cli let you create
+    cronjob with the create subcommand:
+        kubectl create job --from cronjob/my-cronjob my-job
+
     Run a CronJob immediately as Job by extracting the Job spec and creating a
     Job instance thereof.
 
@@ -25,4 +30,4 @@ spec:
         -n, --namespace='': If present, the namespace scope for this CLI request
         --dry-run: If true, only print the object that would be sent, without sending it.
         -h, --help: Display this help
-  homepage: https://github.com/thecloudnatives/kubectl-plugins#exec-cronjob
+  homepage: https://github.com/FikaWorks/kubectl-plugins#exec-cronjob

--- a/plugins/prune-unused.yaml
+++ b/plugins/prune-unused.yaml
@@ -3,13 +3,13 @@ kind: Plugin
 metadata:
   name: prune-unused
 spec:
-  version: v0.5.1
+  version: v0.6.0
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/thecloudnatives/kubectl-plugins/archive/v0.5.1.zip
-    sha256: d382659a4d47cdfc4eb1a7dde9e45ba33cabce87157d309d904909709e939c84
+    uri: https://github.com/FikaWorks/kubectl-plugins/archive/v0.6.0.zip
+    sha256: b92740c91efe7c7101c4d51fb456c08c8fc4014621cac2144a30895c257b6559
     files:
     - from: kubectl-plugins-*/prune-unused/*
       to: .
@@ -26,7 +26,8 @@ spec:
         kubectl prune-unused <configmaps|secrets> [options]
 
     Options:
+        -l, --selector='': Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
         -n, --namespace='': If present, the namespace scope for this CLI request
         --dry-run: If true, only print the object that would be pruned, without deleting it.
         -h, --help='': Display this help
-  homepage: https://github.com/thecloudnatives/kubectl-plugins
+  homepage: https://github.com/FikaWorks/kubectl-plugins#prune-unused


### PR DESCRIPTION
- exec-cronjob and prune-unused to v0.6.0
- add deprecation message for exec-cronjob in favor of `kubectl create job --from`
- rename "thecloudnative" Github organization to "FikaWorks"
