### PR TITLE
Bump rabbitmq

### DIFF
--- a/plugins/rabbitmq.yaml
+++ b/plugins/rabbitmq.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   homepage: https://github.com/rabbitmq/cluster-operator
   shortDescription: Manage RabbitMQ clusters
-  version: v0.48.0
+  version: v0.49.0
   description: |
     A plugin providing utilities to operate RabbitMQ clusters deployed
     by the RabbitMQ cluster operator.
@@ -20,8 +20,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/rabbitmq/cluster-operator/archive/0.48.0.tar.gz
-    sha256: 82d09f2bd1a6744549b871e9823b7008f40eca9d7e6c0fd16d028f2ea520c0a9
+    uri: https://github.com/rabbitmq/cluster-operator/archive/0.49.0.tar.gz
+    sha256: 06710e88996f2270b58b1c5cbd9fe236ea6ab46c1b663085fee66497e3c5a51a
     bin: kubectl-rabbitmq
     files:
     - from: cluster-operator-*/bin/kubectl-rabbitmq


### PR DESCRIPTION
This bump is manually because our GitHub action failed.
This is fixed by https://github.com/rabbitmq/cluster-operator/pull/460.
Next bump will be automated.


