### PR TITLE
Bump the version of open-svc to v2.4.4

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: open-svc
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.3/kubectl-open_svc-darwin-amd64.zip
-    sha256: 3666681f32ea40f94fdf2fd997f6ec482a8cceb4f8441e04b33ba9f77763e934
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-darwin-amd64.zip
+    sha256: 4514c820a430f0b12232722267d82d1555abe0702b49111f140cdee6c27a10f6
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.3/kubectl-open_svc-darwin-arm64.zip
-    sha256: 26ee6965acdc9e0a0c3c36e044121d7e03fb27f7f76e94f3b84858e69d6fcf60
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-darwin-arm64.zip
+    sha256: 532879423c105e57c9a7d223da97a9cf6db5889d3b249a219d4378a6efd0aa78
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.3/kubectl-open_svc-linux-amd64.zip
-    sha256: 5bd3ccb7d52432758e6879ceb400090cfecf45e4e2c19ec082aa80b8d41ca4e9
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-linux-amd64.zip
+    sha256: a74b86504497bba2e6475c914e94609418c8f56edb7afa4bd23966eadf93b680
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -40,8 +40,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.3/kubectl-open_svc-linux-arm64.zip
-    sha256: eaafbeddaabc50a6706bb08e1a980c927eef9b30e43c1ab5fc9b30c703d5806e
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-linux-arm64.zip
+    sha256: ff4979b3ba11081b247478ec1a98800ba7bbea1092cd40fd268f8fe35ad7393f
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -52,8 +52,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.3/kubectl-open_svc-linux-arm.zip
-    sha256: 0521405658bf9ead21174bf40a26d375fc0eeaa1b0f8558a60021443c547a162
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-linux-arm.zip
+    sha256: e95adb18893299dec73944171b16d5f5122b09fb9e948e3a16d13c4a4d90e4c3
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -64,8 +64,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.3/kubectl-open_svc-windows-amd64.zip
-    sha256: f25454cf6916c4d363a327666b904e967865809960030a970cf33d2514237ca4
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-windows-amd64.zip
+    sha256: 9b9cfb7737ca357c611868da7f278c6a8de647323f34d919c5f1503561208f8f
     bin: kubectl-open_svc.exe
     files:
     - from: kubectl-open_svc.exe
@@ -76,7 +76,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.4.3"
+  version: "v2.4.4"
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser.


### PR DESCRIPTION
This PR bumps the version of open-svc to v2.4.4.