### PR TITLE
extract all files copy specific files not working

### DIFF
--- a/plugins/rook-ceph.yaml
+++ b/plugins/rook-ceph.yaml
@@ -21,7 +21,7 @@ spec:
     sha256: bddd96082fda7950305adece88a3a36114943d9e22719a71df8a3dbeff467ac9
     files:
     - from: "kubectl-rook-ceph-*/kubectl-rook-ceph.sh"
-      to: "kubectl-rook-ceph.sh"
+      to: "."
     - from: "kubectl-rook-ceph-*/LICENSE"
       to: "."
     bin: kubectl-rook-ceph.sh


### PR DESCRIPTION
when using having `to: "kubect-rook-ceph.sh"` in files section
it was not working for us but it worked in previous release.

```kubectl rook-ceph
Error: unknown command "rook-ceph" for "kubectl"
Run 'kubectl --help' for usage.
```

but modifying to `to: "."` is working

```
kubectl rook-ceph

DESCRIPTION
kubectl rook-ceph provides common management and troubleshooting tools for Ceph.
....
```

Signed-off-by: subhamkrai <srai@redhat.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
