### PR TITLE
Add ingress-rule plugin to krew index

### DIFF
--- a/plugins/ingress-rule.yaml
+++ b/plugins/ingress-rule.yaml
@@ -1,0 +1,52 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ingress-rule
+spec:
+  version: v0.1.0
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/pragaonj/ingress-rule-updater/releases/download/v0.1.0/ingress-rule_v0.1.0_linux_amd64.tar.gz
+      sha256: 85b05d9ce9f5d3381d513c111aa2a3cfba214bab79f499dc2dc7973906d70875
+      files:
+        - from: "./ingress-rule"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "ingress-rule"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/pragaonj/ingress-rule-updater/releases/download/v0.1.0/ingress-rule_v0.1.0_darwin_amd64.tar.gz
+      sha256: f79a2424b54f33546bb35c78d0c7059752deb4bd37bea841ad81ff424ed42b89
+      files:
+        - from: "./ingress-rule"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "ingress-rule"
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/pragaonj/ingress-rule-updater/releases/download/v0.1.0/ingress-rule_v0.1.0_windows_amd64.zip
+      sha256: 4159631f4b0fadf6b8d8b9092b1533de9e69ab13abf2f32c6cb473adbebb7dcb
+      files:
+        - from: "/ingress-rule.exe"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "ingress-rule.exe"
+  shortDescription: Update ingress rules via command line.
+  homepage: https://github.com/pragaonj/ingress-rule-updater
+  description: |
+    Add/remove rules to/from a kubernetes ingress via command line.
+    This plugin allows the configuration of an ingress resource with command line arguments.
+    
+    When adding/deleting a backend rule the ingress will be updated.
+    On creation of a rule for a non-existing ingress name a new ingress will be created.
+    If the last rule is deleted the ingress will be deleted as well.


### PR DESCRIPTION
First release of `ingress-rule` plugin.

`ingress-rule` allows the configuration of ingress rules via command line.

Plugin installation has been tested locally.