### PR TITLE
Bump the version of view-serviceaccount-kubeconfig to v2.2.6

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,8 +4,8 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.5/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
-    sha256: 6bdfd5307f4c20d0c51fd297e34477510d2f50233c6693da8ea77fddc508dddd
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
+    sha256: 146268ccbd137117d6aae7c0a7b773c9774fb048fe7fa0fbab24976c4111b73f
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: "*"
@@ -14,8 +14,18 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.5/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
-    sha256: 3c50abc71aff4346775d76a6090e0ea6e0189a23fcf4d0d95c83bfc84f4b83de
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-darwin-arm64.zip
+    sha256: d68510c91675fb9ee3054f6ac08be3e2cf22d24df3e2de2724a07caa88fa96d9
+    bin: kubectl-view_serviceaccount_kubeconfig
+    files:
+    - from: "*"
+      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: bfe8f9358dd45a8c9fba0f8fcf3a61b53b93a7697e2d3ef5ee9248cc01feef6e
     bin: kubectl-view_serviceaccount_kubeconfig
     files:
     - from: "*"
@@ -24,8 +34,28 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.5/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
-    sha256: 8bc442464b24e5aa19e864a4a3e3ce40e432930ffc17dc9a12ef03a309461c85
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-arm64.zip
+    sha256: ecdaea81325f36657c863ff1f319115c744ea21c2329110f68e70722a7f87b3f
+    bin: kubectl-view_serviceaccount_kubeconfig
+    files:
+    - from: "*"
+      to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-arm.zip
+    sha256: 66e99d8ba14733c362c31eee823869527924a881ecb8c6479352d0f00fe7e93b
+    bin: kubectl-view_serviceaccount_kubeconfig
+    files:
+    - from: "*"
+      to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
+    sha256: 96f18d0f4d0469bc0d0836b539847fd533cab1524e84888009e1e09f764b64c0
     bin: kubectl-view_serviceaccount_kubeconfig.exe
     files:
     - from: "*"
@@ -34,7 +64,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.2.5"
+  version: "v2.2.6"
   homepage: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.

--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -7,9 +7,6 @@ spec:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
     sha256: 146268ccbd137117d6aae7c0a7b773c9774fb048fe7fa0fbab24976c4111b73f
     bin: kubectl-view_serviceaccount_kubeconfig
-    files:
-    - from: "*"
-      to: .
     selector:
       matchLabels:
         os: darwin
@@ -17,9 +14,6 @@ spec:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-darwin-arm64.zip
     sha256: d68510c91675fb9ee3054f6ac08be3e2cf22d24df3e2de2724a07caa88fa96d9
     bin: kubectl-view_serviceaccount_kubeconfig
-    files:
-    - from: "*"
-      to: .
     selector:
       matchLabels:
         os: darwin
@@ -27,9 +21,6 @@ spec:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
     sha256: bfe8f9358dd45a8c9fba0f8fcf3a61b53b93a7697e2d3ef5ee9248cc01feef6e
     bin: kubectl-view_serviceaccount_kubeconfig
-    files:
-    - from: "*"
-      to: .
     selector:
       matchLabels:
         os: linux
@@ -37,9 +28,6 @@ spec:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-arm64.zip
     sha256: ecdaea81325f36657c863ff1f319115c744ea21c2329110f68e70722a7f87b3f
     bin: kubectl-view_serviceaccount_kubeconfig
-    files:
-    - from: "*"
-      to: .
     selector:
       matchLabels:
         os: linux
@@ -47,9 +35,6 @@ spec:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-arm.zip
     sha256: 66e99d8ba14733c362c31eee823869527924a881ecb8c6479352d0f00fe7e93b
     bin: kubectl-view_serviceaccount_kubeconfig
-    files:
-    - from: "*"
-      to: .
     selector:
       matchLabels:
         os: linux
@@ -57,9 +42,6 @@ spec:
   - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
     sha256: 96f18d0f4d0469bc0d0836b539847fd533cab1524e84888009e1e09f764b64c0
     bin: kubectl-view_serviceaccount_kubeconfig.exe
-    files:
-    - from: "*"
-      to: .
     selector:
       matchLabels:
         os: windows


### PR DESCRIPTION
This PR bumps the version of view-serviceaccount-kubeconfig to v2.2.6.