### PR TITLE
azad-proxy: Update homepage to correct casing

### DIFF
--- a/plugins/azad-proxy.yaml
+++ b/plugins/azad-proxy.yaml
@@ -41,10 +41,10 @@ spec:
         os: windows
         arch: amd64
   version: "v0.0.3"
-  homepage: https://github.com/xenitab/azad-kube-proxy
+  homepage: https://github.com/XenitAB/azad-kube-proxy
   caveats: |
     This plugin is used in combination with the azad-kube-proxy:
-    - https://github.com/xenitab/azad-kube-proxy
+    - https://github.com/XenitAB/azad-kube-proxy
 
     There shouldn't be a use case where you can use the plugin without the proxy.
     If you haven't been asked by a cluster admin to install this plugin - it may


### PR DESCRIPTION
The homepage is required to be in the correct casing (`XenitAB` instead of `xenitab` as it is right now) to get automatic releases to work:
https://github.com/rajatjindal/krew-release-bot/blob/0846c787e0279b71f45d94c5b2c8e4cddb59afe9/pkg/krew/validations.go#L23-L25