### PR TITLE
New plugin - socks5-proxy

### DIFF
--- a/plugins/socks5-proxy.yaml
+++ b/plugins/socks5-proxy.yaml
@@ -9,21 +9,20 @@ spec:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/yokawasa/kubectl-plugin-socks5-proxy/archive/v1.0.0.zip
-    sha256: b8d96ab7b7d2ba23d973eeb3a22080829073ae79f8cad5966740fc1ceaf766d3
+    uri: https://github.com/yokawasa/kubectl-plugin-socks5-proxy/archive/v1.0.1.zip
+    sha256: 507a4fe885cecbf7f3d9f2eddd097588dce08252b11fe4106d24bd3880cdca62
     files:
     - from: "./*/kubectl-socks5-proxy"
       to: .
     - from: "./*/LICENSE"
       to: .
     bin: "./kubectl-socks5-proxy"
-  shortDescription: A kubectl plugin that creates a local SOCKS5 proxy through which you can access to Services or Pods in a Kubernetes cluster.
+  shortDescription: SOCKS5 proxy to Services or Pods in the cluster
   description: |
     A kubectl plugin that creates a local SOCKS5 proxy through which you can
     access to Services or Pods in a Kubernetes cluster.
     
-    What the plugin actually does is that it create a SOCKS proxy server Pod 
-    in a Kubernetes cluster and forwards a local port (default:1080) to the proxy.
+    What the plugin actually does is that it create a SOCKS proxy server Pod (based on serjs/go-socks5-proxy) in a Kubernetes cluster and forwards a local port (default:1080) to the proxy.
     So you can access to Servcies or Pods in Kuberenetes cluster by using the local 
     port as SOCKS5 proxy like this:
 

--- a/plugins/socks5-proxy.yaml
+++ b/plugins/socks5-proxy.yaml
@@ -1,0 +1,30 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: socks5-proxy
+spec:
+  version: "v1.0.0"
+  homepage: https://github.com/yokawasa/kubectl-plugin-socks5-proxy
+  platforms:
+  - selector:
+      matchExpressions:
+      - {key: os, operator: In, values: [darwin, linux]}
+    uri: https://github.com/yokawasa/kubectl-plugin-socks5-proxy/archive/v1.0.0.zip
+    sha256: b8d96ab7b7d2ba23d973eeb3a22080829073ae79f8cad5966740fc1ceaf766d3
+    files:
+    - from: "./*/kubectl-socks5-proxy"
+      to: .
+    - from: "./*/LICENSE"
+      to: .
+    bin: "./kubectl-socks5-proxy"
+  shortDescription: A kubectl plugin that creates a local SOCKS5 proxy through which you can access to Services or Pods in a Kubernetes cluster.
+  description: |
+    A kubectl plugin that creates a local SOCKS5 proxy through which you can
+    access to Services or Pods in a Kubernetes cluster.
+    
+    What the plugin actually does is that it create a SOCKS proxy server Pod 
+    in a Kubernetes cluster and forwards a local port (default:1080) to the proxy.
+    So you can access to Servcies or Pods in Kuberenetes cluster by using the local 
+    port as SOCKS5 proxy like this:
+
+    curl --socks5-hostname localhost:1080 http://httpbin.default.svc.cluster.local/header

--- a/plugins/socks5-proxy.yaml
+++ b/plugins/socks5-proxy.yaml
@@ -22,8 +22,9 @@ spec:
     A kubectl plugin that creates a local SOCKS5 proxy through which you can
     access to Services or Pods in a Kubernetes cluster.
     
-    What the plugin actually does is that it create a SOCKS5 proxy server Pod (based on serjs/go-socks5-proxy) in a Kubernetes cluster and forwards a local port (default:1080) to the proxy.
-    So you can access to Servcies or Pods in Kuberenetes cluster by using the local 
-    port as SOCKS5 proxy like this:
+    What the plugin actually does is that it create a SOCKS5 proxy server Pod
+    (based on serjs/go-socks5-proxy) in a Kubernetes cluster and forwards a local
+    port (default:1080) to the proxy. So you can access Services or Pods in the
+    Kuberenetes cluster by using the local port as SOCKS5 proxy like this:
 
     curl --socks5-hostname localhost:1080 http://httpbin.default.svc.cluster.local/header

--- a/plugins/socks5-proxy.yaml
+++ b/plugins/socks5-proxy.yaml
@@ -22,7 +22,7 @@ spec:
     A kubectl plugin that creates a local SOCKS5 proxy through which you can
     access to Services or Pods in a Kubernetes cluster.
     
-    What the plugin actually does is that it create a SOCKS proxy server Pod (based on serjs/go-socks5-proxy) in a Kubernetes cluster and forwards a local port (default:1080) to the proxy.
+    What the plugin actually does is that it create a SOCKS5 proxy server Pod (based on serjs/go-socks5-proxy) in a Kubernetes cluster and forwards a local port (default:1080) to the proxy.
     So you can access to Servcies or Pods in Kuberenetes cluster by using the local 
     port as SOCKS5 proxy like this:
 


### PR DESCRIPTION
Adds [socks5-proxy](https://github.com/yokawasa/kubectl-plugin-socks5-proxy) plugin
-----
- [x] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]