### PR TITLE
implement go mod cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,18 +4,25 @@ on: pull_request
 
 jobs:
   build:
-    name: Build and Tags
+    name: Validate plugin manifests
     runs-on: ubuntu-latest
     env:
       KREW_VERSION: v0.4.0
       GO111MODULE: on
     steps:
 
-    - name: Set up Go 1.14
+    - name: Setup Go
       uses: actions/setup-go@v1
       with:
         go-version: 1.14
       id: go
+    - name: Go module cache
+      uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Check out PR branch
       uses: actions/checkout@v2


### PR DESCRIPTION
since we do go-get, 15s (about 50%) of the time of each krew-index PR
is spent there. this solves that.

/cc @chriskim06