### PR TITLE
[plugin] kubectl configrep

### DIFF
--- a/plugins.md
+++ b/plugins.md
@@ -25,6 +25,7 @@ Name | Description | Stars
 [cilium](https://github.com/bmcustodio/kubectl-cilium) | Easily interact with Cilium agents. | ![GitHub stars](https://img.shields.io/github/stars/bmcustodio/kubectl-cilium.svg?label=stars&logo=github)
 [cluster-group](https://github.com/u2takey/kubectl-clusters) | Exec commands across a group of contexts. | ![GitHub stars](https://img.shields.io/github/stars/u2takey/kubectl-clusters.svg?label=stars&logo=github)
 [config-cleanup](https://github.com/b23llc/kubectl-config-cleanup) | Automatically clean up your kubeconfig | ![GitHub stars](https://img.shields.io/github/stars/b23llc/kubectl-config-cleanup.svg?label=stars&logo=github)
+[configrep](https://gitlab.com/loomsen/kubectl-configrep) | Find patterns in configmaps | ![GitLab stars](https://img.shields.io/badge/dynamic/json?color=green&label=gitlab%20stars&query=%24.star_count&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F21745902)
 [cssh](https://github.com/containership/kubectl-cssh) | SSH into Kubernetes nodes | ![GitHub stars](https://img.shields.io/github/stars/containership/kubectl-cssh.svg?label=stars&logo=github)
 [ctx](https://github.com/ahmetb/kubectx) | Switch between contexts in your kubeconfig | ![GitHub stars](https://img.shields.io/github/stars/ahmetb/kubectx.svg?label=stars&logo=github)
 [custom-cols](https://github.com/webofmars/kubectl-custom-cols) | A "kubectl get" replacement with customizable column presets | ![GitHub stars](https://img.shields.io/github/stars/webofmars/kubectl-custom-cols.svg?label=stars&logo=github)

--- a/plugins/configrep.yaml
+++ b/plugins/configrep.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  # 'name' must match the filename of the manifest.
+  name: configrep
+spec:
+  # 'version' is a valid semantic version string (see semver.org)
+  version: "v1.0.0"
+  # 'homepage' usually links to the GitHub repository of the plugin
+  homepage: https://gitlab.com/loomsen/kubectl-configrep
+  # 'shortDescription' explains what the plugin does in only a few words
+  shortDescription: "Finds configmaps containing a pattern"
+  description: |
+    Find configmaps containing a pattern. Like grep -l for configmaps.
+    It will return the configmap name.
+  # 'platforms' specify installation methods for various platforms (os/arch)
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    # 'uri' specifies .zip or .tar.gz archive URL of a plugin
+    uri: "https://gitlab.com/api/v4/projects/21752082/repository/archive.tar.gz?sha=v1.0.0"
+    # 'sha256' is the sha256sum of the url above
+    sha256: c61bd1381d5976fdf507655283b71d7a78ea521a279824780af7421bd5fbe39f
+    # 'files' lists which files should be extracted out from downloaded archive
+    files:
+    - from: "*/configrep.sh"
+      to: "."
+    - from: "*/LICENSE"
+      to: "."
+    # 'bin' specifies the path to the the plugin executable among extracted files
+    bin: configrep.sh

--- a/plugins/configrep.yaml
+++ b/plugins/configrep.yaml
@@ -23,9 +23,9 @@ spec:
         - darwin
         - linux
     # 'uri' specifies .zip or .tar.gz archive URL of a plugin
-    uri: "https://gitlab.com/api/v4/projects/21752082/repository/archive.tar.gz?sha=v1.0.0"
+    uri: "https://gitlab.com/api/v4/projects/21752082/repository/archive.tar.gz"
     # 'sha256' is the sha256sum of the url above
-    sha256: c61bd1381d5976fdf507655283b71d7a78ea521a279824780af7421bd5fbe39f
+    sha256: c473a0c1b9bbfa62fe7aa629f993665626bebdaf352c3e53ff49dfd9188a2b94
     # 'files' lists which files should be extracted out from downloaded archive
     files:
     - from: "*/configrep.sh"


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR introduces `kubectl configrep` plugin. It let's you find configmaps in a namespace or across the cluster, that match a certain pattern. Like `grep -l` for configmaps.