### PR TITLE
Update MiniO v4.3.1

### DIFF
--- a/plugins/minio.yaml
+++ b/plugins/minio.yaml
@@ -24,7 +24,7 @@ spec:
   - selector:
       matchLabels:
         os: darwin
-        arch: amd64
+        arch: arm64
     uri: https://github.com/minio/operator/releases/download/v4.3.1/kubectl-minio_darwin_arm64.zip
     sha256: 699244d5625c2af46b7f3bfc657214dcf8326ef1c6b7429350ce00a6137246a1
     bin: kubectl-minio
@@ -38,7 +38,7 @@ spec:
   - selector:
       matchLabels:
         os: linux
-        arch: amd64
+        arch: arm64
     uri: https://github.com/minio/operator/releases/download/v4.3.1/kubectl-minio_linux_arm64.zip
     sha256: f8e16c07c7feccf854364c27f39cdfb2a3013923e0757f944359b92ecc762424
     bin: kubectl-minio


### PR DESCRIPTION
Updated MinIO to v4.3.1
Signed-off-by: Daniel Valdivia <18384552+dvaldivia@users.noreply.github.com>

