### PR TITLE
Fix kubectl-virt-plugin homepage

### DIFF
--- a/plugins/virt.yaml
+++ b/plugins/virt.yaml
@@ -42,7 +42,7 @@ spec:
           to: .
       bin: "virtctl.exe"
   shortDescription: Control KubeVirt virtual machines using virtctl
-  homepage: https://kubevirt.io
+  homepage: https://github.com/kubevirt/kubectl-virt-plugin
   caveats: |
     virt plugin is a wrapper for virtctl originating from the KubeVirt project. In order to use virtctl you will
     need to have KubeVirt installed on your Kubernetes cluster to use it. See https://kubevirt.io/ for details


### PR DESCRIPTION
Fix kubectl-virt-plugin homepage URL to get rid of error ["expected status code 200 got 500. body: opening pr: failed when validating ownership with error: plugin homepage https://kubevirt.io does not have prefix https://github.com/kubevirt/"](https://github.com/kubevirt/kubectl-virt-plugin/runs/1577361409?check_suite_focus=true#step:4:11)

Closes rajatjindal/krew-release-bot#50