### PR TITLE
Bump the version of open-svc to v2.4.2

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: open-svc
 spec:
   platforms:
-  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.1/kubectl-open_svc-darwin-amd64.zip"
-    sha256: "61c1a01630a601c003fd8fb3c57bb1bb9d148814488c4e4bb91461d1468bf31b"
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.2/kubectl-open_svc-darwin-amd64.zip
+    sha256: a46d1b01a63b31b41b3fba5f8fda1d542f33c562f6fc0716eb4f612f51136b18
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.1/kubectl-open_svc-linux-amd64.zip"
-    sha256: "0b91cbdb3a5860b510c1cc2838eaea19a83c327be1a182d68541084fb86793ac"
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.2/kubectl-open_svc-linux-amd64.zip
+    sha256: 5c633b772a639cd5f3e372d2bcb0bc0f24e6b512764eefdaf9ba19927536658e
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: "https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.1/kubectl-open_svc-windows-amd64.zip"
-    sha256: "a4991b89971570f44e863eb1aecd1556ed6c8eb77ec79812318187b788422028"
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.2/kubectl-open_svc-windows-amd64.zip
+    sha256: aa7ac49d2cc24e85a4636d464b4662f8e6fe6d0ce7d92439da2aa7113e422995
     bin: kubectl-open_svc.exe
     files:
     - from: kubectl-open_svc.exe
@@ -40,7 +40,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.4.1"
+  version: "v2.4.2"
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser.


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR bumps the version of open-svc to v2.4.2.
