### PR TITLE
add kubectl view-cert plugin

### DIFF
--- a/plugins/view-cert.yaml
+++ b/plugins/view-cert.yaml
@@ -7,7 +7,8 @@ spec:
   homepage: https://github.com/lmolas/kubectl-view-cert
   shortDescription: View certificate information stored in secrets
   description: |
-    View certificate information stored in secrets.
+    View certificate information (version, serial number, issuer, subject 
+    and validity) stored in secrets. 
     Supported secret types are kubernetes.io/tls. But you can parse any
     type of secret by specifying secret name and secret key to read.
   platforms:

--- a/plugins/view-cert.yaml
+++ b/plugins/view-cert.yaml
@@ -7,8 +7,9 @@ spec:
   homepage: https://github.com/lmolas/kubectl-view-cert
   shortDescription: View certificate information stored in secrets
   description: |
-    kubectl krew plugin to view certificate information stored in secrets.
-    Supported secret types are kubernetes.io/tls. But you can parse any type of secret by specifying secret name and secret key to read.
+    View certificate information stored in secrets.
+    Supported secret types are kubernetes.io/tls. But you can parse any
+    type of secret by specifying secret name and secret key to read.
   platforms:
   - selector:
       matchLabels:

--- a/plugins/view-cert.yaml
+++ b/plugins/view-cert.yaml
@@ -1,0 +1,52 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: view-cert
+spec:
+  version: v0.0.2
+  homepage: https://github.com/lmolas/kubectl-view-cert
+  shortDescription: View certificate information stored in secrets
+  description: |
+    kubectl krew plugin to view certificate information stored in secrets.
+    Supported secret types are kubernetes.io/tls. But you can parse any type of secret by specifying secret name and secret key to read.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_darwin_amd64.tar.gz
+    sha256: c16a91aa3b8a8c88a712b7a7e38c94f362cb5ab59b1ab6111eff186ad634ac93
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-view-cert
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_linux_amd64.tar.gz
+    sha256: 740bed25f0cab34a365f1b62923b8cb6637aa7b823156abe54e07dce193dc894
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-view-cert
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_linux_arm64.tar.gz
+    sha256: 023a2d2b55019de98bbfcc3e1e1d8fb8c2b2678cf093a2024dcc6e9fec05408f
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-view-cert
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_windows_amd64.tar.gz
+    sha256: 339fe5f2a4e7f500b9091f36d30345064c955ffbda67af04a984b2fdf9164de0
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-view-cert.exe

--- a/plugins/view-cert.yaml
+++ b/plugins/view-cert.yaml
@@ -18,9 +18,6 @@ spec:
         arch: amd64
     uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_darwin_amd64.tar.gz
     sha256: c16a91aa3b8a8c88a712b7a7e38c94f362cb5ab59b1ab6111eff186ad634ac93
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-view-cert
   - selector:
       matchLabels:
@@ -28,9 +25,6 @@ spec:
         arch: amd64
     uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_linux_amd64.tar.gz
     sha256: 740bed25f0cab34a365f1b62923b8cb6637aa7b823156abe54e07dce193dc894
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-view-cert
   - selector:
       matchLabels:
@@ -38,9 +32,6 @@ spec:
         arch: arm64
     uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_linux_arm64.tar.gz
     sha256: 023a2d2b55019de98bbfcc3e1e1d8fb8c2b2678cf093a2024dcc6e9fec05408f
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-view-cert
   - selector:
       matchLabels:
@@ -48,7 +39,4 @@ spec:
         arch: amd64
     uri: https://github.com/lmolas/kubectl-view-cert/releases/download/v0.0.2/kubectl-view-cert_v0.0.2_windows_amd64.tar.gz
     sha256: 339fe5f2a4e7f500b9091f36d30345064c955ffbda67af04a984b2fdf9164de0
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-view-cert.exe


### PR DESCRIPTION
As explained in README and the plugin description, this plugin aims at reading certificate informations stored in secrets.

As I'm submitting a new plugin, I confirm that i have read the following topics:

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/

- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

Thanks for the good work with krew plugins.