### PR TITLE
add htpasswd plugin

### DIFF
--- a/plugins/htpasswd.yaml
+++ b/plugins/htpasswd.yaml
@@ -1,0 +1,40 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: htpasswd
+spec:
+  version: v0.1.6
+  homepage: https://github.com/shibumi/kubectl-htpasswd
+  shortDescription: Create nginx-ingress compatible basic-auth secrets
+  description: |
+    This plugin provides a convenient way to create nginx-ingress compatible
+    basic auth secrets.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/shibumi/kubectl-htpasswd/releases/download/v0.1.6/kubectl-htpasswd_v0.1.6_darwin_amd64.tar.gz
+      sha256: a21e1c9ffc5302caa0039622184b7371dd4cd079723d05ca81f3dee2eeb3fa30
+      bin: kubectl-htpasswd
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/shibumi/kubectl-htpasswd/releases/download/v0.1.6/kubectl-htpasswd_v0.1.6_darwin_arm64.tar.gz
+      sha256: fb2401d05125f45120c5df243ad7b8796943454bf09615f958ac9bc789a22867
+      bin: kubectl-htpasswd
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/shibumi/kubectl-htpasswd/releases/download/v0.1.6/kubectl-htpasswd_v0.1.6_linux_amd64.tar.gz
+      sha256: f43eb729240e69da95ca8baf726179f73a1356086067b223b9f5ba8bedc7cec6
+      bin: kubectl-htpasswd
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/shibumi/kubectl-htpasswd/releases/download/v0.1.6/kubectl-htpasswd_v0.1.6_windows_amd64.tar.gz
+      sha256: f94804f82e266b65da1b35ea2376212aff469765fc3fc1809673a0976600e915
+      bin: kubectl-htpasswd.exe


### PR DESCRIPTION
Plugin installation works locally:

```
❯ krew install --manifest /tmp/krew.yaml --archive kubectl-htpasswd_v0.1.6_linux_amd64.tar.gz
Installing plugin: htpasswd
Installed plugin: htpasswd
\
 | Use this plugin:
 |      kubectl htpasswd
 | Documentation:
 |      https://github.com/shibumi/kubectl-htpasswd
/
```

However, I have some issues with my krew.yaml file and the go templating for the krew-releaser-bot.
The templating seems to be buggy and creates an invalid YAML file. I had to fix manually the indention for the hash checksum lines.

Is this a known bug with https://github.com/rajatjindal/krew-release-bot ?
