### PR TITLE
feat: add plugin kubectl-blame

### DIFF
--- a/plugins/blame.yaml
+++ b/plugins/blame.yaml
@@ -1,0 +1,33 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: blame
+spec:
+  version: v0.0.5
+  homepage: https://github.com/knight42/kubectl-blame
+  shortDescription: Show the manager of each field of given resource with information from managed fields.
+  description: |
+    Annotate each line in the given resource's YAML with information from the managedFields to show who last modified the field.
+
+    Examples:
+
+    # Blame pod 'foo' in default namespace
+    kubectl blame pods foo
+
+    # Blame deployment 'bar' in 'ns1' namespace
+    kubectl blame -n ns1 deploy bar
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/knight42/kubectl-blame/releases/download/v0.0.5/kubectl-blame-v0.0.5-darwin-amd64.tar.gz
+    sha256: 8a8e805bf2c3d059b83747e938ad641a5e3e621357c9c9403c565e289a884a1b
+    bin: kubectl-blame
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/knight42/kubectl-blame/releases/download/v0.0.5/kubectl-blame-v0.0.5-linux-amd64.tar.gz
+    sha256: ecf286a372a0c806f39ecaccf57550ec348c281b2707b8be12ec352d77f7a17b
+    bin: kubectl-blame

--- a/plugins/blame.yaml
+++ b/plugins/blame.yaml
@@ -5,17 +5,10 @@ metadata:
 spec:
   version: v0.0.5
   homepage: https://github.com/knight42/kubectl-blame
-  shortDescription: Show the manager of each field of given resource with information from managed fields.
+  shortDescription: Show who edited resource fields.
   description: |
-    Annotate each line in the given resource's YAML with information from the managedFields to show who last modified the field.
-
-    Examples:
-
-    # Blame pod 'foo' in default namespace
-    kubectl blame pods foo
-
-    # Blame deployment 'bar' in 'ns1' namespace
-    kubectl blame -n ns1 deploy bar
+    Annotate each line in the given resource's YAML with information from the managedFields to show
+    who last modified the field.
   platforms:
   - selector:
       matchLabels:


### PR DESCRIPTION
This plugin enable users to visualize the manager of each field of the given resource.