### PR TITLE
Add new plugin kubectl-mc, a multi cluster kubectl client

### DIFF
--- a/plugins/mc.yaml
+++ b/plugins/mc.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: mc
 spec:
-  version: v0.4.0
+  version: v0.5.0
   homepage: https://github.com/jonnylangefeld/kubectl-mc
   shortDescription: Run kubectl commands against multiple clusters at once
   description: |+2
@@ -30,32 +30,35 @@ spec:
     # run a debug container on every kind cluster in the context
     mc --regex kind -- run debug --image=markeijsermans/debug --command -- sleep infinity
 
-    # list all contexts with 'dev' in the name, but not '-ci-' in the name
+    # list all contexts with 'dev' in the name, but not '-test-' in the name
     mc -r dev -l -n '-test-'
 
     # list all pods with label 'app.kubernetes.io/name=audit' in the 'default' namespace from all clusters with 'gke' in the name, but not 'dev'
     # run max 5 processes in parallel and enable debug output
     mc -r gke -n 'dev' -p 5 -d -- get pods -n gatekeeper-system -l app.kubernetes.io/name=audit
+
+    # print the context and the pod names in kube-system using jq
+    mc -r kind -o json -- get pods -n kube-system | jq 'keys[] as $k | "\($k) \(.[$k] | .items[].metadata.name)"'
   platforms:
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.4.0/kubectl-mc_v0.4.0_darwin_amd64.tar.gz
-    sha256: 541f8036a60ae620e5e1c0bfb47937d546199c215ad5bfabece3dbc22fc75b52
+    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.5.0/kubectl-mc_v0.5.0_darwin_amd64.tar.gz
+    sha256: b059a56b9db41bbeaf5c40d83c2f73384b085ae94ec747c97f4d01dca4ce0f52
     bin: kubectl-mc
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.4.0/kubectl-mc_v0.4.0_linux_amd64.tar.gz
-    sha256: a207e37458136d6e1dccea98b40875204c9dcbc7e9f77e3592ff65f11769a2c2
+    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.5.0/kubectl-mc_v0.5.0_linux_amd64.tar.gz
+    sha256: 3fa3f94fd38cc6d112fe121e706e870ac39364ccf2d68bf1c8b79693f8012e12
     bin: kubectl-mc
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.4.0/kubectl-mc_v0.4.0_windows_amd64.tar.gz
-    sha256: 36b0b2287fbf767398ce12d19f1ef776614cdbd62b7094690954b99c1904079d
+    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.5.0/kubectl-mc_v0.5.0_windows_amd64.tar.gz
+    sha256: 4b4ae8aa68faf4268cc478869932492eebf56f9f619ace5feb88431c33ed1ef6
     bin: kubectl-mc.exe
 

--- a/plugins/mc.yaml
+++ b/plugins/mc.yaml
@@ -1,0 +1,61 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mc
+spec:
+  version: v0.4.0
+  homepage: https://github.com/jonnylangefeld/kubectl-mc
+  shortDescription: Run kubectl commands against multiple clusters at once
+  description: |+2
+    A Multi Cluster kubectl Client
+
+    If you work at a company or organization that maintains multiple Kubernetes
+    clusters it is fairly common to connect to multiple different kubernetes
+    clusters throughout your day. And sometimes you want to execute a command
+    against multiple clusters at once. For instance to get the status of a
+    deployment across all `staging` clusters.
+
+    `kubectl-mc` (short for multi cluster) supports this workflow and significantly
+    reduces the return time by executing the necessary API requests in parallel go
+    routines.
+
+    Examples:
+
+    # list all kind contexts
+    mc -r kind -l
+
+    # list the pods in the kube-system namespace of all dev clusters
+    mc -r dev -- get pods -n kube-system
+
+    # run a debug container on every kind cluster in the context
+    mc --regex kind -- run debug --image=markeijsermans/debug --command -- sleep infinity
+
+    # list all contexts with 'dev' in the name, but not '-ci-' in the name
+    mc -r dev -l -n '-test-'
+
+    # list all pods with label 'app.kubernetes.io/name=audit' in the 'default' namespace from all clusters with 'gke' in the name, but not 'dev'
+    # run max 5 processes in parallel and enable debug output
+    mc -r gke -n 'dev' -p 5 -d -- get pods -n gatekeeper-system -l app.kubernetes.io/name=audit
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.4.0/kubectl-mc_v0.4.0_darwin_amd64.tar.gz
+    sha256: 541f8036a60ae620e5e1c0bfb47937d546199c215ad5bfabece3dbc22fc75b52
+    bin: kubectl-mc
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.4.0/kubectl-mc_v0.4.0_linux_amd64.tar.gz
+    sha256: a207e37458136d6e1dccea98b40875204c9dcbc7e9f77e3592ff65f11769a2c2
+    bin: kubectl-mc
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.4.0/kubectl-mc_v0.4.0_windows_amd64.tar.gz
+    sha256: 36b0b2287fbf767398ce12d19f1ef776614cdbd62b7094690954b99c1904079d
+    bin: kubectl-mc.exe
+

--- a/plugins/mc.yaml
+++ b/plugins/mc.yaml
@@ -10,9 +10,7 @@ spec:
     This plugin helps to work with multiple kubernetes clusters at once, filtered by
     a regular expression. For instance to get the status of a deployment across all
     `staging` clusters run the following command:
-    mc -r staging -- get deployments -n kube-system
-
-    For more examples run kubectl mc --help
+    kubectl mc -r staging -- get deployments -n kube-system
   platforms:
   - selector:
       matchLabels:

--- a/plugins/mc.yaml
+++ b/plugins/mc.yaml
@@ -7,38 +7,12 @@ spec:
   homepage: https://github.com/jonnylangefeld/kubectl-mc
   shortDescription: Run kubectl commands against multiple clusters at once
   description: |+2
-    A Multi Cluster kubectl Client
+    This plugin helps to work with multiple kubernetes clusters at once, filtered by
+    a regular expression. For instance to get the status of a deployment across all
+    `staging` clusters run the following command:
+    mc -r staging -- get deployments -n kube-system
 
-    If you work at a company or organization that maintains multiple Kubernetes
-    clusters it is fairly common to connect to multiple different kubernetes
-    clusters throughout your day. And sometimes you want to execute a command
-    against multiple clusters at once. For instance to get the status of a
-    deployment across all `staging` clusters.
-
-    `kubectl-mc` (short for multi cluster) supports this workflow and significantly
-    reduces the return time by executing the necessary API requests in parallel go
-    routines.
-
-    Examples:
-
-    # list all kind contexts
-    mc -r kind -l
-
-    # list the pods in the kube-system namespace of all dev clusters
-    mc -r dev -- get pods -n kube-system
-
-    # run a debug container on every kind cluster in the context
-    mc --regex kind -- run debug --image=markeijsermans/debug --command -- sleep infinity
-
-    # list all contexts with 'dev' in the name, but not '-test-' in the name
-    mc -r dev -l -n '-test-'
-
-    # list all pods with label 'app.kubernetes.io/name=audit' in the 'default' namespace from all clusters with 'gke' in the name, but not 'dev'
-    # run max 5 processes in parallel and enable debug output
-    mc -r gke -n 'dev' -p 5 -d -- get pods -n gatekeeper-system -l app.kubernetes.io/name=audit
-
-    # print the context and the pod names in kube-system using jq
-    mc -r kind -o json -- get pods -n kube-system | jq 'keys[] as $k | "\($k) \(.[$k] | .items[].metadata.name)"'
+    For more examples run kubectl mc --help
   platforms:
   - selector:
       matchLabels:
@@ -61,4 +35,3 @@ spec:
     uri: https://github.com/jonnylangefeld/kubectl-mc/releases/download/v0.5.0/kubectl-mc_v0.5.0_windows_amd64.tar.gz
     sha256: 4b4ae8aa68faf4268cc478869932492eebf56f9f619ace5feb88431c33ed1ef6
     bin: kubectl-mc.exe
-


### PR DESCRIPTION
# Multi Cluster `kubectl`
A new plugin to send kubectl commands to multiple contexts in your kubeconfig at once.
More info here: https://github.com/jonnylangefeld/kubectl-mc

Example usage:
```bash
$ kubectl mc -r kind -- get pods -n kube-system

kind-kind
---------
NAME                                         READY   STATUS    RESTARTS   AGE
coredns-f9fd979d6-q7gnm                      1/1     Running   0          99m
coredns-f9fd979d6-zd4jn                      1/1     Running   0          99m
etcd-kind-control-plane                      1/1     Running   0          99m
kindnet-8qd8p                                1/1     Running   0          99m
kube-apiserver-kind-control-plane            1/1     Running   0          99m
kube-controller-manager-kind-control-plane   1/1     Running   0          99m
kube-proxy-nb55k                             1/1     Running   0          99m
kube-scheduler-kind-control-plane            1/1     Running   0          99m

kind-another-kind-cluster
-------------------------
NAME                                                         READY   STATUS    RESTARTS   AGE
coredns-f9fd979d6-l2xdb                                      1/1     Running   0          91s
coredns-f9fd979d6-m99fx                                      1/1     Running   0          91s
etcd-another-kind-cluster-control-plane                      1/1     Running   0          92s
kindnet-jlrqg                                                1/1     Running   0          91s
kube-apiserver-another-kind-cluster-control-plane            1/1     Running   0          92s
kube-controller-manager-another-kind-cluster-control-plane   1/1     Running   0          92s
kube-proxy-kq2tr                                             1/1     Running   0          91s
kube-scheduler-another-kind-cluster-control-plane            1/1     Running   0          92s
```