### PR TITLE
new version v0.3.0 of edit-status

### DIFF
--- a/plugins/edit-status.yaml
+++ b/plugins/edit-status.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: edit-status
 spec:
-  version: v0.2.0
+  version: v0.3.0
   homepage: https://github.com/ulucinar/kubectl-edit-status
   shortDescription: Edit /status subresources of CRs
   description: |
@@ -20,27 +20,27 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.2.0/kubectl-edit-status_v0.2.0_darwin_amd64.tar.gz
-      sha256: dbb65ab56beb3ece575748c17961e76018ff2e3eb74a4d221369b308d049f8e3
+      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.3.0/kubectl-edit-status_v0.3.0_darwin_amd64.tar.gz
+      sha256: bf5cf012a7531b75739d11bfad8095d2fdc69134291aadaf980b33f52cd60f57
       bin: kubectl-edit_status
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.2.0/kubectl-edit-status_v0.2.0_darwin_arm64.tar.gz
-      sha256: 94022f35297521268ced92be7474e300a7b086079dd0c442c790310c20ba6959
+      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.3.0/kubectl-edit-status_v0.3.0_darwin_arm64.tar.gz
+      sha256: f6da5dbffc90ed69007465771d543874dd0b8fd63b5c469acb927e9816c18a1d
       bin: kubectl-edit_status
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.2.0/kubectl-edit-status_v0.2.0_linux_amd64.tar.gz
-      sha256: f4c463eb61532c865875715862c3e18c17f688f0f0d59365d77c32f37d9b82d5
+      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.3.0/kubectl-edit-status_v0.3.0_linux_amd64.tar.gz
+      sha256: 85a44d895ee4febe9f62942ace5b70a4c1d483929e96c12c1341b5c1fc206bdc
       bin: kubectl-edit_status
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.2.0/kubectl-edit-status_v0.2.0_windows_amd64.tar.gz
-      sha256: 006d2367463cadacf3dee6b026530eabf62e1826078a4c883b16a2f0e76cfc66
+      uri: https://github.com/ulucinar/kubectl-edit-status/releases/download/v0.3.0/kubectl-edit-status_v0.3.0_windows_amd64.tar.gz
+      sha256: 6a02a2fe5e5aa821fbc6f48778d694352614ab3ca9f3c38d884bc3e385efe32d
       bin: kubectl-edit_status.exe


### PR DESCRIPTION
new version `v0.3.0` of `edit-status`. Changelog: 
https://github.com/ulucinar/kubectl-edit-status/releases/tag/v0.3.0

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
