### PR TITLE
Add VolSync v0.4.0

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: volsync
+spec:
+  version: v0.4.0
+  homepage: https://github.com/backube/volsync
+  shortDescription: "Manage replication with the VolSync operator"
+  description: |
+    This plugin provides a set of commands to interact with the VolSync
+    operator.
+
+    It provides an easy method to perform several common data replication
+    workflows without directly creating/manipulating VolSync's CRs.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      # This URL requires the artifact to be added to the release page as an
+      # "Asset"
+      uri: https://github.com/backube/volsync/releases/download/v0.4.0/kubectl-volsync.tar.gz
+      sha256: 6753a9ea4ba44d67133a4c68d21fe55c1a535a71b6cf85cf9573326f0dcee560
+      files:
+        - from: "./kubectl-volsync"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: kubectl-volsync


### PR DESCRIPTION
This is a plugin that provides a CLI interface to the VolSync operator.
Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
