### PR TITLE
Add rename-pvc plugin

### DIFF
--- a/plugins/rename-pvc.yaml
+++ b/plugins/rename-pvc.yaml
@@ -1,0 +1,49 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rename-pvc
+spec:
+  version: "v0.1.3"
+  homepage: https://github.com/stackitcloud/rename-pvc
+  shortDescription: "Rename a PersistentVolumeClaim (PVC)"
+  description: |
+    rename-pvc renames an existing PersistentVolumeClaim (PVC) by creating a new PVC
+    with the same spec and rebinding the existing PersistentClaim (PV) to the newly created PVC.
+    Afterwards the old PVC is automatically deleted.
+  caveats: "Be sure to create a backup of your data in the PVC before using rename-pvc!"
+  platforms:
+  - bin: rename-pvc
+    uri: https://github.com/stackitcloud/rename-pvc/releases/download/v0.1.3/rename-pvc-linux-amd64.tar.gz
+    sha256: dc4859fd254e035b06e7bfa33f97d5a4ef313513203077ae46128053e1da0abb
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - bin: rename-pvc
+    uri: https://github.com/stackitcloud/rename-pvc/releases/download/v0.1.3/rename-pvc-linux-arm64.tar.gz
+    sha256: cd37adca311518645d395646fe06aa6e702063b09f2870eb4ff452a395c493c6
+    selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+  - bin: rename-pvc
+    uri: https://github.com/stackitcloud/rename-pvc/releases/download/v0.1.3/rename-pvc-darwin-amd64.tar.gz
+    sha256: 192fddd86e989eff5810e0fb388492c7eb617c2ef7562af86819caa5c42fb6cd
+    selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+  - bin: rename-pvc
+    uri: https://github.com/stackitcloud/rename-pvc/releases/download/v0.1.3/rename-pvc-darwin-arm64.tar.gz
+    sha256: 84fc2d3c494c695a8c0313b554fec9b6719421c16735b26dd325b1598d68cfaf
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - bin: rename-pvc.exe
+    uri: https://github.com/stackitcloud/rename-pvc/releases/download/v0.1.3/rename-pvc-windows-amd64.zip
+    sha256: ff2f33ba73206286613dd23a310e06515014edc92eaf620ae0815d7ee2434707
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64


### PR DESCRIPTION
This PR adds `rename-pvc` plugin to the krew-index. 

`rename-pvc` renames an existing PersistentVolumeClaim (PVC) by creating a new PVC with the same spec and rebinding the existing PersistentClaim (PV) to the newly created PVC. Afterwards the old PVC is automatically deleted.

Project repo: https://github.com/stackitcloud/rename-pvc