### PR TITLE
`kubectl secretdata` plugin

### DIFF
--- a/plugins/secretdata.yaml
+++ b/plugins/secretdata.yaml
@@ -5,14 +5,10 @@ metadata:
 spec:
   version: v1.0.1
   homepage: https://github.com/kei6u/kubectl-secretdata
-  shortDescription: A kubectl plugin for finding decoded secret data with productive search flags
+  shortDescription: Viewing decoded Secret data with search flags
   description: |
-    This is a kubectl plugin for finding decoded secret data.
-    Since kubectl outputs base64-encoded secrets basically,
-    it makes it difficult to check the secret value.
-    And searching secrets also is difficult. This tool helps
-    verify the real secret value and find the secrets
-    you want with productive search flags.
+    This plugin provides functions to view decoded Secret data and helpful flags
+    such as regular expression, selecting multiple namespaces, label selectors, etc.
   platforms:
   - selector:
       matchLabels:

--- a/plugins/secretdata.yaml
+++ b/plugins/secretdata.yaml
@@ -1,0 +1,51 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: secretdata
+spec:
+  version: v1.0.1
+  homepage: https://github.com/kei6u/kubectl-secretdata
+  shortDescription: A kubectl plugin for finding decoded secret data with productive search flags
+  description: |
+    This is a kubectl plugin for finding decoded secret data.
+    Since kubectl outputs base64-encoded secrets basically,
+    it makes it difficult to check the secret value.
+    And searching secrets also is difficult. This tool helps
+    verify the real secret value and find the secrets
+    you want with productive search flags.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/kei6u/kubectl-secretdata/releases/download/v1.0.1/kubectl-secretdata_v1.0.1_darwin_amd64.tar.gz
+    sha256: 548c283e6ff3fbb477fbe602219599fd749d7be7b47bcf4ea549e1a262950866
+    bin: kubectl-secretdata
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/kei6u/kubectl-secretdata/releases/download/v1.0.1/kubectl-secretdata_v1.0.1_darwin_arm64.tar.gz
+    sha256: 732f55d4c0d06343f746d676e62fe9d148396be2a1b250c23f6fe123a4fed895
+    bin: kubectl-secretdata
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/kei6u/kubectl-secretdata/releases/download/v1.0.1/kubectl-secretdata_v1.0.1_linux_amd64.tar.gz
+    sha256: 612d5c9c0a43e0f8b87c61b047911d1ce66286156fe9fce1f1d9d637503235af
+    bin: kubectl-secretdata
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/kei6u/kubectl-secretdata/releases/download/v1.0.1/kubectl-secretdata_v1.0.1_linux_arm64.tar.gz
+    sha256: 983d612eb493ec80af0fa5ac2d33c5dd1b4f5ebdaf62f5599293df93104856f8
+    bin: kubectl-secretdata
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/kei6u/kubectl-secretdata/releases/download/v1.0.1/kubectl-secretdata_v1.0.1_windows_amd64.tar.gz
+    sha256: d95cd7a88465e8e5c81fe5007ba0ef3f1301e782e864355c421895a3176123da
+    bin: kubectl-secretdata.exe


### PR DESCRIPTION
This patch introduces `kubectl secretdata` as a kubectl plugin.

**Local installation**

![Screen Shot 2022-01-11 at 7 41 08](https://user-images.githubusercontent.com/41987730/148850361-07348587-5c01-4126-ac21-eebd2bc97002.png)

**Plugin help**

![Screen Shot 2022-01-11 at 7 41 50](https://user-images.githubusercontent.com/41987730/148850419-c998deb6-2a1d-45f6-be46-f9a3dd0c640f.png)
