### PR TITLE
add pod-viewer plugin

### DIFF
--- a/plugins/pod-viewer.yaml
+++ b/plugins/pod-viewer.yaml
@@ -25,4 +25,4 @@ spec:
     Usage:
       kubectl pod-viewer <pod-name> -n <namespace-name>
       This plugin provides you with a full view of kubernetes pod. This is particularly useful for debugging
-      Read more documentation at: https://github.com/HamzaZo/kubectl-pod-viewe
+      Read more documentation at: https://github.com/HamzaZo/kubectl-pod-viewer

--- a/plugins/pod-viewer.yaml
+++ b/plugins/pod-viewer.yaml
@@ -1,0 +1,28 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: pod-viewer
+spec:
+  version: v0.1.0
+  homepage: https://github.com/HamzaZo/kubectl-pod-viewer
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/HamzaZo/kubectl-pod-viewer/releases/download/v0.1.0/kubectl-pod-viewer_v0.1.0_darwin_amd64.tar.gz
+      sha256: 2cd54b8c84ad556363931d0c8163ae846e23473ad2a97e32ded216b61a4a1e46
+      bin: kubectl-pod-viewer
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/HamzaZo/kubectl-pod-viewer/releases/download/v0.1.0/kubectl-pod-viewer_v0.1.0_linux_amd64.tar.gz
+      sha256: c5d6a8961eaf4821bb031e2a12e38bb43f8eb5692c9e5b1026b5fafcae7eb32b
+      bin: kubectl-pod-viewer
+  shortDescription: A full view of kubernetes pods
+  description: |
+    Usage:
+      kubectl pod-viewer <pod-name> -n <namespace-name>
+      This plugin provides you with a full view of kubernetes pod. This is particularly useful for debugging
+      Read more documentation at: https://github.com/HamzaZo/kubectl-pod-viewe


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Adding a new plugin called `pod-viewer`
`pod-viewer` provides you with a full view of Kubernetes pod with information such as conditions, events, logs, etc.

