### PR TITLE
`kubectl explore` plugin

### DIFF
--- a/plugins/explore.yaml
+++ b/plugins/explore.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: explore
+spec:
+  version: v0.3.2
+  homepage: https://github.com/kei6u/kubectl-explore
+  shortDescription: A better kubectl explain with the fuzzy finder
+  description: |
+    Fuzzy-find and explain the fields associated with
+    supported API resource.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_darwin_amd64.tar.gz
+    sha256: 0f9ea364efe6b9ef5fc3962bda85f0e06d8c1498c44b333f23f3b9338742432c
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_darwin_arm64.tar.gz
+    sha256: 737c3803cee28c49d0fb07f18369372d93f55f490f407fe644105abf53759b46
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_linux_amd64.tar.gz
+    sha256: 17db3f0fcacf8b32a8bfaf908331838ed642073079d487fbf3d86459730f7074
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_linux_arm64.tar.gz
+    sha256: 65c206a4679bcdd5411ea2da92aba9522e65670501f1d1de683e00017fa01c52
+    bin: kubectl-explore
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/kei6u/kubectl-explore/releases/download/v0.3.2/kubectl-explore_v0.3.2_windows_amd64.tar.gz
+    sha256: a5d76115a49d0f9eff120ef5fe59011cafccfe94eeefb8e1934488ea6fb4a273
+    bin: kubectl-explore.exe


### PR DESCRIPTION
This patch introduces `kubectl explore` as a kubectl plugin.

**Local installation**

![Screen Shot 2022-01-06 at 22 55 34](https://user-images.githubusercontent.com/41987730/148393570-bbb1b29a-fb6d-4fff-a197-b87c2cf2ce21.png)

**Plugin help**

![Screen Shot 2022-01-06 at 22 57 25](https://user-images.githubusercontent.com/41987730/148393828-90507c3f-8f48-4429-906f-9d035fb2593e.png)

