### PR TITLE
feat: add m1 support (darwin/arm64) for deprecations (kubepug)

### DIFF
--- a/plugins/deprecations.yaml
+++ b/plugins/deprecations.yaml
@@ -26,7 +26,14 @@ spec:
         arch: amd64
     uri: https://github.com/rikatz/kubepug/releases/download/v1.3.2/kubepug_darwin_amd64.tar.gz
     sha256: 3c5e6d49e1a32d2e102004486ae929dcede6ac07bad1a8c2243e2c6cc1c0eb67
-    bin: "kubepug" 
+    bin: "kubepug"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/rikatz/kubepug/releases/download/v1.3.2/kubepug_darwin_arm64.tar.gz
+    sha256: f11ce7b78f1a31b27d4b014fb1edd234ece19684bda485316f6c23de5ab083b1
+    bin: "kubepug"
   - selector:
       matchLabels:
         os: linux


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

# Motivation

Installation for https://github.com/rikatz/kubepug currently fails on m1 macbooks
```
kubectl krew install deprecations
Updated the local copy of plugin index.
Installing plugin: deprecations
W0124 17:06:28.276080   99305 install.go:164] failed to install plugin "deprecations": plugin "deprecations" does not offer installation for this platform
F0124 17:06:28.276136   99305 root.go:79] failed to install some plugins: [deprecations]: plugin "deprecations" does not offer installation for this platform
```

This adds the m1 compatible binary links