### PR TITLE
Add new plugin resource-versions

### DIFF
--- a/plugins/resource-versions.yaml
+++ b/plugins/resource-versions.yaml
@@ -1,0 +1,49 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: resource-versions
+spec:
+  version: v0.1.0
+  platforms:
+  - bin: kubectl-resource-versions
+    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.0/kubectl-resource-versions-darwin-amd64.tar.gz
+    sha256: 407d562fa3c34f49bc1b101294d06fec13639ff95c23bb2d071a5326f67de9af
+    files:
+      - from: "kubectl-resource-versions-darwin-amd64/*"
+        to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - bin: kubectl-resource-versions
+    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.0/kubectl-resource-versions-linux-amd64.tar.gz
+    sha256: ecbbbd0892dd2e49f4b487ff92c95e2c322e3eb7b02c78b8354aef216404d643
+    files:
+      - from: "kubectl-resource-versions-linux-amd64/*"
+        to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - bin: kubectl-resource-versions.exe
+    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.0/kubectl-resource-versions-windows-amd64.tar.gz
+    sha256: 062eee95e959de5d0c0230a51ab03a05d2f992d070bed5dd0d75311cfd1835c5
+    files:
+      - from: "kubectl-resource-versions-windows-amd64/*"
+        to: .
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+  shortDescription: Print the supported API resource versions on the server
+  homepage: https://github.com/chengshiwen/kubectl-resource-versions
+  caveats: |
+      Usage:
+        kubectl resource-versions [flags]
+  description: |
+      Print the supported API resource versions on the server
+
+      Have you ever wondered which api group and version should be used for a specified resource on a provided kubernetes cluster?
+      It is useful to find out the matrix of resources and api versions by using this kubectl plugin as shown below:
+
+      $ kubectl resource-versions

--- a/plugins/resource-versions.yaml
+++ b/plugins/resource-versions.yaml
@@ -7,7 +7,7 @@ spec:
   platforms:
   - bin: kubectl-resource-versions
     uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.1/kubectl-resource-versions-darwin-amd64.tar.gz
-    sha256: d236209638d9ad6a001b66ed9c69df483773bc3bfd11aff2dac966774b1ef524
+    sha256: 48f31d24f9ebaeed6c24fabb568c26f500809a444a8efde5cdb653dff8fae132
     files:
       - from: "kubectl-resource-versions-darwin-amd64/*"
         to: .
@@ -17,7 +17,7 @@ spec:
         arch: amd64
   - bin: kubectl-resource-versions
     uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.1/kubectl-resource-versions-linux-amd64.tar.gz
-    sha256: 12f7072196d274cb6e08f58cce759b266f299bb9c7e6b04eb127fa9c918763d9
+    sha256: 60c9fd5db5694109bae69a760c2252996e19b260ea89215e1d5e1037c09ae1b8
     files:
       - from: "kubectl-resource-versions-linux-amd64/*"
         to: .
@@ -27,7 +27,7 @@ spec:
         arch: amd64
   - bin: kubectl-resource-versions.exe
     uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.1/kubectl-resource-versions-windows-amd64.tar.gz
-    sha256: f44f8c371a779ef988f83eb9c6a971bf02b10391439900ac992601e3ba9675b3
+    sha256: c806215594ab835d213abb8a2f2d9d2651c4aaad10a9223f47e214e66ab7ffc7
     files:
       - from: "kubectl-resource-versions-windows-amd64/*"
         to: .

--- a/plugins/resource-versions.yaml
+++ b/plugins/resource-versions.yaml
@@ -37,4 +37,4 @@ spec:
         arch: amd64
   shortDescription: Print available versions of each API
   homepage: https://github.com/chengshiwen/kubectl-resource-versions
-  description: This plugin prints the API resources available on the API server along with groups/versions that offer that API
+  description: Print the API resources along with the supported API versions on the server

--- a/plugins/resource-versions.yaml
+++ b/plugins/resource-versions.yaml
@@ -3,11 +3,11 @@ kind: Plugin
 metadata:
   name: resource-versions
 spec:
-  version: v0.1.0
+  version: v0.1.1
   platforms:
   - bin: kubectl-resource-versions
-    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.0/kubectl-resource-versions-darwin-amd64.tar.gz
-    sha256: 407d562fa3c34f49bc1b101294d06fec13639ff95c23bb2d071a5326f67de9af
+    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.1/kubectl-resource-versions-darwin-amd64.tar.gz
+    sha256: d236209638d9ad6a001b66ed9c69df483773bc3bfd11aff2dac966774b1ef524
     files:
       - from: "kubectl-resource-versions-darwin-amd64/*"
         to: .
@@ -16,8 +16,8 @@ spec:
         os: darwin
         arch: amd64
   - bin: kubectl-resource-versions
-    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.0/kubectl-resource-versions-linux-amd64.tar.gz
-    sha256: ecbbbd0892dd2e49f4b487ff92c95e2c322e3eb7b02c78b8354aef216404d643
+    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.1/kubectl-resource-versions-linux-amd64.tar.gz
+    sha256: 12f7072196d274cb6e08f58cce759b266f299bb9c7e6b04eb127fa9c918763d9
     files:
       - from: "kubectl-resource-versions-linux-amd64/*"
         to: .
@@ -26,8 +26,8 @@ spec:
         os: linux
         arch: amd64
   - bin: kubectl-resource-versions.exe
-    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.0/kubectl-resource-versions-windows-amd64.tar.gz
-    sha256: 062eee95e959de5d0c0230a51ab03a05d2f992d070bed5dd0d75311cfd1835c5
+    uri: https://github.com/chengshiwen/kubectl-resource-versions/releases/download/v0.1.1/kubectl-resource-versions-windows-amd64.tar.gz
+    sha256: f44f8c371a779ef988f83eb9c6a971bf02b10391439900ac992601e3ba9675b3
     files:
       - from: "kubectl-resource-versions-windows-amd64/*"
         to: .

--- a/plugins/resource-versions.yaml
+++ b/plugins/resource-versions.yaml
@@ -35,15 +35,6 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  shortDescription: Print the supported API resource versions on the server
+  shortDescription: Print available versions of each API
   homepage: https://github.com/chengshiwen/kubectl-resource-versions
-  caveats: |
-      Usage:
-        kubectl resource-versions [flags]
-  description: |
-      Print the supported API resource versions on the server
-
-      Have you ever wondered which api group and version should be used for a specified resource on a provided kubernetes cluster?
-      It is useful to find out the matrix of resources and api versions by using this kubectl plugin as shown below:
-
-      $ kubectl resource-versions
+  description: This plugin prints the API resources available on the API server along with groups/versions that offer that API


### PR DESCRIPTION
`kubectl-resource-versions` is a plugin made by [Shiwen Cheng](https://github.com/chengshiwen) to help users find out the API resources along with the supported API versions on the server as shown below.:

![image](https://raw.githubusercontent.com/chengshiwen/kubectl-resource-versions/master/doc/kubectl-resource-versions.png)

The source is available at:
https://github.com/chengshiwen/kubectl-resource-versions