### PR TITLE
Update open-svc to v2.5.2

### DIFF
--- a/plugins/open-svc.yaml
+++ b/plugins/open-svc.yaml
@@ -3,83 +3,53 @@ kind: Plugin
 metadata:
   name: open-svc
 spec:
+  version: v2.5.2
   platforms:
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-darwin-amd64.zip
-    sha256: e18741c35e75b027ac4d43e11d179848042873f74fc3e11c486f452af07b2d47
-    bin: kubectl-open_svc
-    files:
-    - from: kubectl-open_svc
-      to: .
-    - from: LICENSE
-      to: .
+  - bin: kubectl-open_svc.exe
+    uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.2/kubectl-open_svc-windows-arm64.zip
+    sha256: 633bed73d605629eb38ebb5c007e8b8f532a5f62ec7536d6694c2dd5b1dd9b04
     selector:
       matchLabels:
-        os: darwin
-        arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-darwin-arm64.zip
-    sha256: 1d4e5f772736e4130af8fa71a07111f237258b8ac7ad4a1f4e933cfec8ff1d77
-    bin: kubectl-open_svc
-    files:
-    - from: kubectl-open_svc
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: darwin
+        os: windows
         arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-linux-amd64.zip
-    sha256: 46083b84b6066692639a9ee0eaa5a7ffe44bb2fc3020b84c0b0aeefdce93e3d8
-    bin: kubectl-open_svc
-    files:
-    - from: kubectl-open_svc
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-linux-arm64.zip
-    sha256: f21ef09fab5b569a915ff18a59b3975b5d1928f74fea24db71eee88e26eab4ef
-    bin: kubectl-open_svc
-    files:
-    - from: kubectl-open_svc
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: linux
-        arch: arm64
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-linux-arm.zip
-    sha256: 7a29a02f23a045bcff5d0fb880348206992c1da7809e1906394bf2ece9ae1aca
-    bin: kubectl-open_svc
-    files:
-    - from: kubectl-open_svc
-      to: .
-    - from: LICENSE
-      to: .
-    selector:
-      matchLabels:
-        os: linux
-        arch: arm
-  - uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.1/kubectl-open_svc-windows-amd64.zip
-    sha256: 8c1aacfce72fff8625ecf2282211ce70e07ee748ca06793d525878a9b17e7e95
-    bin: kubectl-open_svc.exe
-    files:
-    - from: kubectl-open_svc.exe
-      to: .
-    - from: LICENSE
-      to: .
+  - bin: kubectl-open_svc.exe
+    uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.2/kubectl-open_svc-windows-amd64.zip
+    sha256: 46c38708263112b1a3d056f8c637f24bad325294eba845be137cced877159f36
     selector:
       matchLabels:
         os: windows
         arch: amd64
-  version: "v2.5.1"
+  - bin: kubectl-open_svc
+    uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.2/kubectl-open_svc-linux-arm64.zip
+    sha256: c6fb6204a39b7dc9b72ba6441222d48b7e9eaa39c8a1aa56271a92d9bdefd8d8
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+  - bin: kubectl-open_svc
+    uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.2/kubectl-open_svc-linux-amd64.zip
+    sha256: b5200c4241cc78daded172e183dbca9b7e5b0174a437bc6851edab8cce573a95
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - bin: kubectl-open_svc
+    uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.2/kubectl-open_svc-darwin-arm64.zip
+    sha256: dfdc560e438cd07086c895a57a9ccd2ac00003b40fc4cf645ba4091d4d6e4ea9
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - bin: kubectl-open_svc
+    uri: https://github.com/superbrothers/kubectl-open-svc-plugin/releases/download/v2.5.2/kubectl-open_svc-darwin-amd64.zip
+    sha256: 0dfd2bf8e9eca7cde00bb67df61626567e6f8202f35b24b8cf21ffbbb6751f2d
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
   shortDescription: Open the Kubernetes URL(s) for the specified service in your browser.
+  homepage: https://github.com/superbrothers/kubectl-open-svc-plugin
   description: |
     Open the Kubernetes URL(s) for the specified service in your browser.
     Unlike the `kubectl port-forward` command, this plugin makes services
     accessible via their ClusterIP.
-  homepage: https://github.com/superbrothers/kubectl-open-svc-plugin


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

I changed to use GoReleaser to generate the krew plugin manifest file. The order of the fields has changed because of this. Next time the changes should be minimal.

