### PR TITLE
Add kubectl-macro plugin to krew index

### DIFF
--- a/plugins/macro.yaml
+++ b/plugins/macro.yaml
@@ -4,7 +4,7 @@ metadata:
   name: macro
 spec:
   homepage: https://github.com/morningspace/kubemacro
-  shortDescription: "Wrap a set of kubectl calls into one command and run as a macro."
+  shortDescription: "Wrap multiple kubectl calls and run as a macro"
   version: "v0.1.0"
   description: |
     Run kubectl macro (macro for short) that wraps a set of 

--- a/plugins/macro.yaml
+++ b/plugins/macro.yaml
@@ -4,7 +4,7 @@ metadata:
   name: macro
 spec:
   homepage: https://github.com/morningspace/kubemacro
-  shortDescription: "Wrap multiple kubectl calls and run as a macro"
+  shortDescription: "Wrap multiple kubectl calls to run as a macro"
   version: "v0.1.0"
   description: |
     Run kubectl macro (macro for short) that wraps a set of 

--- a/plugins/macro.yaml
+++ b/plugins/macro.yaml
@@ -1,0 +1,28 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: macro
+spec:
+  homepage: https://github.com/morningspace/kubemacro
+  shortDescription: "Wrap a set of kubectl calls into one command and run as a macro."
+  version: "v0.1.0"
+  description: |
+    Run kubectl macro (macro for short) that wraps a set of 
+    kubectl calls into one command that you can run from the
+    command line as many times as you want.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/morningspace/kubemacro/archive/v0.1.0.tar.gz
+    sha256: 8b691712abf5a08e69775e13c10615922043cbecf941191c945327f2cef1b4f4
+    bin: kubectl-macro.sh
+    files:
+    - from: "/kubemacro-*/kubectl-macro.sh"
+      to: "."
+    - from: "/kubemacro-*/LICENSE"
+      to: "."


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Hi,

I'd like to raise the request to add kubectl-macro plugin to krew index. It is a kubectl plugin to run `kubectl macro` (or `macro` for short) that wraps a set of kubectl calls into one command to be run repeatedly.

More details can be found from the [online documentation](https://morningspace.github.io/kubemacro/docs/).
The source code repository can be found [here](https://github.com/morningspace/kubemacro/).

There is also a website, called [KubeMacro Hub](https://morningspace.github.io/kubemacro-hub/), essentially a [GitHub repository](https://github.com/morningspace/kubemacro-hub/) too, which is designed as a central place for people to exchange the macros.

I've gone through the guidelines and verified the installation locally. Let me know if that makes sense and I'm happy to make any change per request.

Thanks in advance.