### PR TITLE
Add artifacthub-repo.yml for ownership claim

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,3 @@
+owners:
+  - name: chriskim06
+    email: chriskim06@gmail.com


### PR DESCRIPTION
I got added to the kubernetes-sigs AH org. Once this file is added I'll make the ownership claim there under that org. After that I'll submit a follow-up PR adding the AH repositoryID to this file.

Fixes #972 

/assign @ahmetb 
/assign @corneliusweig 
/cc @tegioz