### PR TITLE
Bump kubectl-fuzzy version to v1.9.0

### DIFF
--- a/plugins/fuzzy.yaml
+++ b/plugins/fuzzy.yaml
@@ -4,8 +4,8 @@ metadata:
   name: fuzzy
 spec:
   platforms:
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_darwin_amd64.tar.gz"
-    sha256: "9fdd553ec742366a3bc780cf04b6534a2277ad66f3cf180f03775a79c8340181"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.9.0/kubectl-fuzzy_1.9.0_darwin_amd64.tar.gz"
+    sha256: "92b8bea8da0887f3de29cc161532a2156e89e003eba6903c2832de81b6afdea9"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -16,8 +16,20 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_linux_amd64.tar.gz"
-    sha256: "b513d93a9335f3fcb6929aa4058e985837a9e2cb3af1969799d21c563086671d"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.9.0/kubectl-fuzzy_1.9.0_darwin_arm64.tar.gz"
+    sha256: "3acb9ad298d6b1c965545f1168c073e8ae07592cd5ebe1929f56f5eae8a22f68"
+    bin: kubectl-fuzzy
+    files:
+    - from: kubectl-fuzzy
+      to: .
+    - from: LICENSE
+      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.9.0/kubectl-fuzzy_1.9.0_linux_amd64.tar.gz"
+    sha256: "4df1a54ad1c4b82b14acf375e0a43a4df12431c4190a39595119c00a7066776f"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -28,8 +40,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_linux_arm64.tar.gz"
-    sha256: "100bebe9b56b187846a52e7bafdff5bdf4c170ea89175cec6215e516e907d9c8"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.9.0/kubectl-fuzzy_1.9.0_linux_arm64.tar.gz"
+    sha256: "c7bde0d9ac0c6e82a44a1178c2bf506f9edf7d06bc31d5ebb29cd464fd3b3d88"
     bin: kubectl-fuzzy
     files:
     - from: kubectl-fuzzy
@@ -40,8 +52,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.8.1/kubectl-fuzzy_1.8.1_windows_amd64.tar.gz"
-    sha256: "8001ed2833e63a08b20526fdc687383e6d516cf7cee70f66c81822a3685f8664"
+  - uri: "https://github.com/d-kuro/kubectl-fuzzy/releases/download/v1.9.0/kubectl-fuzzy_1.9.0_windows_amd64.tar.gz"
+    sha256: "937967008a5d5c2b245eae019de303fddcb34659f293fb8d9513ebb65144fd67"
     bin: kubectl-fuzzy.exe
     files:
     - from: kubectl-fuzzy.exe
@@ -52,7 +64,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v1.8.1"
+  version: "v1.9.0"
   shortDescription: Fuzzy and partial string search for kubectl
   description: |
     This tool uses fzf(1)-like fuzzy-finder to do partial or fuzzy search of Kubernetes resources.


### PR DESCRIPTION
refs: https://github.com/d-kuro/kubectl-fuzzy/releases/tag/v1.9.0

Bump kubectl-fuzzy version to v1.9.0

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
