### PR TITLE
Update cert-manager kubectl plugin to 1.6.1

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v1.5.0
+  version: v1.6.1
   homepage: https://github.com/jetstack/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -16,41 +16,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.5.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 4adeb315224f9ad178c5b6359c3ef8d40515900a20bdf8bea343fcd3dcf2948d
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: 52014c55de5728f3d107dd80b6319e4dc72b6a7700643bcd3e4a89c7f3eb0d98
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.5.0/kubectl-cert_manager-darwin-arm64.tar.gz
-    sha256: 4f053b1863f7bd02991bfce79328fd35700ea31078c84fe3342642e77c9cb9bb
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-darwin-arm64.tar.gz
+    sha256: 3d98377471d8625235dfa41a05f762a4888944f40734b37b405b894244d4c149
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.5.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: 576d6fc05f785795de83ccfc62ae72d29c2907795a4a411458e57642f5e47891
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: cf9cb0b1020cc437d431805be4baf2bc9de6de0b06e7821b0dd7d5d598cc1f36
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.5.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 91a299a76eae0722065f79c9d2e775804066461577c409e824c34081075f9b98
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 9b7835fc52c106ba6d740d9f73a60ffdd2ccf108de3a73d1c7cba32576bba6c2
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.5.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 1ef7a5e98dc8b61e8c8d3f9e08c7811a1c3cddd703f0b756f03e997154b5b00c
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 4c69a8f41135c89c09f5d151ffb1cd6bb30412e8e9681327acad03070cf95164
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.5.0/kubectl-cert_manager-windows-amd64.tar.gz
-    sha256: 25ec3306bbfef265c0620b59a917337ac6485d72b12a24c0179084e99c18b2b5
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-windows-amd64.tar.gz
+    sha256: 7f2f3359e1b0c9ff49d41cf5454ffc3237df36fb451a7ca16dd67db38973af96
     bin: kubectl-cert_manager


### PR DESCRIPTION
This process isn't automated because the github actions workflow didn't mesh very well with cert-manager's current development workflow, and we didn't have the time to invest to create a shim between the two. We'd ideally like to automate this at some point but for now it's still manual.
