### PR TITLE
Bump cert-manager plugin versions for 1.8

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,54 +3,53 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v1.7.0
-  homepage: https://github.com/jetstack/cert-manager
+  version: v1.8.0
+  homepage: https://github.com/cert-manager/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
-    The official plugin accompanying cert-manger, a Kubernetes add-on to
-    automate the management and issuance of TLS certificates. Allows for
-    direct interaction with cert-manager resources e.g. manual renewal of
-    Certificate resources.
+    cert-manager is the easiest way to automatically manage certificates
+    in Kubernetes and OpenShift clusters. The kubectl plugin helps with
+    managing cert-manager resources e.g. manual renewal of Certificates.
   platforms:
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: d8ecfb9c5395c3ac393396bcfa9709565f90c610039fafe557c2f21036b94e45
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: 3ede246673a2247509b63f5cf83280ff3b981a5bba635302051a3648ffbb7a28
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-darwin-arm64.tar.gz
-    sha256: c96927aa4b7f7dc67ae5e6486b977550906538b19827457ad86c22b8b1fa7cb5
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-darwin-arm64.tar.gz
+    sha256: acbade0918d50ce0e482d99ae30cc419ba11a44dd3ed7711a6389cfb260f981c
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: 73618617b9ec42994c3ea77bbc8be743e382501d42ad2ee7aeca0d32c15655c0
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: c707f95473444e56b35c0febc05088b4b8fa3061571d7bd2f09414ee7bf0e377
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 18ea6a0f3e4e3ae84a200ca288d8f7e7ca9a6d3d739197542d12f5ab372a6602
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 675a3349145986ea2235daaaa339549f95cdbdbbe35accc2dcd1e66ca2d6759d
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: e7ac390db26728b03673b1b6591d535de1694786dcbac456266b9794a323e5ec
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 90aaf3e12db27045f5170df7f396ea75a9a65f1a0c92a07b1f3fab618cd08102
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jetstack/cert-manager/releases/download/v1.7.0/kubectl-cert_manager-windows-amd64.tar.gz
-    sha256: c59741c73acb825014e2842f5234dde7a5f65e61dfb6927e58b059981c177aab
-    bin: kubectl-cert_manager
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-windows-amd64.zip
+    sha256: 97ca9470ef5c6147f7f461aa596a8356dc518b5742be0bbc5612c094f56f9e32
+    bin: kubectl-cert_manager.exe


### PR DESCRIPTION
This process isn't automated because the automation that's provided for the krew-index isn't a great fit for the cert-manager release process.

Even if it was automated, this PR would require manual review in any case since we changed our repo name, updated Windows to use zip and added the `.exe` extension for the Windows binary.

If this needs any changes please let me know!