### PR TITLE
Bump krew version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,10 @@ jobs:
       run: |
         set -euo pipefail
         cd "$(mktemp -d)"
-        curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew.{tar.gz,yaml}"
-        tar zxvf krew.tar.gz
-        ./krew-linux_amd64 install --manifest=krew.yaml --archive=krew.tar.gz
+        curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew.yaml"
+        curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/download/${KREW_VERSION}/krew-linux_amd64.tar.gz"
+        tar zxvf krew-linux_amd64.tar.gz
+        ./krew-linux_amd64 install --manifest=krew.yaml --archive=krew-linux_amd64.tar.gz
 
     - name: Install validate-krew-manifest plugin
       run : |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Validate plugin manifests
     runs-on: ubuntu-latest
     env:
-      KREW_VERSION: v0.4.2
+      KREW_VERSION: v0.4.3
       GO111MODULE: on
     steps:
 
@@ -52,9 +52,7 @@ jobs:
       run : |
         set -euo pipefail
         export GOBIN=$HOME/bin
-        # TODO(corneliusweig): pin validator version after next release
-        # go get sigs.k8s.io/krew/cmd/validate-krew-manifest@${KREW_VERSION}
-        go get sigs.k8s.io/krew/cmd/validate-krew-manifest@b015efbdf40d4cce7e02b9e4e4805d373c40aa25
+        go get sigs.k8s.io/krew/cmd/validate-krew-manifest@${KREW_VERSION}
 
     - name: Validate updated plugin manifests
       run : |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Validate plugin manifests
     runs-on: ubuntu-latest
     env:
-      KREW_VERSION: v0.4.0
+      KREW_VERSION: v0.4.2
       GO111MODULE: on
     steps:
 


### PR DESCRIPTION
Should fix this issue: https://github.com/kubernetes-sigs/krew-index/pull/1971#issuecomment-1030410185

Because v0.4.2 contains the commit that fixes it: https://github.com/kubernetes-sigs/krew/commit/c762f1fd853fcb93f9d1efa4362a9a0f9db5dcca
