### PR TITLE
Add openebs plugin to krew index

### DIFF
--- a/plugins/openebs.yaml
+++ b/plugins/openebs.yaml
@@ -1,0 +1,53 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: openebs
+spec:
+  version: v0.2.0
+  homepage: https://github.com/openebs/openebsctl
+  shortDescription: View and debug OpenEBS storage resources
+  description: |
+    The openebs plugin provides a simplified interface to view
+    and debug different OpenEBS volumes and related storage resources.
+  caveats: |
+    * This plugin works with newer OpenEBS releases, where volumes are
+      provisioned by CSI.
+    * For resources that are not in default namespace, you must specify
+      -n/--namespace explicitly (the current namespace setting is not
+      yet used).
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/openebs/openebsctl/releases/download/v0.2.0/kubectl-openebs_v0.2.0_Darwin_x86_64.tar.gz
+    sha256: b99b3ffddc23f1624aeafc81004edfd59bd391a061c4238797ecfe19ffb61059
+    bin: kubectl-openebs_v0.2.0_Darwin_x86_64/kubectl-openebs
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/openebs/openebsctl/releases/download/v0.2.0/kubectl-openebs_v0.2.0_Darwin_arm64.tar.gz
+    sha256: 7b923ad015cd8f7f72a39e1d3aed091d4e4ea957e3dc5cdcb12ea6b7c00fb639
+    bin: kubectl-openebs_v0.2.0_Darwin_arm64/kubectl-openebs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/openebs/openebsctl/releases/download/v0.2.0/kubectl-openebs_v0.2.0_Linux_x86_64.tar.gz
+    sha256: 71d1e36ea4d7b288af642f162167bd27b9ccf158bbdd09381e03ed891ab1ced6
+    bin: kubectl-openebs_v0.2.0_Linux_x86_64/kubectl-openebs
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/openebs/openebsctl/releases/download/v0.2.0/kubectl-openebs_v0.2.0_Linux_arm64.tar.gz
+    sha256: 4a58b3acbcb88189aaf29e9f834ece608881f815213978aa2b6c6848aedc04fe
+    bin: kubectl-openebs_v0.2.0_Linux_arm64/kubectl-openebs
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/openebs/openebsctl/releases/download/v0.2.0/kubectl-openebs_v0.2.0_Windows_x86_64.zip
+    sha256: eefbf39807f8d7c4a554e1a876d01bf6a2a8efbcf99269e7e10b7ea445a58ee3
+    bin: kubectl-openebs_v0.2.0_Windows_x86_64/kubectl-openebs.exe


### PR DESCRIPTION
# Summary

The openebs plugin is a simpler way to view, manage and debug storage resources of different OpenEBS storage engines.

Project homepage: https://openebs.io/
Plugin source: https://github.com/openebs/openebsctl/


Signed-off-by: Harsh Vardhan <harsh.vardhan@mayadata.io>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
