### PR TITLE
feat: add plugin kubectl-relay

### DIFF
--- a/plugins/relay.yaml
+++ b/plugins/relay.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.0.1
   homepage: https://github.com/knight42/krelay
-  shortDescription: An enhanced `kubectl port-forward`.
+  shortDescription: Drop-in "port-forward" replacement with UDP and hostname resolution.
   description: |
     This kubectl plugin is a drop-in replacement for `kubectl port-forward` with some enhanced features:
     * Supports UDP port forwarding

--- a/plugins/relay.yaml
+++ b/plugins/relay.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: relay
+spec:
+  version: v0.0.1
+  homepage: https://github.com/knight42/krelay
+  shortDescription: An enhanced `kubectl port-forward`.
+  description: |
+    This kubectl plugin is a drop-in replacement for `kubectl port-forward` with some enhanced features:
+    * Supports UDP port forwarding
+    * Forwarding data to the given IP or hostname that is accessible within the kubernetes cluster
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/knight42/krelay/releases/download/v0.0.1/kubectl-relay_v0.0.1_darwin-amd64.tar.gz
+    sha256: a2f6dffa0c1f47fcefcc4fd18de5910ad754c124477b496e8aa3907af17f4255
+    bin: kubectl-relay
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/knight42/krelay/releases/download/v0.0.1/kubectl-relay_v0.0.1_darwin-arm64.tar.gz
+    sha256: d5d704118c98e9c3bff8f51a407f45144b5251601ca25b91c68c103d949d3104
+    bin: kubectl-relay
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/knight42/krelay/releases/download/v0.0.1/kubectl-relay_v0.0.1_linux-amd64.tar.gz
+    sha256: 84f1e95a2d6fd0e59afe5fe3211eee98ee726f534078195fa8b0c39770d07e56
+    bin: kubectl-relay
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/knight42/krelay/releases/download/v0.0.1/kubectl-relay_v0.0.1_linux-arm64.tar.gz
+    sha256: 54eb164a036c793117569d24a1b8ec7ecc533b439609004d7bf4ce3dd115dd5b
+    bin: kubectl-relay


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

This kubectl plugin is a drop-in replacement for `kubectl port-forward` with some enhanced features:
* Supports UDP port forwarding
* Forwarding data to the given IP or hostname that is accessible within the kubernetes cluster