### PR TITLE
Bump the version of sort-manifests to v0.4.2

### DIFF
--- a/plugins/sort-manifests.yaml
+++ b/plugins/sort-manifests.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: sort-manifests
 spec:
-  version: v0.4.1
+  version: v0.4.2
   shortDescription: Sort manifest files in a proper order by Kind
   description: |
     When installing manifests, they should be sorted in a proper order by Kind.
@@ -14,38 +14,44 @@ spec:
     using tiller.SortByKind() in Kubernetes Helm.
   homepage: https://github.com/superbrothers/ksort
   platforms:
-  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.1/ksort-darwin-amd64.zip
-    sha256: a79e1f6a7eebf2cd081732a1ef3bb5fa1722a20286259460be2bb9c89309c86b
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.2/ksort-darwin-amd64.zip
+    sha256: 858d410b302b6a2d5b4d0dd4a05625f68350b5fbe741c9fa7d9040a24dccdd0c
     bin: ksort
-    files:
-    - from: ksort
-      to: .
-    - from: LICENSE.txt
-      to: .
     selector:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.1/ksort-linux-amd64.zip
-    sha256: 2854bfade8c37eded4fcabe576e1b15e58a46d794f037da67c502c233a97ecd9
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.2/ksort-darwin-arm64.zip
+    sha256: 92ee55277cbd9310a2085a77f84178e70b6b7786235d0b9e65a457b9c2a030b2
     bin: ksort
-    files:
-    - from: ksort
-      to: .
-    - from: LICENSE.txt
-      to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.2/ksort-linux-amd64.zip
+    sha256: 651b029c61bd167c024bc53b0f3f7a5c7e2416a3e106af23f146be7f80245745
+    bin: ksort
     selector:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.1/ksort-windows-amd64.zip
-    sha256: f50dc818f9f91c72e0a46f989c8284c5ee427ea84ed9c22eebaaa0cc4c296db0
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.2/ksort-linux-arm64.zip
+    sha256: d60e2be6069afa2faec94dce29c08d31acd6ee88c0a466b6db0a03d52f5dc410
+    bin: ksort
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.2/ksort-linux-arm.zip
+    sha256: dce5ef548fdac6e4128aeb144e185b8a579cee7523b41c7cd02b235d0e9692b2
+    bin: ksort
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm
+  - uri: https://github.com/superbrothers/ksort/releases/download/v0.4.2/ksort-windows-amd64.zip
+    sha256: 47da1847343e1d5be88931e759cc2ebff6db7ae51facff6678654d40b343e34a
     bin: ksort.exe
-    files:
-    - from: ksort.exe
-      to: .
-    - from: LICENSE.txt
-      to: .
     selector:
       matchLabels:
         os: windows


### PR DESCRIPTION
This PR bumps the version of sort-manifests to v0.4.2.