### PR TITLE
add Clusternet plugin

### DIFF
--- a/plugins/clusternet.yaml
+++ b/plugins/clusternet.yaml
@@ -6,7 +6,7 @@ spec:
   homepage: https://github.com/clusternet/kubectl-clusternet
   shortDescription: "Wrap multiple kubectl calls to Clusternet"
   description: |
-    interacting with Clusternet.
+    A plugin to interact with Clusternet.
   version: "v0.3.0"
   caveats: |
     For additional options:

--- a/plugins/clusternet.yaml
+++ b/plugins/clusternet.yaml
@@ -1,0 +1,87 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: clusternet
+spec:
+  homepage: https://github.com/clusternet/kubectl-clusternet
+  shortDescription: "Wrap multiple kubectl calls to Clusternet"
+  description: |
+    interacting with Clusternet.
+  version: "v0.3.0"
+  caveats: |
+    For additional options:
+      $ kubectl clusternet --help
+      or https://github.com/clusternet/kubectl-clusternet/blob/main/doc/USAGE.md
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/clusternet/kubectl-clusternet/releases/download/v0.3.0/kubectl-clusternet_darwin_amd64.tar.gz
+    sha256: "541e0a12e5a8cc5f8c61df94ca9f971ba887b6348963b167e7c60186251d801d"
+    files:
+    - from: "./kubectl-clusternet"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "kubectl-clusternet"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/clusternet/kubectl-clusternet/releases/download/v0.3.0/kubectl-clusternet_darwin_arm64.tar.gz
+    sha256: "578983b113737bf8e0162496870d528f4880453fae23685f573d3556976c107e"
+    files:
+      - from: "./kubectl-clusternet"
+        to: "."
+      - from: LICENSE
+        to: "."
+    bin: "kubectl-clusternet"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/clusternet/kubectl-clusternet/releases/download/v0.3.0/kubectl-clusternet_linux_amd64.tar.gz
+    sha256: "f71559df77e37f099826ca6a75c128fb763bee1bb5cc3e11bd19ffe7d89d6ffe"
+    files:
+      - from: "./kubectl-clusternet"
+        to: "."
+      - from: LICENSE
+        to: "."
+    bin: "kubectl-clusternet"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/clusternet/kubectl-clusternet/releases/download/v0.3.0/kubectl-clusternet_linux_arm64.tar.gz
+    sha256: "0bbc63f14cd49c6fcce76e879896eae36ae28cf8948e0caffe35cdef8b83ba54"
+    files:
+      - from: "./kubectl-clusternet"
+        to: "."
+      - from: LICENSE
+        to: "."
+    bin: "kubectl-clusternet"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: "arm"
+    uri: https://github.com/clusternet/kubectl-clusternet/releases/download/v0.3.0/kubectl-clusternet_linux_armv6.tar.gz
+    sha256: "275161d0722c8877e82e7e599bfa647cbbbc97791ddb3277ca0689a6ae00c388"
+    files:
+      - from: "./kubectl-clusternet"
+        to: "."
+      - from: LICENSE
+        to: "."
+    bin: "kubectl-clusternet"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: "386"
+    uri: https://github.com/clusternet/kubectl-clusternet/releases/download/v0.3.0/kubectl-clusternet_linux_i386.tar.gz
+    sha256: "fe5ac6d0c950cf7b8f96be9f67da7a7ccdc6c3085c1c97b059326b62d4bf0ac1"
+    files:
+      - from: "./kubectl-clusternet"
+        to: "."
+      - from: LICENSE
+        to: "."
+    bin: "kubectl-clusternet"


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR is a proposal to add the [clusternet](https://github.com/clusternet/clusternet) plugin to krew-index.

[Clusternet](https://github.com/clusternet/clusternet) helps manage multiple Kubernetes clusters and coordinate applications to multiple clusters from a single set of APIs in a hosting cluster.
 
The README in the repos has more information [How It Works](https://github.com/clusternet/kubectl-clusternet#how-it-works).
