### PR TITLE
correct the typo in file name

### DIFF
--- a/plugins/rook-ceph.yaml
+++ b/plugins/rook-ceph.yaml
@@ -21,7 +21,7 @@ spec:
     sha256: bddd96082fda7950305adece88a3a36114943d9e22719a71df8a3dbeff467ac9
     files:
     - from: "kubectl-rook-ceph-*/kubectl-rook-ceph.sh"
-      to: "kubect-rook-ceph.sh"
+      to: "kubectl-rook-ceph.sh"
     - from: "kubectl-rook-ceph-*/LICENSE"
       to: "."
-    bin: kubect-rook-ceph.sh
+    bin: kubectl-rook-ceph.sh


### PR DESCRIPTION
change `kubect` to `kubectl`. It was big typo for us :disappointed:

Signed-off-by: subhamkrai <srai@redhat.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
