### PR TITLE
Add kubectl applythis plugin

### DIFF
--- a/plugins/applythis.yaml
+++ b/plugins/applythis.yaml
@@ -1,0 +1,25 @@
+
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: applythis
+spec:
+  homepage: https://github.com/turkenh/kubectl-applythis
+  shortDescription: Directly create/apply yaml files without writing into file.
+  version: v0.1.0
+  description: |
+    A simple kubectl plugin that allows to create/apply Kubernetes resources directly from editor.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/turkenh/kubectl-applythis/releases/download/v0.1.0/kubectl-applythis-v0.1.0.tar.gz
+    sha256: 1429a90224b435e7185804022d1840c0ce72c05bacedf162982059b2ff7440d4
+    bin: kubectl-applythis/applythis
+    files:
+    - from: '*'
+      to: .


### PR DESCRIPTION
A simple kubectl plugin that allows to create/apply Kubernetes resources directly from editor.

More details:

https://github.com/turkenh/kubectl-applythis/blob/main/README.md

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
