### PR TITLE
Add kubectl realname-diff plugin to krew index

### DIFF
--- a/plugins/realname-diff.yaml
+++ b/plugins/realname-diff.yaml
@@ -22,14 +22,14 @@ spec:
   shortDescription: Diffs live and local resources ignoring Kustomize hash-suffixes
   homepage: https://github.com/hhiroshell/kubectl-realname-diff
   description: |
-    Normally, kubectl realname-diff works the same as kubectl diff, but if you set
-    "real name" as a label, local and live resources with the same label will be
+    Kubectl realname-diff works the same as kubectl diff, but if you set "real
+    name" as a label, local and live resources with the same label will be
     compared.
 
-    This is especially beneficial if you use the Kustomize and enable the hash
-    suffixed ConfigMap/Secret name. In case of `kubectl diff`, local and live
+    This is especially beneficial if you use the Kustomize and enable hash
+    suffixing ConfigMap/Secret names. In case of `kubectl diff`, local and live
     resources with hash suffixed name are considered as irrelevant. So you will not
     be able to get any results comparing them.
 
-    However, with realname-diff, you can compare the resources with hash suffixed
-    name by specifying the comparison target with "real name" labels.
+    With realname-diff, you can compare the resources with hash suffixed name by
+    specifying the comparison target with "real name" labels.

--- a/plugins/realname-diff.yaml
+++ b/plugins/realname-diff.yaml
@@ -1,0 +1,35 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: realname-diff
+spec:
+  version: v0.1.1
+  platforms:
+  - bin: kubectl-realname_diff
+    uri: https://github.com/hhiroshell/kubectl-realname-diff/releases/download/v0.1.1/kubectl-realname-diff-linux-amd64.zip
+    sha256: ba5d1ca7452717e798d7c1413857919541d291e8bd6385b5c83d5b8857f9d6f6
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - bin: kubectl-realname_diff
+    uri: https://github.com/hhiroshell/kubectl-realname-diff/releases/download/v0.1.1/kubectl-realname-diff-darwin-amd64.zip
+    sha256: 28a10e70064f814614de5de57473cae20b099639747ef3b855b6d0eda090443d
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  shortDescription: Diffs live and local resources ignoring Kustomize hash-suffixes
+  homepage: https://github.com/hhiroshell/kubectl-realname-diff
+  description: |
+    Normally, kubectl realname-diff works the same as kubectl diff, but if you set
+    "real name" as a label, local and live resources with the same label will be
+    compared.
+
+    This is especially beneficial if you use the Kustomize and enable the hash
+    suffixed ConfigMap/Secret name. In case of `kubectl diff`, local and live
+    resources with hash suffixed name are considered as irrelevant. So you will not
+    be able to get any results comparing them.
+
+    However, with realname-diff, you can compare the resources with hash suffixed
+    name by specifying the comparison target with "real name" labels.


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Hi,

I'd like to raise the request to add realname-diff plugin to krew index. It is a kubectl plugin to diff live and local resources ignoring Kustomize hash-suffixes.

## Local installation

```
❯ kubectl krew install --manifest=plugins/realname-diff.yaml
Installing plugin: realname-diff
Installed plugin: realname-diff
\
 | Use this plugin:
 | 	kubectl realname-diff
 | Documentation:
 | 	https://github.com/hhiroshell/kubectl-realname-diff
/
```

## Plugin help

```
❯ kubectl realname-diff -h
Diffs live and local resources ignoring Kustomize hash-suffixes.

Normally, "kubectl realname-diff" works the same as "kubectl diff", but if you
set "real name" as a label, local and live resources with the same label will be
compared.

Usage:
  kubectl realname-diff -f FILENAME

Examples:
  # Make sure you have already labeled the resources with
  # "realname-diff/realname: [real name]". For a complete example, see:
  # https://github.com/hhiroshell/kubectl-realname-diff/tree/main/example

  # Diff resources included in the result of kustomize build
  kustomize build ./example | kubectl realname-diff -f -

  # Also you can use kubectl's built-in kustomize
  kubectl realname-diff -k ./example

Flags:
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default cache directory (default "/Users/hhiroshell/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --field-manager string           Name of the manager used to track field ownership. (default "kubectl-client-side-apply")
  -f, --filename strings               Filename, directory, or URL to files contains the configuration to diff
      --force-conflicts                If true, server-side apply will force the changes against conflicts.
  -h, --help                           help for kubectl
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -k, --kustomize string               Process the kustomization directory. This flag can't be used together with -f or -R.
  -n, --namespace string               If present, the namespace scope for this CLI request
  -R, --recursive                      Process the directory used in -f, --filename recursively. Useful when you want to manage related manifests organized within the same directory.
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
  -s, --server string                  The address and port of the Kubernetes API server
      --server-side                    If true, apply runs in the server instead of the client.
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
```