### PR TITLE
Make cache work on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       id: go
 
     - name: Check out PR branch
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0  # disable shallow clones
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,10 @@ jobs:
     steps:
 
     - name: Setup Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
-        go-version: 1.14
+        go-version: '1.14'
       id: go
-    - name: Go module cache
-      uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
 
     - name: Check out PR branch
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: krew-index CI
 
-on: pull_request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:
@@ -17,12 +21,21 @@ jobs:
         go-version: '1.14'
       id: go
 
+    - name: Go module cache
+      uses: actions/cache@v3
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ env.KREW_VERSION }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+
     - name: Check out PR branch
       uses: actions/checkout@v3
       with:
         fetch-depth: 0  # disable shallow clones
 
     - name: Fetch base branch
+      if: github.event_name == 'pull_request'
       run: |
         git fetch --no-tags --prune --depth=1 origin +refs/heads/${GITHUB_BASE_REF}:refs/remotes/origin/${GITHUB_BASE_REF}
 
@@ -48,6 +61,7 @@ jobs:
         go get sigs.k8s.io/krew/cmd/validate-krew-manifest@${KREW_VERSION}
 
     - name: Validate updated plugin manifests
+      if: github.event_name == 'pull_request'
       run : |
         set -x
         set -euo pipefail
@@ -55,4 +69,3 @@ jobs:
         git diff --name-only --diff-filter=AM origin/${GITHUB_BASE_REF} ${{ github.sha }} -- plugins/ |
           tee /dev/stderr |
           xargs -I _ $HOME/bin/validate-krew-manifest -manifest _
-


### PR DESCRIPTION
Because each PRs has a fresh build, caching on GHA rarely happens. And even if it happens, it doesn't show a significant result, see https://github.com/kubernetes-sigs/krew-index/runs/6546909595?check_suite_focus=true and https://github.com/kubernetes-sigs/krew-index/runs/6550071463?check_suite_focus=true for example. One of the reasons is our build time is quite small.
Thus I think we could remove caching modules to simplify. While doing it, this also updates some actions to the latest ones.

**UPDATE**: This PR now enables cache on every pull request as requested in https://github.com/kubernetes-sigs/krew-index/pull/2303#issuecomment-1147644947.