### PR TITLE
Update Reliably plugin homepage

### DIFF
--- a/plugins/reliably.yaml
+++ b/plugins/reliably.yaml
@@ -29,7 +29,7 @@ spec:
       to: "."
     - from: LICENSE
       to: .
-  homepage: https://reliably.com/docs
+  homepage:  https://github.com/reliablyhq/cli
   shortDescription: "Surfaces reliability issues in Kubernetes"
   description: |
     Surfaces reliability issues in your Kubernetes configuration,


### PR DESCRIPTION
This PR aims to update the Reliably plugin homepage in the manifest and change it to https://github.com/reliablyhq/cli

The current homepage (https://reliably.com/docs) prevents us from using [Krew Release Bot](https://github.com/rajatjindal/krew-release-bot).

Before submitting a PR, Krew Release Bot identifies the owner of the plugin by comparing the homepage in the manifest with the GitHub user of the repo in which it is run. [1]

Putting https://reliably.com/docs as the homepage was a suggestion by Ahmet [2], but I'm updating the CLI README so it makes better reference to the CLI usage as a Krew plugin.

[1] https://github.com/rajatjindal/krew-release-bot/blob/0846c787e0279b71f45d94c5b2c8e4cddb59afe9/pkg/krew/validations.go#L23
[2] https://github.com/kubernetes-sigs/krew-index/pull/1022#discussion_r577192409


Signed-off-by: Marc Perrien <marc@chaosiq.io>

