### PR TITLE
Bump the version of sort-manifests to v0.4.1

### DIFF
--- a/plugins/sort-manifests.yaml
+++ b/plugins/sort-manifests.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: sort-manifests
 spec:
-  version: v0.4.0
+  version: v0.4.1
   shortDescription: Sort manifest files in a proper order by Kind
   description: |
     When installing manifests, they should be sorted in a proper order by Kind.
@@ -14,8 +14,8 @@ spec:
     using tiller.SortByKind() in Kubernetes Helm.
   homepage: https://github.com/superbrothers/ksort
   platforms:
-  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.0/ksort-darwin-amd64.zip
-    sha256: 7e794656a28b5c684a7b8c83a6f241aa01caa792c2542cab35edbdd02908f9ef
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.1/ksort-darwin-amd64.zip
+    sha256: a79e1f6a7eebf2cd081732a1ef3bb5fa1722a20286259460be2bb9c89309c86b
     bin: ksort
     files:
     - from: ksort
@@ -26,8 +26,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.0/ksort-linux-amd64.zip
-    sha256: 3ff26e30b1cf457c9f0d9be8acf62af4b7c1c104bcfe6427f06f524b84bd05a2
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.1/ksort-linux-amd64.zip
+    sha256: 2854bfade8c37eded4fcabe576e1b15e58a46d794f037da67c502c233a97ecd9
     bin: ksort
     files:
     - from: ksort
@@ -37,4 +37,16 @@ spec:
     selector:
       matchLabels:
         os: linux
+        arch: amd64
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.1/ksort-windows-amd64.zip
+    sha256: f50dc818f9f91c72e0a46f989c8284c5ee427ea84ed9c22eebaaa0cc4c296db0
+    bin: ksort.exe
+    files:
+    - from: ksort.exe
+      to: .
+    - from: LICENSE.txt
+      to: .
+    selector:
+      matchLabels:
+        os: windows
         arch: amd64


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR bumps the version of sort-manifests to v0.4.1. The addition, on this version, this plugin added windows support.