### PR TITLE
feat: add new plugins translate and move2kube

### DIFF
--- a/plugins/move2kube.yaml
+++ b/plugins/move2kube.yaml
@@ -1,0 +1,31 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: move2kube
+spec:
+  version: v0.2.0-alpha.5
+  homepage: https://move2kube.konveyor.io/
+  shortDescription: Migrate your application to run on Kubernetes
+  description: |
+    Move2Kube is a tool that uses source artifacts such as Docker Compose files
+    or Cloud Foundry manifest files, and even source code, to generate Kubernetes
+    deployment artifacts including K8s yamls, Helm charts, CI/CD pipelines, and Operators.
+  caveats: |
+    * Optional dependencies:
+      - docker
+      - operator-sdk
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/konveyor/move2kube/releases/download/v0.2.0-alpha.5/move2kube-v0.2.0-alpha.5-darwin-amd64.tar.gz
+      sha256: 028185704652ea71ee37a23459b2bd3700721d09c672ef5723c8390e0d3cf6c9
+      bin: move2kube/move2kube
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/konveyor/move2kube/releases/download/v0.2.0-alpha.5/move2kube-v0.2.0-alpha.5-linux-amd64.tar.gz
+      sha256: 481563ddf2fb08d711deb39236b1f15960b1867f3d4941a27c13afca0bd4e849
+      bin: move2kube/move2kube

--- a/plugins/translate.yaml
+++ b/plugins/translate.yaml
@@ -1,0 +1,32 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: translate
+spec:
+  version: v0.2.0-alpha.5
+  homepage: https://move2kube.konveyor.io/
+  shortDescription: Migrate your application to run on Kubernetes
+  description: |
+    Translate creates all the resources required for deploying your application to Kubernetes, including containerization and Kubernetes resources.
+    It supports translating from Docker Swarm/Docker Compose, Cloud Foundry apps and even other non-containerized applications.
+    This plugin contains a subset of the features of a more flexible CLI tool called Move2Kube https://github.com/konveyor/move2kube
+    For more documentation and support for this plugin and Move2Kube, visit https://move2kube.konveyor.io/
+  caveats: |
+    * Optional dependencies:
+      - docker
+      - operator-sdk
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/konveyor/move2kube/releases/download/v0.2.0-alpha.5/kubectl-translate-v0.2.0-alpha.5-darwin-amd64.tar.gz
+      sha256: f017ca365e296ed2ce7bc814f8b0572ff1ec051dda83216b836ef4dac3f0e684
+      bin: kubectl-translate/kubectl-translate
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/konveyor/move2kube/releases/download/v0.2.0-alpha.5/kubectl-translate-v0.2.0-alpha.5-linux-amd64.tar.gz
+      sha256: 76d961b4e6af828d8d841e7c35b59df1a2ab8f2c5cb8ca6f47fb4078e5822a7a
+      bin: kubectl-translate/kubectl-translate


### PR DESCRIPTION
`kubectl-move2kube` is a plugin made by Konveyor to help users migrate their apps to run on K8s.
`kubectl-translate` is a plugin with a subset of the features of `kubect-move2kube`, for simpler use cases.

The plugins can containerize applications and generate K8s yamls, Helm charts, CI/CD pipelines and Operators required to migrate an existing application to K8s.

The source is available at:
https://github.com/konveyor/move2kube

I tested the plugin installation locally on macos and linux/amd64 servers with installing locally and through the URL in the manifest.

I read the Naming Guide, it mentioned not adding `kube` to the plugin name but in this case `move2kube` is the name of the CLI tool.

Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>