### PR TITLE
ktop plugin

### DIFF
--- a/plugins/ktop.yaml
+++ b/plugins/ktop.yaml
@@ -1,0 +1,43 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ktop
+spec:
+  version: v0.2.0
+  platforms:
+    - bin: kubectl-ktop
+      uri: https://github.com/vladimirvivien/ktop/releases/download/v0.2.0/kubectl-ktop_v0.2.0_linux_arm64.tar.gz
+      sha256: f6e979ccfbd24467b94db44e11e17a43fa80afc2fd90fcb0aac0139327b464b3
+      selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+    - bin: kubectl-ktop
+      uri: https://github.com/vladimirvivien/ktop/releases/download/v0.2.0/kubectl-ktop_v0.2.0_linux_amd64.tar.gz
+      sha256: 6390c612c4715fe0debc8df476a52325fc71a3e4fdb8ace1d9de2629afcfd0a8
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - bin: kubectl-ktop
+      uri: https://github.com/vladimirvivien/ktop/releases/download/v0.2.0/kubectl-ktop_v0.2.0_darwin_arm64.tar.gz
+      sha256: f941b71c0628dffade4b178fc00b69e466118aacd3065f3f6128228d2fe9d548
+      selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+    - bin: kubectl-ktop
+      uri: https://github.com/vladimirvivien/ktop/releases/download/v0.2.0/kubectl-ktop_v0.2.0_darwin_amd64.tar.gz
+      sha256: a4348ea29fc11821292e78b7f114cc5a9d441fa0404b5b7f1c65fcf57a50f1c8
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+  shortDescription: A top tool to display workload metrics
+  homepage: https://github.com/vladimirvivien/ktop
+  caveats: |
+    * By default, ktop displays metrics for resources in the default namespace. You can override this behavior
+    by providing a --namespace or use -A for all namespaces.
+  description: |
+    This is a kubectl plugin for ktop, a top-like tool for displaying workload
+    metrics for a running Kubernetes cluster.


### PR DESCRIPTION
This patch introduces ktop as a kubectl plugin.

### Local installation

```
kubectl krew install --manifest dist/ktop.yaml
Installing plugin: ktop
Installed plugin: ktop
\
 | Use this plugin:
 | 	kubectl ktop
 | Documentation:
 | 	https://github.com/vladimirvivien/ktop
 | Caveats:
 | \
 |  | * By default, ktop displays metrics for resources in the default namespace. You can override this behavior
 |  | by providing a --namespace or use -A for all namespaces.
 | /
/
```

### Local verification

```
kubectl ktop
Connected to: https://192.168.64.21:8443

 _    _
| | _| |_ ___  _ __
| |/ / __/ _ \| '_ \
|   <| || (_) | |_) |
|_|\_\\__\___/| .__/
              |_|
Version v0.2.0 (426916f7d1eb3d9da0586970b112f21d6ebdfff0)
```

### Plugin help

```
 kubectl ktop --help
Runs kubectl-ktop as kubectl plugin

Usage:
  kubectl-ktop [flags]

Examples:

# Start ktop using default configuration for the "default" namespace
kubectl-ktop

# Start ktop with default configuration for all accessible namespaces
kubectl-ktop -A

# Start ktop for a specific namespace in current context
kubectl-ktop --namespace <namespace>

# Start ktop for a specific namespace and context
kubectl-ktop --namespace <namespace> --context <context>


Flags:
  -A, --all-namespaces                 If true, display metrics for all accessible namespaces
      --as string                      Username to impersonate for the operation. User could be a regular user or a service account in a namespace.
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --as-uid string                  UID to impersonate for the operation.
      --cache-dir string               Default cache directory (default "/Users/vivienv/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
  -h, --help                           help for kubectl-ktop
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
```