### PR TITLE
Bump auth-proxy to v1.1.1

### DIFF
--- a/plugins/auth-proxy.yaml
+++ b/plugins/auth-proxy.yaml
@@ -16,10 +16,10 @@ spec:
     You need to configure authentication in the kubeconfig.
     See https://github.com/int128/kauthproxy for more.
 
-  version: v1.1.0
+  version: v1.1.1
   platforms:
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.0/kauthproxy_linux_amd64.zip
-      sha256: "3d8024b232b660609de7ba3851915cdc4a33f479c89b347973c6406b0c7e0b98"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.1/kauthproxy_linux_amd64.zip
+      sha256: "331ff9ed096806181e7cb026b937107b10c1aaa9851df949f7a9c7b4a7f5a237"
       bin: kauthproxy
       files:
         - from: kauthproxy
@@ -30,8 +30,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.0/kauthproxy_darwin_amd64.zip
-      sha256: "628bfae223f47f94747a9dd1503298bd3d203bc4550e56a5dd0b16805f320641"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.1/kauthproxy_darwin_amd64.zip
+      sha256: "1153b327db7b4015e659102f7c16bd674b9ada2c0cb06423ea1b784ad623a8f8"
       bin: kauthproxy
       files:
         - from: kauthproxy
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.0/kauthproxy_windows_amd64.zip
-      sha256: "8fd3d97099f5d4ee9d51cdd1f2a0318d56fcaea040ca042b2cc4f22bedd6f7e5"
+    - uri: https://github.com/int128/kauthproxy/releases/download/v1.1.1/kauthproxy_windows_amd64.zip
+      sha256: "b742030a9403a8ff24bce69886244b3a47d1215a865b42e4653eb40ad5920e28"
       bin: kauthproxy.exe
       files:
         - from: kauthproxy.exe


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
