### PR TITLE
Update tree manifest (remove defaults)

### DIFF
--- a/plugins/tree.yaml
+++ b/plugins/tree.yaml
@@ -21,9 +21,6 @@ spec:
         arch: amd64
     uri: https://github.com/ahmetb/kubectl-tree/releases/download/v0.4.0/kubectl-tree_v0.4.0_darwin_amd64.tar.gz
     sha256: c90dd260212b7da7163f12a27269923dedaeb17667616d990aa7ddbee31d2364
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-tree
   - selector:
       matchLabels:
@@ -31,9 +28,6 @@ spec:
         arch: amd64
     uri: https://github.com/ahmetb/kubectl-tree/releases/download/v0.4.0/kubectl-tree_v0.4.0_linux_amd64.tar.gz
     sha256: 3253a981099abceb41f2ea32c89489fd1ba459d950becef2e302f79a8b2f0507
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-tree
   - selector:
       matchLabels:
@@ -41,7 +35,4 @@ spec:
         arch: amd64
     uri: https://github.com/ahmetb/kubectl-tree/releases/download/v0.4.0/kubectl-tree_v0.4.0_windows_amd64.tar.gz
     sha256: 8fe0fefe22816c3c34116f7b2e236bc351db053a839f7e2f396c7eaaf88e612c
-    files:
-    - from: "*"
-      to: "."
     bin: kubectl-tree.exe


### PR DESCRIPTION
This manifest was used as an example in
https://krew.sigs.k8s.io/docs/developer-guide/example-manifests/
and is likely the leading cause why people still develop new
plugin manifests with `files:[{from: *, to: .]` mode.

/assign @corneliusweig