### PR TITLE
HLF v1.3.1 update

### DIFF
--- a/plugins/hlf.yaml
+++ b/plugins/hlf.yaml
@@ -27,7 +27,7 @@ spec:
           os: linux
           arch: amd64
       uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.1/kubectl-hlf_linux_amd64.zip
-      sha256: c7011d2222754caafebc71ecee3cd83f380226028018a0133920b2f8e230ca56
+      sha256: 2ca33b574b4ff141404666936b206cc68d038a52906714538ae9a1a05ccdd901
       bin: kubectl-hlf
     - selector:
         matchLabels:

--- a/plugins/hlf.yaml
+++ b/plugins/hlf.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: hlf
 spec:
-  version: "v1.3.1"
+  version: "v1.3.2"
   homepage: https://github.com/kfsoftware/hlf-operator
   shortDescription: "Deploy and manage Hyperledger Fabric components"
   description: |
@@ -19,20 +19,20 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.1/kubectl-hlf_darwin_amd64.zip
+      uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.2/kubectl-hlf_darwin_amd64.zip
       sha256: 31e5b0bbeb7d55aa07f089672649f860a66c51da49bdace2e29f681dee9a5ab2
       bin: kubectl-hlf
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.1/kubectl-hlf_linux_amd64.zip
+      uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.2/kubectl-hlf_linux_amd64.zip
       sha256: 2ca33b574b4ff141404666936b206cc68d038a52906714538ae9a1a05ccdd901
       bin: kubectl-hlf
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.1/kubectl-hlf_windows_amd64.zip
+      uri: https://github.com/kfsoftware/hlf-operator/releases/download/v1.3.2/kubectl-hlf_windows_amd64.zip
       sha256: 75a9251c12e518ad45ac1543faeb088107a0b61f49b11c4853bd361b39122f1e
       bin: kubectl-hlf.exe


### PR DESCRIPTION
Linux binary wasn't executable, i had to `chmod +x kubectl-hlf` and upload the zip again.