### PR TITLE
Add kubectl-cost plugin to krew index

### DIFF
--- a/plugins/cost.yaml
+++ b/plugins/cost.yaml
@@ -8,6 +8,13 @@ spec:
   description: |
     Uses Kubecost's API to gather and format cluster cost information broken
     down by various aggregations like namespace, deployment, and label.
+
+    Kubecost is a cluster-side daemon that tracks the real cost of Kubernetes
+    resources by combining resource utilization monitoring with your provider's
+    cost data. Website: https://www.kubecost.com/
+  caveats: |
+    Requires Kubecost (a cluster-side daemon) to be installed in your cluster.
+    See https://www.kubecost.com/install for installation instructions.
   homepage: https://github.com/kubecost/kubectl-cost
   platforms:
   - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.4/kubectl-cost-darwin-amd64.tar.gz

--- a/plugins/cost.yaml
+++ b/plugins/cost.yaml
@@ -11,7 +11,10 @@ spec:
 
     Kubecost is a cluster-side daemon that tracks the real cost of Kubernetes
     resources by combining resource utilization monitoring with your provider's
-    cost data. Website: https://www.kubecost.com/
+    cost data. Kubecost support GCP/GKE, AWS/EKS, Azure/AKS, and custom
+    (including on-prem) "providers" via user-specified pricing sheets.
+
+    Website: https://www.kubecost.com/
   caveats: |
     Requires Kubecost (a cluster-side daemon) to be installed in your cluster.
     See https://www.kubecost.com/install for installation instructions.

--- a/plugins/cost.yaml
+++ b/plugins/cost.yaml
@@ -3,15 +3,15 @@ kind: Plugin
 metadata:
   name: cost
 spec:
-  version: v0.1.3
+  version: v0.1.4
   shortDescription: View cluster cost information
   description: |
     Uses Kubecost's API to gather and format cluster cost information broken
     down by various aggregations like namespace, deployment, and label.
   homepage: https://github.com/kubecost/kubectl-cost
   platforms:
-  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-darwin-amd64.tar.gz
-    sha256: 3d060bbf7883198282fc2b9b189b3fae3f277566307ce233b67c344869f0ec15
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.4/kubectl-cost-darwin-amd64.tar.gz
+    sha256: 46a021e30f774143fbfbf182da4f898511e8fd481f7b172f9ba84bdfefd15f84
     bin: kubectl-cost
     files:
     - from: kubectl-cost
@@ -22,8 +22,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-darwin-arm64.tar.gz
-    sha256: d40f1a0e9ba868821d3a2aa7a62bb0a112055d0c00d976ffa7cdc09c5351eba0
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.4/kubectl-cost-darwin-arm64.tar.gz
+    sha256: 91180b3fddbb30298e69ceccc68bfe53e7bda8d452d201943b9a62a3afbc545d
     bin: kubectl-cost
     files:
     - from: kubectl-cost
@@ -34,8 +34,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-linux-amd64.tar.gz
-    sha256: 87cb10063d26b8a072fbf2b98372fa5aa9d5bef884d91ffd38a97bd99c37459a
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.4/kubectl-cost-linux-amd64.tar.gz
+    sha256: c2e66cbc9a690ef84d3b62366f29652f99d45960181031e1095c97a9725b1ef0
     bin: kubectl-cost
     files:
     - from: kubectl-cost
@@ -46,8 +46,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-windows-amd64.tar.gz
-    sha256: 3391be9091b988da1f3b12a133e9c8412193f20bf9c4349812d7b1e3b90b336c
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.4/kubectl-cost-windows-amd64.tar.gz
+    sha256: 974ec890eba1eb7db99d57a1d3ef73139de7b586b8fb6d50a6c17ece0579e55b
     bin: kubectl-cost.exe
     files:
     - from: kubectl-cost

--- a/plugins/cost.yaml
+++ b/plugins/cost.yaml
@@ -1,0 +1,60 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cost
+spec:
+  version: v0.1.3
+  shortDescription: View cluster cost information
+  description: |
+    Uses Kubecost's API to gather and format cluster cost information broken
+    down by various aggregations like namespace, deployment, and label.
+  homepage: https://github.com/kubecost/kubectl-cost
+  platforms:
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-darwin-amd64.tar.gz
+    sha256: 3d060bbf7883198282fc2b9b189b3fae3f277566307ce233b67c344869f0ec15
+    bin: kubectl-cost
+    files:
+    - from: kubectl-cost
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-darwin-arm64.tar.gz
+    sha256: d40f1a0e9ba868821d3a2aa7a62bb0a112055d0c00d976ffa7cdc09c5351eba0
+    bin: kubectl-cost
+    files:
+    - from: kubectl-cost
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-linux-amd64.tar.gz
+    sha256: 87cb10063d26b8a072fbf2b98372fa5aa9d5bef884d91ffd38a97bd99c37459a
+    bin: kubectl-cost
+    files:
+    - from: kubectl-cost
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - uri: https://github.com/kubecost/kubectl-cost/releases/download/v0.1.3/kubectl-cost-windows-amd64.tar.gz
+    sha256: 3391be9091b988da1f3b12a133e9c8412193f20bf9c4349812d7b1e3b90b336c
+    bin: kubectl-cost.exe
+    files:
+    - from: kubectl-cost
+      to: kubectl-cost.exe
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64


### PR DESCRIPTION
`kubectl-cost` is a plugin made by Kubecost to provide a CLI interface for cluster cost visibility.

See source:
https://github.com/kubecost/kubectl-cost

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

I tested locally on `linux/amd64` with the manual specification of manifest and archive.

I read the Naming Guide, would you prefer this plugin be named `kubecost`?