### PR TITLE
update cert-manager plugins for cert-manager 1.7

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v1.6.1
+  version: v1.7.0
   homepage: https://github.com/jetstack/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -16,41 +16,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 52014c55de5728f3d107dd80b6319e4dc72b6a7700643bcd3e4a89c7f3eb0d98
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: d8ecfb9c5395c3ac393396bcfa9709565f90c610039fafe557c2f21036b94e45
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-darwin-arm64.tar.gz
-    sha256: 3d98377471d8625235dfa41a05f762a4888944f40734b37b405b894244d4c149
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-darwin-arm64.tar.gz
+    sha256: c96927aa4b7f7dc67ae5e6486b977550906538b19827457ad86c22b8b1fa7cb5
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: cf9cb0b1020cc437d431805be4baf2bc9de6de0b06e7821b0dd7d5d598cc1f36
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 73618617b9ec42994c3ea77bbc8be743e382501d42ad2ee7aeca0d32c15655c0
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 9b7835fc52c106ba6d740d9f73a60ffdd2ccf108de3a73d1c7cba32576bba6c2
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 18ea6a0f3e4e3ae84a200ca288d8f7e7ca9a6d3d739197542d12f5ab372a6602
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 4c69a8f41135c89c09f5d151ffb1cd6bb30412e8e9681327acad03070cf95164
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: e7ac390db26728b03673b1b6591d535de1694786dcbac456266b9794a323e5ec
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.6.1/kubectl-cert_manager-windows-amd64.tar.gz
-    sha256: 7f2f3359e1b0c9ff49d41cf5454ffc3237df36fb451a7ca16dd67db38973af96
+    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-windows-amd64.tar.gz
+    sha256: c59741c73acb825014e2842f5234dde7a5f65e61dfb6927e58b059981c177aab
     bin: kubectl-cert_manager


### PR DESCRIPTION
This process isn't automated because the github actions workflow didn't mesh very well with cert-manager's current development workflow, and we didn't have the time to invest to create a shim between the two. We'd ideally like to automate this at some point but for now it's still manual.