### PR TITLE
Revert "Remove tee line that's causing errors in ci"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,6 @@ jobs:
         set -euo pipefail
         export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
         git diff --name-only --diff-filter=AM origin/${GITHUB_BASE_REF} ${{ github.sha }} -- plugins/ |
+          tee /dev/stderr |
           xargs -I _ $HOME/bin/validate-krew-manifest -manifest _
+


### PR DESCRIPTION
Reverts kubernetes-sigs/krew-index#993

This should be fixed now (https://github.com/actions/runner/issues/927#issuecomment-765696055). I guess we didn't need this change after all 😆, super quick turnaround by the github actions team.