### PR TITLE
Update Karmada plugin sha256 of v1.1.2

### DIFF
--- a/plugins/karmada.yaml
+++ b/plugins/karmada.yaml
@@ -23,7 +23,7 @@ spec:
         arch: arm64
         os: linux
     uri: https://github.com/karmada-io/karmada/releases/download/v1.1.2/kubectl-karmada-linux-arm64.tgz
-    sha256: 309ee5a91044ee4e8c00e711253aac5b3317968210098bf7fa75c586229a2537
+    sha256: b045cabedfb37b8902d7ae49d76a62ffe74dda4044fc081b77454bd623f9345f
   - bin: kubectl-karmada
     files:
     - from: kubectl-karmada
@@ -35,7 +35,7 @@ spec:
         arch: arm64
         os: darwin
     uri: https://github.com/karmada-io/karmada/releases/download/v1.1.2/kubectl-karmada-darwin-arm64.tgz
-    sha256: 0ec22d67c7379ee95616e29471ea55f89d3135a36851a1203c6af5cccbd2f7f5
+    sha256: 1d86ca7bb1b49d9ce11e5e5a481138149d8cd60d842f71a67400e06124d0f9ba
   - bin: kubectl-karmada
     files:
     - from: kubectl-karmada
@@ -47,7 +47,7 @@ spec:
         arch: amd64
         os: linux
     uri: https://github.com/karmada-io/karmada/releases/download/v1.1.2/kubectl-karmada-linux-amd64.tgz
-    sha256: 2711a6b7aa51da6ec263f639559399832f8a6edfef989e8c2d8c65bca191087d
+    sha256: 255c1f410ff3108c777b5924ec49b7604a3c49ed2284df817a6f4015f22c884f
   - bin: kubectl-karmada
     files:
     - from: kubectl-karmada
@@ -59,6 +59,6 @@ spec:
         arch: amd64
         os: darwin
     uri: https://github.com/karmada-io/karmada/releases/download/v1.1.2/kubectl-karmada-darwin-amd64.tgz
-    sha256: ecbbd8c9173a61e5a54a365f058ae715f9fe61fd176751818eb08f8c3065876b
+    sha256: b34bc03a4815855a15bf5d959b78a3faa07fba4d147c63b2fb5009849b114eee
   shortDescription: Manage clusters with Karmada federation.
   version: v1.1.2


### PR DESCRIPTION
Hi,

[Karmada maintainer](https://github.com/karmada-io/karmada/blob/master/MAINTAINERS.md) here. 

I'm sorry for wasting your review effort on fixing a stupid mistake I made.
I incorrectly re-uploaded the release assets to fix an issue brought by release scripts. And that causes the `sha256` checksum to change, so people can't install the Karmada plugin now. (https://github.com/karmada-io/karmada/issues/1784)

Please let me know if it is not allowed to manually update the checksum. 
