### PR TITLE
Update pod-inspect to 0.1.8

### DIFF
--- a/plugins/pod-inspect.yaml
+++ b/plugins/pod-inspect.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: pod-inspect
 spec:
-  version: v0.1.7
+  version: v0.1.8
   homepage: https://github.com/jpriebe/kubectl-pod-inspect
   shortDescription: Get all of a pod's details at a glance
   description: |

--- a/plugins/pod-inspect.yaml
+++ b/plugins/pod-inspect.yaml
@@ -14,21 +14,21 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.7/kubectl-pod-inspect_0.1.7_Darwin_x86_64.tar.gz
-    sha256: ec62b259d971b63de10cb367ed4547374b1d5c908886f258663ff000c4338e4d
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.8/kubectl-pod-inspect_0.1.8_Darwin_x86_64.tar.gz
+    sha256: e9c0b34bcfc3f11036ba38913adfd928551299e324bacfb7176b4b397a059ed6
     bin: kubectl-pod_inspect
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.7/kubectl-pod-inspect_0.1.7_Linux_x86_64.tar.gz
-    sha256: f44ebb1e99109f88e9aee6c60749d78ecf6c6f6764f194d5e0082d8bca25503d
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.8/kubectl-pod-inspect_0.1.8_Linux_x86_64.tar.gz
+    sha256: 84f091b8a4b6c60cd6124980deb4a434c394ec76fc32f166c0a8f326f5f344f2  
     bin: kubectl-pod_inspect
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.7/kubectl-pod-inspect_0.1.7_Windows_x86_64.tar.gz
-    sha256: 1b9872c91d39bdba47b5c43ceccb0fdae39af3903336813cdc59974edfe6b324
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.8/kubectl-pod-inspect_0.1.8_Windows_x86_64.tar.gz
+    sha256: 9169738c72e4d73cfec11cae7792f7ac704c2c9f2ba5c5583ea21e92b74f8151
     bin: kubectl-pod_inspect.exe
 


### PR DESCRIPTION
Numerous improvements in handling pods of various states

- improved display of completed job containers:
  - show a check instead of an "x" in the Ready column
  - don't show PodCompleted conditions as "failed"
  - don't show logs for successfully completed containers

- now show a container that is waiting due to CrashLoopBackoff with an "x" instead of a "..." and show last terminated info (Error, ExitCode, and Time)

- handle container restarts better:
  - highlight the restart count in yellow
  - show last terminated info (Error, ExitCode, and Time)

- handle evicted pods better by detecting an empty ContainerStatuses slice; display Phase/Reason/Message
