### PR TITLE
Add rbac-tool krew plugin

### DIFF
--- a/plugins/rbac-tool.yaml
+++ b/plugins/rbac-tool.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rbac-tool
+spec:
+  version: v1.1.1
+  platforms:
+  - bin: rbac-tool
+    uri: https://github.com/alcideio/rbac-tool/releases/download/v1.1.1/rbac-tool_v1.1.1_linux_amd64.tar.gz
+    sha256: ecdc8b365b8f9bb4303d194e777a9e7fdf3376158e3a2fb78cf7425007118a1d
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+
+  - bin: rbac-tool
+    uri: https://github.com/alcideio/rbac-tool/releases/download/v1.1.1/rbac-tool_v1.1.1_darwin_amd64.tar.gz
+    sha256: 038d583a98783bf72324eda1c9bab88edff115c1a0b03f4e67c27ea55f7a6407
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+
+  - bin: rbac-tool.exe
+    uri: https://github.com/alcideio/rbac-tool/releases/download/v1.1.1/rbac-tool_v1.1.1_windows_amd64.tar.gz
+    sha256: 1cd62b006b1cfc484866760ca846ca3d2701791e300a1f419b756e29cdc7b6a8
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+
+  shortDescription: Kubernetes RBAC Power Toys - Visualize, Analyze, Generate & Query
+  homepage: https://github.com/alcideio/rbac-tool
+  description: |
+    This plugin is a collection of Kubernetes RBAC power tools to simplify Kubernetes RBAC.
+
+    Available Commands:
+      auditgen        Generate RBAC policy from Kubernetes audit events
+      generate        Generate Role or ClusterRole and reduce the use of wildcards
+      lookup          RBAC Lookup by subject (user/group/serviceaccount) name
+      policy-rules    RBAC List Policy Rules For subject (user/group/serviceaccount) name
+      version         Print rbac-tool version
+      visualize       A RBAC visualizer
+      who-can         Shows which subjects have RBAC permissions to perform an action
+
+    Flags:
+      -h, --help      help for rbac-tool
+      -v, --v Level   number for the log level verbosity

--- a/plugins/rbac-tool.yaml
+++ b/plugins/rbac-tool.yaml
@@ -29,17 +29,9 @@ spec:
         os: windows
         arch: amd64
 
-  shortDescription: RBAC Power Toys - Visualize, Analyze, Generate & Query.
+  shortDescription: RBAC power toys to analyze permissions and generate policies
   homepage: https://github.com/alcideio/rbac-tool
   description: |
     This plugin is a collection of RBAC power tools to simplify RBAC analysis and configuration.
-
-    Available Sub-Commands:
-      auditgen        Generate RBAC policy from Kubernetes audit events (audit log)
-      generate        Generate Role or ClusterRole and reduce the use of wildcards.
-      lookup          RBAC Lookup by subject (user/group/serviceaccount) name
-      policy-rules    List RBAC Policy Rules For subject (user/group/serviceaccount) name across all bindings
-      version         Print version
-      visualize       A graph visualization of RBAC permissions
-      who-can         Shows which subjects have RBAC permissions to perform a specified action
+    You can visualize, analyze, query permissions as well as generate policies in multiple ways.
 

--- a/plugins/rbac-tool.yaml
+++ b/plugins/rbac-tool.yaml
@@ -29,20 +29,17 @@ spec:
         os: windows
         arch: amd64
 
-  shortDescription: Kubernetes RBAC Power Toys - Visualize, Analyze, Generate & Query
+  shortDescription: RBAC Power Toys - Visualize, Analyze, Generate & Query.
   homepage: https://github.com/alcideio/rbac-tool
   description: |
-    This plugin is a collection of Kubernetes RBAC power tools to simplify Kubernetes RBAC.
+    This plugin is a collection of RBAC power tools to simplify RBAC analysis and configuration.
 
-    Available Commands:
-      auditgen        Generate RBAC policy from Kubernetes audit events
-      generate        Generate Role or ClusterRole and reduce the use of wildcards
+    Available Sub-Commands:
+      auditgen        Generate RBAC policy from Kubernetes audit events (audit log)
+      generate        Generate Role or ClusterRole and reduce the use of wildcards.
       lookup          RBAC Lookup by subject (user/group/serviceaccount) name
-      policy-rules    RBAC List Policy Rules For subject (user/group/serviceaccount) name
-      version         Print rbac-tool version
-      visualize       A RBAC visualizer
-      who-can         Shows which subjects have RBAC permissions to perform an action
+      policy-rules    List RBAC Policy Rules For subject (user/group/serviceaccount) name across all bindings
+      version         Print version
+      visualize       A graph visualization of RBAC permissions
+      who-can         Shows which subjects have RBAC permissions to perform a specified action
 
-    Flags:
-      -h, --help      help for rbac-tool
-      -v, --v Level   number for the log level verbosity

--- a/plugins/rbac-tool.yaml
+++ b/plugins/rbac-tool.yaml
@@ -29,10 +29,10 @@ spec:
         os: windows
         arch: amd64
 
-  shortDescription: RBAC power toys to analyze permissions and generate policies
+  shortDescription: Plugin to analyze permissions and generate policies
   homepage: https://github.com/alcideio/rbac-tool
   description: |
-    This plugin is a collection of RBAC power tools to simplify RBAC analysis and configuration.
+    This plugin is a collection of RBAC tools to simplify analysis and configuration.
     You can visualize, analyze, query permissions as well as generate policies in multiple ways.
 
     Examples:
@@ -43,4 +43,4 @@ spec:
     kubectl rbac-tool who-can get secret
 
     # Generate a ClusterRole policy that allows to read everything except secrets and services
-    kubectl rbac-tool  gen  --deny-resources=secrets.,services. --allowed-verbs=get,list
+    kubectl rbac-tool gen --deny-resources=secrets.,services. --allowed-verbs=get,list

--- a/plugins/rbac-tool.yaml
+++ b/plugins/rbac-tool.yaml
@@ -35,3 +35,12 @@ spec:
     This plugin is a collection of RBAC power tools to simplify RBAC analysis and configuration.
     You can visualize, analyze, query permissions as well as generate policies in multiple ways.
 
+    Examples:
+    # Generate HTML visualzation of your RBAC permissions
+    kubectl rbac-tool viz
+
+    # Query who can read secrets
+    kubectl rbac-tool who-can get secret
+
+    # Generate a ClusterRole policy that allows to read everything except secrets and services
+    kubectl rbac-tool  gen  --deny-resources=secrets.,services. --allowed-verbs=get,list


### PR DESCRIPTION
This plugin is a collection of Kubernetes RBAC power tools to simplify Kubernetes RBAC.
