### PR TITLE
add log2rbac plugin (version v0.0.2)

### DIFF
--- a/plugins/log2rbac.yaml
+++ b/plugins/log2rbac.yaml
@@ -1,0 +1,34 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: log2rbac
+spec:
+  version: "v0.0.2"
+  homepage: https://github.com/jkremser/log2rbac-operator/tree/master/kubectl-plugin
+  shortDescription: "Fine-tune your RBAC using log2rbac operator"
+  description: |
+    Simple TUI based kubectl plugin to interface with the log2rbac operator.
+    It can (un)deploy the operator and create the `RbacNegotiation` custom
+    resources for various types of K8s kinds. The operator will help with
+    setting up the correct RBAC rules for your application by inspecting the
+    log files from pods and adding the rights violation as new rules.
+    Don't use this in production, but only for development purposes!
+  platforms:
+    - selector:
+        matchExpressions:
+          - key: "os"
+            operator: "In"
+            values:
+              - darwin
+              - linux
+      uri: https://github.com/jkremser/log2rbac-operator/archive/v0.0.2.zip
+      # 'sha256' is the sha256sum of the zip from url above (shasum -a 256 ..zip)
+      sha256: 69e4e4740a2ebbd14b9d33713f1405cd0a7047778d976b4add46d3bbfe2ea63f
+      files:
+        - from: "log2rbac-operator-*/kubectl-plugin/kubectl-log2rbac"
+          to: "."
+        - from: "log2rbac-operator-*/LICENSE"
+          to: "."
+        - from: "log2rbac-operator-*/kubectl-plugin/README.md"
+          to: "."
+      bin: kubectl-log2rbac


### PR DESCRIPTION
It's a bash script that provides couple of convenience features when working with log2rbac operator

if it's run w/o any parameters, it will trigger the TUI (interactive) mode that relies on `fzf`(or fail if it's not installed).

However, it can also work in  a non-interactive mode where all the information needs to be given as arguments.

In the future versions I would like to rewrite it to a standalone golang app that will bundle all the dependencies to the binary.

example:
![demo](https://user-images.githubusercontent.com/535866/158987064-cd1cc35f-9f93-4200-9cb9-8cfd29819d58.gif)



upstream repo: https://github.com/jkremser/log2rbac-operator/tree/master/kubectl-plugin

Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>