### PR TITLE
Bump the version of open-svc to v2.5.0

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: open-svc
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-darwin-amd64.zip
-    sha256: 4514c820a430f0b12232722267d82d1555abe0702b49111f140cdee6c27a10f6
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-darwin-amd64.zip
+    sha256: a194cb7c1573134ca41dcc9c5f685d56af07143c22be222a2a0801eff33cd93c
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-darwin-arm64.zip
-    sha256: 532879423c105e57c9a7d223da97a9cf6db5889d3b249a219d4378a6efd0aa78
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-darwin-arm64.zip
+    sha256: 9394f7c71c5b17560f0a29792240e089c101b531970ba98b0efd466be0c3c451
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-linux-amd64.zip
-    sha256: a74b86504497bba2e6475c914e94609418c8f56edb7afa4bd23966eadf93b680
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-linux-amd64.zip
+    sha256: 6f4bc11f9d54ef80260e324b0e9638312ec3c8a5e82f760f7134126491941197
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -40,8 +40,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-linux-arm64.zip
-    sha256: ff4979b3ba11081b247478ec1a98800ba7bbea1092cd40fd268f8fe35ad7393f
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-linux-arm64.zip
+    sha256: b2a785431fc17ef78769ade97360bf3f3d6e0537978edc49807b14d842a589ee
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -52,8 +52,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-linux-arm.zip
-    sha256: e95adb18893299dec73944171b16d5f5122b09fb9e948e3a16d13c4a4d90e4c3
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-linux-arm.zip
+    sha256: e1e919e2e08891dde6d4933bc0547769838ec4c071260fa3ce4a5917080ad17a
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -64,8 +64,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.4.4/kubectl-open_svc-windows-amd64.zip
-    sha256: 9b9cfb7737ca357c611868da7f278c6a8de647323f34d919c5f1503561208f8f
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-windows-amd64.zip
+    sha256: 3e46ae360a2d804dd700b3295a6453c9755c6f057dc921aeaa2ee36bcb564d12
     bin: kubectl-open_svc.exe
     files:
     - from: kubectl-open_svc.exe
@@ -76,7 +76,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.4.4"
+  version: "v2.5.0"
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser.


### PR DESCRIPTION
This PR bumps the version of open-svc to v2.5.0.