### PR TITLE
Bump the version of view-serviceaccount-kubeconfig to v2.2.7

### DIFF
--- a/plugins/view-serviceaccount-kubeconfig.yaml
+++ b/plugins/view-serviceaccount-kubeconfig.yaml
@@ -4,49 +4,49 @@ metadata:
   name: view-serviceaccount-kubeconfig
 spec:
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
-    sha256: 146268ccbd137117d6aae7c0a7b773c9774fb048fe7fa0fbab24976c4111b73f
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.7/kubectl-view_serviceaccount_kubeconfig-darwin-amd64.zip
+    sha256: 4516192453d73e419372bd5c40eca4e29a52664f98ac883e6b7e53e584ab9b1c
     bin: kubectl-view_serviceaccount_kubeconfig
     selector:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-darwin-arm64.zip
-    sha256: d68510c91675fb9ee3054f6ac08be3e2cf22d24df3e2de2724a07caa88fa96d9
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.7/kubectl-view_serviceaccount_kubeconfig-darwin-arm64.zip
+    sha256: 6e6a608834fa3d54ac98124f7a2973f31a3ce83566ab104b5d146d90a56e8004
     bin: kubectl-view_serviceaccount_kubeconfig
     selector:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
-    sha256: bfe8f9358dd45a8c9fba0f8fcf3a61b53b93a7697e2d3ef5ee9248cc01feef6e
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.7/kubectl-view_serviceaccount_kubeconfig-linux-amd64.zip
+    sha256: 2daba6bbc4752d580a201f1cb0fa6d8558c19c1fae806531a23823f70847a21c
     bin: kubectl-view_serviceaccount_kubeconfig
     selector:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-arm64.zip
-    sha256: ecdaea81325f36657c863ff1f319115c744ea21c2329110f68e70722a7f87b3f
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.7/kubectl-view_serviceaccount_kubeconfig-linux-arm64.zip
+    sha256: d93ae906b097df8eaff75f30ad8d523d777dfcbce010cf0dafc0deba3f151aad
     bin: kubectl-view_serviceaccount_kubeconfig
     selector:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-linux-arm.zip
-    sha256: 66e99d8ba14733c362c31eee823869527924a881ecb8c6479352d0f00fe7e93b
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.7/kubectl-view_serviceaccount_kubeconfig-linux-arm.zip
+    sha256: 8512cf3e4b9515085abae73ae0a4c0278a17a7221c08ae5cf1bf1f3e5637b70e
     bin: kubectl-view_serviceaccount_kubeconfig
     selector:
       matchLabels:
         os: linux
         arch: arm
-  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.6/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
-    sha256: 96f18d0f4d0469bc0d0836b539847fd533cab1524e84888009e1e09f764b64c0
+  - uri: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin/releases/download/v2.2.7/kubectl-view_serviceaccount_kubeconfig-windows-amd64.zip
+    sha256: 31d0c056d0b5bf521dd90ab7a285d6ad5fe4142a9e3c72546b47a21e8d42f98d
     bin: kubectl-view_serviceaccount_kubeconfig.exe
     selector:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.2.6"
+  version: "v2.2.7"
   homepage: https://github.com/superbrothers/kubectl-view-serviceaccount-kubeconfig-plugin
   shortDescription: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.
   description: Show a kubeconfig setting to access the apiserver with a specified serviceaccount.


### PR DESCRIPTION
This PR bumps the version of view-serviceaccount-kubeconfig to v2.2.7.