### PR TITLE
add janitor plugin v0.1.0

### DIFF
--- a/plugins/janitor.yaml
+++ b/plugins/janitor.yaml
@@ -1,0 +1,34 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: janitor
+spec:
+  version: v0.1.0
+  homepage: https://github.com/dastergon/kubectl-janitor
+  shortDescription: Find objects in a problematic state
+  description: |
+    This plugin assists in finding
+    Kubernetes objects in a problematic state.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/dastergon/kubectl-janitor/releases/download/v0.1.0/kubectl-janitor_v0.1.0_darwin_amd64.tar.gz
+    sha256: b991c1c80c58c4563b5718babb8345ac9d7bfe98e08dcbf633a7a7882f447826
+    bin: kubectl-janitor
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/dastergon/kubectl-janitor/releases/download/v0.1.0/kubectl-janitor_v0.1.0_linux_amd64.tar.gz
+    sha256: a2d1d34e4173569cff0b6804c93376c535e9a33e939e44b8da3111d48eb3a6ab
+    bin: kubectl-janitor
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/dastergon/kubectl-janitor/releases/download/v0.1.0/kubectl-janitor_v0.1.0_windows_amd64.tar.gz
+    sha256: 3de3f8c66e38e41629ecd776e52d5e614bfc00874454c793d5b5c9ed00bb3e87
+    bin: kubectl-janitor.exe
+

--- a/plugins/janitor.yaml
+++ b/plugins/janitor.yaml
@@ -7,8 +7,14 @@ spec:
   homepage: https://github.com/dastergon/kubectl-janitor
   shortDescription: Lists objects in a problematic state
   description: |
-    This plugin assists in finding
-    Kubernetes objects in a problematic state.
+    Troubleshooting Kubernetes clusters sometimes requires
+    a combination of kubectl commands and other command-line tools
+    such as jq to do correlations around the issues that the various
+    objects might have. Moreover, sometimes the supported options
+    of the --field-selector flag might be limited as well.
+    This plugin assists in finding Kubernetes objects in a problematic state.
+    It currently supports Job, Pod, PersistentVolume,
+    and PersistentVolumeClaim resources.
   platforms:
   - selector:
       matchLabels:

--- a/plugins/janitor.yaml
+++ b/plugins/janitor.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.1.0
   homepage: https://github.com/dastergon/kubectl-janitor
-  shortDescription: Find objects in a problematic state
+  shortDescription: Lists objects in a problematic state
   description: |
     This plugin assists in finding
     Kubernetes objects in a problematic state.
@@ -31,4 +31,3 @@ spec:
     uri: https://github.com/dastergon/kubectl-janitor/releases/download/v0.1.0/kubectl-janitor_v0.1.0_windows_amd64.tar.gz
     sha256: 3de3f8c66e38e41629ecd776e52d5e614bfc00874454c793d5b5c9ed00bb3e87
     bin: kubectl-janitor.exe
-


### PR DESCRIPTION
This PR introduces the `janitor` plugin. A `kubectl` plugin to assist in finding Kubernetes objects in a problematic state.

## Actions taken
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
- [x] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/

PTAL
