### PR TITLE
Add rook-ceph plugin

### DIFF
--- a/rook-ceph.yaml
+++ b/rook-ceph.yaml
@@ -1,0 +1,27 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rook-ceph
+spec:
+  version: "v0.0.1"
+  homepage: https://github.com/rook/kubectl-rook-ceph
+  shortDescription: "Rook plugin for Ceph management"
+  description: |
+     Krew plugin to provide insight to Rook configuration of the Ceph storage provider.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+        - windows
+    uri: https://github.com/rook/kubectl-rook-ceph/archive/v0.0.1.zip
+    sha256: 2ca817372441097235c0b7e8dff87c0e99153b154dc83a6a47fc5d691a966209
+    files:
+    - from: "kubectl-rook-ceph-0.0.1/kubectl-rook-ceph.sh"
+      to: "kubect-rook-ceph.sh"
+    - from: "kubectl-rook-ceph-0.0.1/LICENSE"
+      to: "."
+    bin: kubect-rook-ceph.sh


### PR DESCRIPTION
Adding rook-ceph as plugin in krew which will
help user run commands to related to Ceph and to
troubleshoot rook Ceph cluster.

few examples:

```
kubectl rook-ceph ceph status
  cluster:
    id:     7a127d0d-79fe-419c-9524-cdad7880cffd
    health: HEALTH_OK

  services:
    mon: 1 daemons, quorum a (age 50s)
    mgr: a(active, since 11s)
    osd: 1 osds: 1 up (since 11s), 1 in (since 28s)

  data:
    pools:   1 pools, 1 pgs
    objects: 0 objects, 0 B
    usage:   4.8 MiB used, 14 GiB / 14 GiB avail
    pgs:     1 active+clean
```

```
kubectl rook-ceph ceph mon stat
e1: 1 mons at {a=[v2:10.108.140.137:3300/0,v1:10.108.140.137:6789/0]}, election epoch 3, leader 0 a, quorum 0 a
+ kubectl rook-ceph ceph osd tree
ID  CLASS  WEIGHT   TYPE NAME              STATUS  REWEIGHT  PRI-AFF
-1         0.01369  root default
-3         0.01369      host fv-az129-623
 0    hdd  0.01369          osd.0              up   1.00000  1.00000
```

Signed-off-by: subhamkrai <srai@redhat.com>



- [X] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- [X]  Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
