### PR TITLE
chore(deps): bump starboard from v0.14.1 to v0.15.0

### DIFF
--- a/plugins/starboard.yaml
+++ b/plugins/starboard.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: starboard
 spec:
-  version: "v0.14.1"
+  version: "v0.15.0"
   homepage: https://github.com/aquasecurity/starboard
   shortDescription: >-
     Toolkit for finding risks in kubernetes resources
@@ -12,10 +12,10 @@ spec:
     and configuration benchmark tests to be incorporated into Kubernetes CRDs
     (Custom Resource Definitions) and from there, accessed through the 
     Kubernetes API. 
-    
+
     Users familiar with kubectl or with a dashboard tool like Octant can find
     security risk information at their fingertips.
-    
+
   caveats: |
     The plugin requires access to create Jobs and CustomResources.
   platforms:
@@ -23,8 +23,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/aquasecurity/starboard/releases/download/v0.14.1/starboard_darwin_x86_64.tar.gz
-      sha256: 54d677bd8a782fa7bc0a5294c269224f00b9029d5ee13bbb70cdc6d0b8b7a98a
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.15.0/starboard_darwin_x86_64.tar.gz
+      sha256: 6edf5421e2a7ea9638a4d917d5b519311fc297b51ce8532c822f11c92f299a16
       files:
         - from: starboard
           to: .
@@ -35,8 +35,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/aquasecurity/starboard/releases/download/v0.14.1/starboard_linux_x86_64.tar.gz
-      sha256: 11da996611972553a4ba9c2b5a79f56ad50846482272d2cf9f1a307063e9650c
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.15.0/starboard_linux_x86_64.tar.gz
+      sha256: ca4e1059909feeaab62a2573d5f99ec9034c64fc38290de791f1c5aa21e38907
       files:
         - from: starboard
           to: .
@@ -47,8 +47,44 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/aquasecurity/starboard/releases/download/v0.14.1/starboard_windows_x86_64.zip
-      sha256: cf75e60c666aa2dae03191df360530d4974fa51c034750c85507587f91625d75
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.15.0/starboard_windows_x86_64.zip
+      sha256: 5a6c9cae43dcb5aa2763ec5f0bb066db53b0efa52d6a5486ac33be861c956399
+      files:
+        - from: starboard.exe
+          to: .
+        - from: LICENSE
+          to: .
+      bin: starboard.exe
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.15.0/starboard_darwin_ARM64.tar.gz
+      sha256: 23d8fec24aadc01b87d1a305cb222027dd2b886d9b9c6e85e817600c7eaa93c7
+      files:
+        - from: starboard
+          to: .
+        - from: LICENSE
+          to: .
+      bin: starboard
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.15.0/starboard_linux_ARM64.tar.gz
+      sha256: 3aafff60998996ac4c1c5517cbd4a0345ac7c513f4bb4042b539438b4adc0946
+      files:
+        - from: starboard
+          to: .
+        - from: LICENSE
+          to: .
+      bin: starboard
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/aquasecurity/starboard/releases/download/v0.15.0/starboard_windows_ARM64.zip
+      sha256: 55e8c5b16885a374902c0d805bc73d6e41aa2343030d8b40735c97aed0b2331d
       files:
         - from: starboard.exe
           to: .


### PR DESCRIPTION
This patch adds support for new architectures.
Exceptionally, it's submitted manually because of the bug in
our release workflow, but normally we'd use krew-release-bot.

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>