### PR TITLE
new version v0.2.0 of operator

### DIFF
--- a/plugins/operator.yaml
+++ b/plugins/operator.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: operator
 spec:
-  version: v0.1.0
+  version: v0.2.0
   homepage: https://github.com/operator-framework/kubectl-operator
   shortDescription: Manage operators with Operator Lifecycle Manager
   description: |
@@ -23,28 +23,35 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.1.0/kubectl-operator_v0.1.0_darwin_amd64.tar.gz
-    sha256: d08895655f03f3f5ba374f40834ef37aa5f2022f2c6a52c99c4e6e78c65926d6
+    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.2.0/kubectl-operator_v0.2.0_darwin_amd64.tar.gz
+    sha256: 8d45859775b6076789aa332719325422cd78a9d3a1e3ba17215badc8c21c1ec6
+    bin: kubectl-operator
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.2.0/kubectl-operator_v0.2.0_darwin_arm64.tar.gz
+    sha256: 14a82841734593b09ca70f2cc8ae2067aac43fdfb893f4dc4bdf09692ada2bb6
     bin: kubectl-operator
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.1.0/kubectl-operator_v0.1.0_linux_amd64.tar.gz
-    sha256: 5d17c001841e55842be5f8bb1f0fd2d7a5b22a12cf8b8877c37b626480ed81f7
+    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.2.0/kubectl-operator_v0.2.0_linux_amd64.tar.gz
+    sha256: 8c77737cc2878284e4e5fbe26b1e0e53322fae380487524365eb99ef3be9bf91
     bin: kubectl-operator
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.1.0/kubectl-operator_v0.1.0_linux_arm64.tar.gz
-    sha256: 2eb6cfbb8dab6c0c136f858d3e6eaf393cf7588345b89fa12f0d6934cc2c532b
+    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.2.0/kubectl-operator_v0.2.0_linux_arm64.tar.gz
+    sha256: 9535e34fa7d9b56ebc4f7bfa5225733cca5106e2b58547583fafb39977aabce5
     bin: kubectl-operator
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.1.0/kubectl-operator_v0.1.0_windows_amd64.tar.gz
-    sha256: df9f7ecabc25a62691da9774d7538cbb8a99a123a314c47714fec3710aab8112
+    uri: https://github.com/operator-framework/kubectl-operator/releases/download/v0.2.0/kubectl-operator_v0.2.0_windows_amd64.tar.gz
+    sha256: a10d66ec50ab2a68ded6d61a5da7bb0a6858ec2481092025c86b566d2dd02baa
     bin: kubectl-operator.exe
 


### PR DESCRIPTION
Normal version bump, but this also adds platform support for darwin/arm64 for the `operator` plugin.