### PR TITLE
CI: Update validate-krew-manifest with latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         export GOBIN=$HOME/bin
         # TODO(corneliusweig): pin validator version after next release
         # go get sigs.k8s.io/krew/cmd/validate-krew-manifest@${KREW_VERSION}
-        go get sigs.k8s.io/krew/cmd/validate-krew-manifest@ec169f8c9c53e0aaaf57f1f73fb38590842ceb77
+        go get sigs.k8s.io/krew/cmd/validate-krew-manifest@b015efbdf40d4cce7e02b9e4e4805d373c40aa25
 
     - name: Validate updated plugin manifests
       run : |


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This PR updates `validate-krew-manifest` used in CI with latest. It has been added windows/arm64 to the supported platforms.

**Before**

```
$ g show -q
commit 9cdc1f313d0758d54b91b81b279b5928c0099dab (HEAD -> open-svc-2.5.2, superbrothers/open-svc-2.5.2)
Author: Kazuki Suda <kazuki.suda@gmail.com>
Date:   Wed Dec 15 22:31:07 2021 +0900

    Update open-svc to v2.5.2

$ go install sigs.k8s.io/krew/cmd/validate-krew-manifest@ec169f8c9c53e0aaaf57f1f73fb38590842ceb77

$ validate-krew-manifest -manifest plugins/open-svc.yaml
I1216 08:48:42.498895 3969238 main.go:67] reading file "plugins/open-svc.yaml"
I1216 08:48:42.499641 3969238 main.go:84] structural validation OK
F1216 08:48:42.499721 3969238 main.go:62] spec.platform[0]'s selector (&LabelSelector{MatchLabels:map[string]string{arch: arm64,os: windows,},MatchExpressions:[]LabelSelectorRequirement{},}) doesn't match any supported platforms
```

**After**

```
$ go install sigs.k8s.io/krew/cmd/validate-krew-manifest@b015efbdf40d4cce7e02b9e4e4805d373c40aa25

$ validate-krew-manifest -manifest plugins/open-svc.yaml -skip-install
I1216 08:54:05.756337  523057 main.go:69] reading file "plugins/open-svc.yaml"
I1216 08:54:05.757277  523057 main.go:86] structural validation OK
I1216 08:54:05.757662  523057 main.go:94] all spec.platform[] items are used
I1216 08:54:05.758062  523057 main.go:100] no overlapping spec.platform[].selector
```

/ref https://github.com/kubernetes-sigs/krew-index/pull/1844
