### PR TITLE
Bump the version of open-svc to v2.5.1

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -4,8 +4,8 @@ metadata:
   name: open-svc
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-darwin-amd64.zip
-    sha256: a194cb7c1573134ca41dcc9c5f685d56af07143c22be222a2a0801eff33cd93c
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-darwin-amd64.zip
+    sha256: e18741c35e75b027ac4d43e11d179848042873f74fc3e11c486f452af07b2d47
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -16,8 +16,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-darwin-arm64.zip
-    sha256: 9394f7c71c5b17560f0a29792240e089c101b531970ba98b0efd466be0c3c451
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-darwin-arm64.zip
+    sha256: 1d4e5f772736e4130af8fa71a07111f237258b8ac7ad4a1f4e933cfec8ff1d77
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -28,8 +28,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-linux-amd64.zip
-    sha256: 6f4bc11f9d54ef80260e324b0e9638312ec3c8a5e82f760f7134126491941197
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-linux-amd64.zip
+    sha256: 46083b84b6066692639a9ee0eaa5a7ffe44bb2fc3020b84c0b0aeefdce93e3d8
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -40,8 +40,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-linux-arm64.zip
-    sha256: b2a785431fc17ef78769ade97360bf3f3d6e0537978edc49807b14d842a589ee
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-linux-arm64.zip
+    sha256: f21ef09fab5b569a915ff18a59b3975b5d1928f74fea24db71eee88e26eab4ef
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -52,8 +52,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-linux-arm.zip
-    sha256: e1e919e2e08891dde6d4933bc0547769838ec4c071260fa3ce4a5917080ad17a
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-linux-arm.zip
+    sha256: 7a29a02f23a045bcff5d0fb880348206992c1da7809e1906394bf2ece9ae1aca
     bin: kubectl-open_svc
     files:
     - from: kubectl-open_svc
@@ -64,8 +64,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.0/kubectl-open_svc-windows-amd64.zip
-    sha256: 3e46ae360a2d804dd700b3295a6453c9755c6f057dc921aeaa2ee36bcb564d12
+  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-windows-amd64.zip
+    sha256: 8c1aacfce72fff8625ecf2282211ce70e07ee748ca06793d525878a9b17e7e95
     bin: kubectl-open_svc.exe
     files:
     - from: kubectl-open_svc.exe
@@ -76,7 +76,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.5.0"
+  version: "v2.5.1"
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser.


### PR DESCRIPTION
This PR bumps the version of open-svc to v2.5.1.