### PR TITLE
Add kubectl-safe

### DIFF
--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: safe
+spec:
+  version: 0.0.1-alpha
+  homepage: https://github.com/rumstead/kubectl-safe
+  shortDescription: Prompts before running edit commands
+  description: |
+    This plugin allows users to confirm when they get prompted
+    on certain kubectl commands.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_darwin_amd64.tar.gz
+    sha256: dd133478cafd3228583b69e806e547013b897a57d8a18f25dc32e405400a8fbb
+      bin: kubectl-safe
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_darwin_arm64.tar.gz
+    sha256: 765f2cd8dd5fadb384ebcd6315029c1d721b817e8ce6e87d77902d3c24209335
+      bin: kubectl-safe
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_linux_amd64.tar.gz
+    sha256: af321a76bcc97d9d298170e7287cce7bdb54e888a6f46aba70dca2bb1e4f2393
+      bin: kubectl-safe
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_linux_arm64.tar.gz
+    sha256: 0db79e44d908ab9d27430f66a96ebe21a5f63d6dc0e63fe40616952e8f0ee855
+      bin: kubectl-safe
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_windows_amd64.tar.gz
+    sha256: e3a1c29f07c3a75d7e6c1eedebfb9089c04ffe33661cd8bbe1b8242aeb60219f
+      bin: kubectl-safe.exe

--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -15,33 +15,33 @@ spec:
           os: darwin
           arch: amd64
       uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_darwin_amd64.tar.gz
-    sha256: dd133478cafd3228583b69e806e547013b897a57d8a18f25dc32e405400a8fbb
+      sha256: dd133478cafd3228583b69e806e547013b897a57d8a18f25dc32e405400a8fbb
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
       uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_darwin_arm64.tar.gz
-    sha256: 765f2cd8dd5fadb384ebcd6315029c1d721b817e8ce6e87d77902d3c24209335
+      sha256: 765f2cd8dd5fadb384ebcd6315029c1d721b817e8ce6e87d77902d3c24209335
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: linux
           arch: amd64
       uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_linux_amd64.tar.gz
-    sha256: af321a76bcc97d9d298170e7287cce7bdb54e888a6f46aba70dca2bb1e4f2393
+      sha256: af321a76bcc97d9d298170e7287cce7bdb54e888a6f46aba70dca2bb1e4f2393
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: linux
           arch: arm64
       uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_linux_arm64.tar.gz
-    sha256: 0db79e44d908ab9d27430f66a96ebe21a5f63d6dc0e63fe40616952e8f0ee855
+      sha256: 0db79e44d908ab9d27430f66a96ebe21a5f63d6dc0e63fe40616952e8f0ee855
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: windows
           arch: amd64
       uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_windows_amd64.tar.gz
-    sha256: e3a1c29f07c3a75d7e6c1eedebfb9089c04ffe33661cd8bbe1b8242aeb60219f
+      sha256: e3a1c29f07c3a75d7e6c1eedebfb9089c04ffe33661cd8bbe1b8242aeb60219f
       bin: kubectl-safe.exe

--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -14,34 +14,34 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_darwin_amd64.tar.gz
-      sha256: dd133478cafd3228583b69e806e547013b897a57d8a18f25dc32e405400a8fbb
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/v0.0.1-alpha/kubectl-safe_v0.0.1-alpha_darwin_amd64.tar.gz
+      sha256: d0b64fea473619b852f36d79d49572533c9c008b696ac43e7ffb0159e6ac70bb
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_darwin_arm64.tar.gz
-      sha256: 765f2cd8dd5fadb384ebcd6315029c1d721b817e8ce6e87d77902d3c24209335
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/v0.0.1-alpha/kubectl-safe_v0.0.1-alpha_darwin_arm64.tar.gz
+      sha256: 68fa5cb320459822864c15059682a378bad2466872fa07cde4b161e1f693f658
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_linux_amd64.tar.gz
-      sha256: af321a76bcc97d9d298170e7287cce7bdb54e888a6f46aba70dca2bb1e4f2393
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/v0.0.1-alpha/kubectl-safe_v0.0.1-alpha_linux_amd64.tar.gz
+      sha256: 421bccd51a73220750c815c000af2d449ebe9b1c51f226d0e3324cbd78296d40
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_linux_arm64.tar.gz
-      sha256: 0db79e44d908ab9d27430f66a96ebe21a5f63d6dc0e63fe40616952e8f0ee855
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/v0.0.1-alpha/kubectl-safe_v0.0.1-alpha_linux_arm64.tar.gz
+      sha256: 79240e6b9c0a727868cc913e8cea024e8d451dbf2d15276df1829e89e8585fde
       bin: kubectl-safe
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/rumstead/kubectl-safe/releases/download/0.0.1-alpha/kubectl-safe_0.0.1-alpha_windows_amd64.tar.gz
-      sha256: e3a1c29f07c3a75d7e6c1eedebfb9089c04ffe33661cd8bbe1b8242aeb60219f
+      uri: https://github.com/rumstead/kubectl-safe/releases/download/v0.0.1-alpha/kubectl-safe_v0.0.1-alpha_windows_amd64.tar.gz
+      sha256: 36eabb6ee733d35dbbf8f62e639ba3ab3978b98c12044092ed87b9eae73f0bea
       bin: kubectl-safe.exe

--- a/plugins/safe.yaml
+++ b/plugins/safe.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe
 spec:
-  version: 0.0.1-alpha
+  version: v0.0.1-alpha
   homepage: https://github.com/rumstead/kubectl-safe
   shortDescription: Prompts before running edit commands
   description: |


### PR DESCRIPTION
This plugin allows users to confirm when they get prompted on certain kubectl commands.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
