### PR TITLE
add kubectl-skew plugin

### DIFF
--- a/plugins/skew.yaml
+++ b/plugins/skew.yaml
@@ -7,9 +7,10 @@ spec:
   homepage: https://github.com/dty1er/kubectl-skew
   shortDescription: Find if your cluster/kubectl version is skewed
   description: |
-      "kubectl skew" shows if your kubernetes cluster of kubectl follows
-      the kubernetes official version skew policy. If your usage is "skewed",
-      a warning message is shown.
+      This plugin checks if your kubernetes cluster or kubectl follows
+      the kubernetes official version skew policy.
+      https://kubernetes.io/docs/setup/release/version-skew-policy/
+      If your usage is "skewed", a warning message is shown.
   platforms:
   - selector:
       matchLabels:

--- a/plugins/skew.yaml
+++ b/plugins/skew.yaml
@@ -11,8 +11,6 @@ spec:
       the kubernetes official version skew policy. If your usage is "skewed",
       a warning message is shown.
   platforms:
-
-  # linux
   - selector:
       matchLabels:
         os: linux
@@ -20,8 +18,6 @@ spec:
     uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Linux_x86_64.tar.gz
     sha256: 9e325ee7011f157ce071c9c2a5253ad03a9163aea72d7c8d40c298fda1bf3ec8
     bin: kubectl-skew
-
-  # darwin
   - selector:
       matchLabels:
         os: darwin
@@ -29,8 +25,6 @@ spec:
     uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Darwin_x86_64.tar.gz
     sha256: 4ab9399734bc3fe7a29776d37d587c6d72c8f0b5d1b43ce1bd6b406ca34408a7
     bin: kubectl-skew
-
-  # windows
   - selector:
       matchLabels:
         os: windows

--- a/plugins/skew.yaml
+++ b/plugins/skew.yaml
@@ -1,0 +1,51 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: skew
+spec:
+  version: v0.0.3
+  homepage: https://github.com/dty1er/kubectl-skew
+  shortDescription: Show if your kubernetes cluster/kubectl is skewed
+  description: |
+      "kubectl skew" shows if your kubernetes cluster of kubectl follows
+      the kubernetes official version skew policy.
+  platforms:
+
+  # linux
+  - selector:
+    matchLabels:
+      os: linux
+    uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Linux_x86_64.tar.gz
+    sha256: 9e325ee7011f157ce071c9c2a5253ad03a9163aea72d7c8d40c298fda1bf3ec8
+    bin: kubectl-skew
+    files:
+    - from: kubectl-skew
+      to: .
+    - from: LICENSE
+      to: .
+
+  # darwin
+  - selector:
+    matchLabels:
+      os: darwin
+    uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Darwin_x86_64.tar.gz
+    sha256: 4ab9399734bc3fe7a29776d37d587c6d72c8f0b5d1b43ce1bd6b406ca34408a7
+    bin: kubectl-skew
+    files:
+    - from: kubectl-skew
+      to: .
+    - from: LICENSE
+      to: .
+
+  # windows
+  - selector:
+    matchLabels:
+      os: windows
+    uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Windows_x86_64.zip
+    sha256: 96aeea0151aea36c3a405bb5ab122f5a3534a92faa5c03a5d4317ae0ca1f6740
+    bin: kubectl-skew.exe
+    files:
+    - from: kubectl-skew.exe
+      to: .
+    - from: LICENSE
+      to: .

--- a/plugins/skew.yaml
+++ b/plugins/skew.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.0.3
   homepage: https://github.com/dty1er/kubectl-skew
-  shortDescription: Show if your kubernetes cluster/kubectl is skewed
+  shortDescription: Find if your cluster/kubectl version is skewed
   description: |
       "kubectl skew" shows if your kubernetes cluster of kubectl follows
       the kubernetes official version skew policy. If your usage is "skewed",

--- a/plugins/skew.yaml
+++ b/plugins/skew.yaml
@@ -8,44 +8,33 @@ spec:
   shortDescription: Show if your kubernetes cluster/kubectl is skewed
   description: |
       "kubectl skew" shows if your kubernetes cluster of kubectl follows
-      the kubernetes official version skew policy.
+      the kubernetes official version skew policy. If your usage is "skewed",
+      a warning message is shown.
   platforms:
 
   # linux
   - selector:
-    matchLabels:
-      os: linux
+      matchLabels:
+        os: linux
+        arch: amd64
     uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Linux_x86_64.tar.gz
     sha256: 9e325ee7011f157ce071c9c2a5253ad03a9163aea72d7c8d40c298fda1bf3ec8
     bin: kubectl-skew
-    files:
-    - from: kubectl-skew
-      to: .
-    - from: LICENSE
-      to: .
 
   # darwin
   - selector:
-    matchLabels:
-      os: darwin
+      matchLabels:
+        os: darwin
+        arch: amd64
     uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Darwin_x86_64.tar.gz
     sha256: 4ab9399734bc3fe7a29776d37d587c6d72c8f0b5d1b43ce1bd6b406ca34408a7
     bin: kubectl-skew
-    files:
-    - from: kubectl-skew
-      to: .
-    - from: LICENSE
-      to: .
 
   # windows
   - selector:
-    matchLabels:
-      os: windows
+      matchLabels:
+        os: windows
+        arch: amd64
     uri: https://github.com/dty1er/kubectl-skew/releases/download/v0.0.3/kubectl-skew_0.0.3_Windows_x86_64.zip
     sha256: 96aeea0151aea36c3a405bb5ab122f5a3534a92faa5c03a5d4317ae0ca1f6740
     bin: kubectl-skew.exe
-    files:
-    - from: kubectl-skew.exe
-      to: .
-    - from: LICENSE
-      to: .


### PR DESCRIPTION
I want to introduce a new kubectl plugin "kubectl-skew" (https://github.com/dty1er/kubectl-skew).
This is a simple plugin to show if the user's kubernets cluster/kubectl version is "skewed" (= not following [Kubernetes version skew policy](https://kubernetes.io/docs/setup/release/version-skew-policy/)).

Some kubernetes users (especially beginners) get confused by `kubectl` or `kubernetes` behavior which looks weird. They might be a actual bug, but some of them are caused by their version. Because kubernetes development is fast, sometimes using inappropriate version causes such confusion. 

What I want to do are:
* Help people to be aware of "version skew policy" (I've found some people even don't know it)
* Help people to understand if they are "skewed" or not easily
 
I believe this plugin is useful for such situation and be worth to be indexed in krew central repository.


---

* The result of `kubectl krew install` on my laptop
```
~/repos/src/github.com/dty1er/krew-index add-skew $ kubectl krew install --manifest=./plugins/skew.yaml --archive=./tmp/kubectl-skew_0.0.3_Linux_x86_64.tar.gz
Installing plugin: skew
Installed plugin: skew
\
 | Use this plugin:
 |      kubectl skew
 | Documentation:
 |      https://github.com/dty1er/kubectl-skew
/
```