### PR TITLE
Add kubectl-assert plugin file

### DIFF
--- a/plugins/assert.yaml
+++ b/plugins/assert.yaml
@@ -1,0 +1,28 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: assert
+spec:
+  homepage: https://github.com/morningspace/kubeassert
+  shortDescription: "Assert Kubernetes resources"
+  version: "v0.2.0"
+  description: |
+    Provides a set of assertions that can be used to quickly 
+    assert Kubernetes resources from the command line against 
+    your working cluster.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/morningspace/kubeassert/archive/v0.2.0.tar.gz
+    sha256: a35b62a111212a74c954f2991fdfa7b4cad8e92b9318773f87c9ff8c12a5ea52
+    bin: kubectl-assert.sh
+    files:
+    - from: "/kubeassert-*/kubectl-assert.sh"
+      to: "."
+    - from: "/kubeassert-*/LICENSE"
+      to: "."


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Hi Team,

I'd like to raise the request to add kubectl-assert plugin to krew index. It is a kubectl plugin to assert Kubernetes resources. It can also work with [KUTTL](https://kuttl.dev/) to extend its test assert capability.

More details can be found from the online documentation: https://morningspace.github.io/kubeassert/docs/
The source code repo is: https://github.com/morningspace/kubeassert/

I've gone through the guidelines and verified the installation locally. Let me know if that makes sense and I'm happy to make any change per request.

Thanks in advance.
