### PR TITLE
schemahero v0.12.3

### DIFF
--- a/plugins/schemahero.yaml
+++ b/plugins/schemahero.yaml
@@ -10,7 +10,7 @@ spec:
         os: linux
         arch: amd64
     uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_linux_amd64.tar.gz
-    sha256: b54b8505c2fbfbf01ad41d8bc30bdb649badbfc709d34f3dcedb0ae8df891ac3
+    sha256: 7691e82d8f2ca7f03bf8f8a74386b55eb5b4ed8130bf5902080e9b1675ed7e68
     files:
     - from: kubectl-schemahero
       to: .
@@ -22,7 +22,7 @@ spec:
         os: linux
         arch: arm64
     uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_linux_arm64.tar.gz
-    sha256: 7454653e2f91cc35454bd78cd2f2588ce196849e042734fa4f415661c56b9558
+    sha256: a4e4f3ab868fb1f3e76bae97362a163cc84dcf4aa0f67505dfe0ecb0ca4d49c1
     files:
     - from: kubectl-schemahero
       to: .
@@ -34,7 +34,7 @@ spec:
         os: darwin
         arch: amd64
     uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_darwin_amd64.tar.gz
-    sha256: bb048aab0ea2bbdd2cb1908b6d43c80d537586c0ac47d77620ccc4df7026418c
+    sha256: af405363ad06db6afe5bcb097986b494835e7bd7dd9a4753db71ef01bb2c81e0
     files:
     - from: kubectl-schemahero
       to: .
@@ -46,7 +46,7 @@ spec:
         os: darwin
         arch: arm64
     uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_darwin_arm64.tar.gz
-    sha256: 8f322060c6f23cf9ae28fa9187b56872f578d756a3c37cc5c789671b05ae8412
+    sha256: c144e84ad29210e9357b27f582e5b674de970c4dfb82783a26aa2aa7347cf529
     files:
     - from: kubectl-schemahero
       to: .
@@ -58,7 +58,7 @@ spec:
         os: windows
         arch: amd64
     uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_windows_amd64.tar.gz
-    sha256: b37bbaa84c40c6b6456c7480a113f70d3f1592c30656581af0b0b0b970256049
+    sha256: 4da5ac882d7b8903f54ae3f91c9acd32afbc135e2cf91ebbc729d6cc5c7cb52d
     files:
     - from: kubectl-schemahero.exe
       to: .

--- a/plugins/schemahero.yaml
+++ b/plugins/schemahero.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: schemahero
 spec:
-  version: v0.12.2
+  version: v0.12.3
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.2/kubectl-schemahero_linux_amd64.tar.gz
-    sha256: bea2654f3688230c1c79918eeee9dd57f62967725898937ac3ade17791783956
+    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_linux_amd64.tar.gz
+    sha256: b54b8505c2fbfbf01ad41d8bc30bdb649badbfc709d34f3dcedb0ae8df891ac3
     files:
     - from: kubectl-schemahero
       to: .
@@ -21,8 +21,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.2/kubectl-schemahero_linux_arm64.tar.gz
-    sha256: d3e42a2b416dddc46cd4e77836fac43509654cfe37937204ec684b3320d1b8e6
+    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_linux_arm64.tar.gz
+    sha256: 7454653e2f91cc35454bd78cd2f2588ce196849e042734fa4f415661c56b9558
     files:
     - from: kubectl-schemahero
       to: .
@@ -33,8 +33,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.2/kubectl-schemahero_darwin_amd64.tar.gz
-    sha256: dc8abafc9c5c145acd8c11c44ae17239f370b6fa8fe78b67615601779ca56c7d
+    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_darwin_amd64.tar.gz
+    sha256: bb048aab0ea2bbdd2cb1908b6d43c80d537586c0ac47d77620ccc4df7026418c
     files:
     - from: kubectl-schemahero
       to: .
@@ -45,8 +45,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.2/kubectl-schemahero_darwin_arm64.tar.gz
-    sha256: 39c69fde31a2db5b8787c9540a5f0455fc8d8edc5dcde0e97152bb99504257ef
+    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_darwin_arm64.tar.gz
+    sha256: 8f322060c6f23cf9ae28fa9187b56872f578d756a3c37cc5c789671b05ae8412
     files:
     - from: kubectl-schemahero
       to: .
@@ -57,8 +57,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.2/kubectl-schemahero_windows_amd64.tar.gz
-    sha256: 8f6d605834e600b698ee2bc6d37efe9d1217719a721dcc281b62c1ea626a0366
+    uri: https://github.com/schemahero/schemahero/releases/download/v0.12.3/kubectl-schemahero_windows_amd64.tar.gz
+    sha256: b37bbaa84c40c6b6456c7480a113f70d3f1592c30656581af0b0b0b970256049
     files:
     - from: kubectl-schemahero.exe
       to: .


### PR DESCRIPTION
replacement for https://github.com/kubernetes-sigs/krew-index/pull/1416 (we had mistakenly included our binaries within the tarballs at `./bin/binary` instead of `./binary` after changing the release process)
