### PR TITLE
updated pod-inspect to v0.1.10

### DIFF
--- a/plugins/pod-inspect.yaml
+++ b/plugins/pod-inspect.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: pod-inspect
 spec:
-  version: v0.1.9
+  version: v0.1.10
   homepage: https://github.com/jpriebe/kubectl-pod-inspect
   shortDescription: Get all of a pod's details at a glance
   description: |
@@ -14,27 +14,27 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.9/kubectl-pod-inspect_0.1.9_Darwin_x86_64.tar.gz
-    sha256: a5ff8e021fb9113892c4410fe8a577f70a08f7dbb29920a4c2dd17ced865249d
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.10/kubectl-pod-inspect_0.1.10_Darwin_x86_64.tar.gz
+    sha256: c215362e16898e0e44c831d5816ef7e094af35c80baf23a37e588ae724556ccb
     bin: kubectl-pod_inspect
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.9/kubectl-pod-inspect_0.1.9_Darwin_arm64.tar.gz
-    sha256: 461ddff930197b9a57ab34f97dfdd03849f314fa762088c2029ab15456e70db1
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.10/kubectl-pod-inspect_0.1.10_Darwin_arm64.tar.gz
+    sha256: 304cdec55ecb348d275a242b9f32451700c76144ba10b480a0a4bf06e41580f4
     bin: kubectl-pod_inspect
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.9/kubectl-pod-inspect_0.1.9_Linux_x86_64.tar.gz
-    sha256: 6248073893f3a195818026c41282d80bd237e2461c1588ced4be7e5131c35fe3  
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.10/kubectl-pod-inspect_0.1.10_Linux_x86_64.tar.gz
+    sha256: c7c44017ae67326cd6286c86d0d33d3b4a6efd8681b36283b4257404a0224413  
     bin: kubectl-pod_inspect
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.9/kubectl-pod-inspect_0.1.9_Windows_x86_64.tar.gz
-    sha256: b7df4b74676bca92f2b4e0852200d41524235b5c4a4465caf447cfabf5730c64
+    uri: https://github.com/jpriebe/kubectl-pod-inspect/releases/download/v0.1.10/kubectl-pod-inspect_0.1.10_Windows_x86_64.tar.gz
+    sha256: a8faf0e850a32a34dd08e16b9ce38fdfe8f53cc1f1f2ba633d4aebc9be43c32a
     bin: kubectl-pod_inspect.exe


### PR DESCRIPTION
This version updates all go modules, including an update from k8s.io/api v0.19.2 to v0.24.1 (intended to fix issues with EKS clusters using newer versions of kubernetes)