### PR TITLE
rook-ceph: release new version v0.1.0 of rook-ceph

### DIFF
--- a/plugins/rook-ceph.yaml
+++ b/plugins/rook-ceph.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: rook-ceph
 spec:
-  version: "v0.0.2"
+  version: "v0.1.0"
   homepage: https://github.com/rook/kubectl-rook-ceph
   shortDescription: "Rook plugin for Ceph management"
   description: |
@@ -17,8 +17,8 @@ spec:
         - darwin
         - linux
         - windows
-    uri: https://github.com/rook/kubectl-rook-ceph/archive/v0.0.2.zip
-    sha256: bddd96082fda7950305adece88a3a36114943d9e22719a71df8a3dbeff467ac9
+    uri: https://github.com/rook/kubectl-rook-ceph/archive/v0.1.0.zip
+    sha256: 751223ec6f69952aa1918dbcb6c2610c0e973e733a32b7e53f52134389acb008
     files:
     - from: "kubectl-rook-ceph-*/kubectl-rook-ceph.sh"
       to: "."


### PR DESCRIPTION
this is new release version v0.1.0 of rook-ceph plugin.

Signed-off-by: subhamkrai <srai@redhat.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
