### PR TITLE
Add kubeSize (capacity) as a plugin for krew to install

### DIFF
--- a/plugins/capacity.yaml
+++ b/plugins/capacity.yaml
@@ -1,0 +1,33 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: capacity
+spec:
+  version: "v0.1.2"
+  homepage: https://github.com/akrzos/kubeSize
+  shortDescription: "Get cluster size and capacity"
+  description: |
+    Show counts of nodes and pods. Aggregates max-pod, cpu, and memory capacity.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/akrzos/kubeSize/releases/download/v0.1.2/kubeSize_0.1.2_macOS_x86_64.tar.gz
+    sha256: afb8853d1113f80343bc35aea99637a851e99dda121fb45ad351c5d1040dee5b
+    bin: kubectl-capacity
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/akrzos/kubeSize/releases/download/v0.1.2/kubeSize_0.1.2_Linux_x86_64.tar.gz
+    sha256: d1e680f66c66ca7f9664bf2efcdcdf4e9580b565de45152c2cba2f208b457df6
+    bin: kubectl-capacity
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/akrzos/kubeSize/releases/download/v0.1.2/kubeSize_0.1.2_Windows_x86_64.tar.gz
+    sha256: 743c86196b826e63cdc44bd05709ba93538637b0a5698ca481bdcc90bf8daaae
+    bin: kubectl-capacity.exe
+


### PR DESCRIPTION
Add [kubeSize](https://github.com/akrzos/kubeSize) a kubectl capacity and sizing tool.

- [x] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

Output from test install:
```
$ kubectl krew install --manifest=deploy/krew/capacity.yml
Installing plugin: capacity
Installed plugin: capacity
\
 | Use this plugin:
 | 	kubectl capacity
 | Documentation:
 | 	https://github.com/akrzos/kubeSize
/
$ kubectl capacity c
NODES                     PODS                                      CPU (cores)                                   MEMORY (GiB)
Total Ready Unready Unsch Capacity Allocatable Total Non-Term Avail Capacity    Allocatable Requests Limits Avail Capacity     Allocatable Requests Limits Avail
1     1     0       0     110      110         9     9        101   4.0         4.0         0.8      0.1    3.1   1.9          1.9         0.2      0.4    1.8
```
