### PR TITLE
add kubectl-smart

### DIFF
--- a/plugins/smart.yaml
+++ b/plugins/smart.yaml
@@ -1,0 +1,27 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: smart
+spec:
+  homepage: https://github.com/FingerLiu/kubectl-smart
+  shortDescription: A plugin that makes kubectl smart with name search.
+  version: v0.0.1
+  description: |
+      A kubectl plugin that makes kubectl smart with name search.Type less letters!Save more life!
+      Added grep support for most kubectl sub commands.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/FingerLiu/kubectl-smart/archive/0.0.3.tar.gz
+    sha256: 747897fcc67d3d05a1481215fec00884063fd20bfcdc796de3e7101fe1b960a0
+    bin: kubectl-smart
+    files:
+    - from: kubectl-smart-*/kubectl-smart
+      to: .
+    - from: kubectl-smart-*/LICENSE
+      to: .


### PR DESCRIPTION
Signed-off-by: FingerLiu <liupeng.dalian@gmail.com>
https://github.com/FingerLiu/kubectl-smart
A kubectl plugin that makes kubectl smart with name search.Type less letters!Save more life!
Added grep support for most kubectl sub commands.

> Installing plugin: smart
Installed plugin: smart
\
 | Use this plugin:
 | 	kubectl smart
 | Documentation:
 | 	https://github.com/FingerLiu/kubectl-smart
/
Make kubectl smart with name search.Type less letters!Save more life!
USAGE:
  smart sub_command [options...] [name_pattern...]
SUB_COMMAND:
  gp                        : shortcut for get pod
  l,logs                    : shortcut for logs
  e,exec                    : shortcut for exec
  edp                       : shortcut for edit pod
  ed,edit                   : shortcut for edit
  dp                        : shortcut for delete pod
  g                         : shortcut for get
  h,help                    : show this message
OPTIONS:
  -A                        : all-namespaces
  -n                        : namespace
  -w,--wide                 : TODO get with wide output
  -f,--follow               : follow log output
  --tail                    : tail logs
  -t                        : --tty=true: Stdin is a TTY
  -i                        : --stdin=true: Pass stdin to the container
  -c                        : TODO container name.
  -e                        : use exact match rather than grep. Only use this when you want to disable grep when grep return multi items.
Examples:
```
  # get pod with name contains my in namespace her-namespace
  # (kubectl get pod -n her-namespace-a |grep my)
  kubectl smart gp -n her.*a my

  # get log for pod with name my
  # (kubectl logs --tail 100 -f $(kubectl get pods | awk '/my/ {print $1;exit}'))
  kubectl smart l my

  # exec into pod
  # kubectl exec -ti my-pod-i3jx bash
  kubectl smart e my bash

  # get deploy with name contains my
  # (kubectl get deploy | grep my)
  kubectl smart g deploy my
```