### PR TITLE
bump fuzzy to v1.8.1

### DIFF
--- a/plugins/fuzzy.yaml
+++ b/plugins/fuzzy.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fuzzy
 spec:
   platforms:
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.0/kubectl-fuzzy_1.8.0_darwin_amd64.tar.gz"
-    sha256: "ab5f3a13f784e92680f8091f7c6f853337fb758f3af0d3f3444e3698ca6a1fd7"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_darwin_amd64.tar.gz"
+    sha256: "9fdd553ec742366a3bc780cf04b6534a2277ad66f3cf180f03775a79c8340181"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.0/kubectl-fuzzy_1.8.0_linux_amd64.tar.gz"
-    sha256: "a8d9e47c648bd5b3faccd45e299c8564a7ed07860f5bc46bbe3b0303dfab5d5a"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_linux_amd64.tar.gz"
+    sha256: "b513d93a9335f3fcb6929aa4058e985837a9e2cb3af1969799d21c563086671d"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -28,8 +28,20 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.0/kubectl-fuzzy_1.8.0_windows_amd64.tar.gz"
-    sha256: "8a8d52362967fd57f1b768e61999f2b7f56e47ec653424867a666c75039cb190"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_linux_arm64.tar.gz"
+    sha256: "100bebe9b56b187846a52e7bafdff5bdf4c170ea89175cec6215e516e907d9c8"
+    bin: kubectl-fuzzy
+    files:
+    - from: kubectl-fuzzy
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_windows_amd64.tar.gz"
+    sha256: "8001ed2833e63a08b20526fdc687383e6d516cf7cee70f66c81822a3685f8664"
     bin: kubectl-fuzzy.exe
     files:
     - from: kubectl-fuzzy.exe
@@ -40,7 +52,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v1.8.0"
+  version: "v1.8.1"
   shortDescription: Fuzzy and partial string search for kubectl
   description: |
     This tool uses fzf(1)-like fuzzy-finder to do partial or fuzzy search of Kubernetes resources.


### PR DESCRIPTION
Added ARM builds binary support.

https://github.com/d-kuro/kubectl-fuzzy/releases/tag/v1.8.1

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
