### PR TITLE
add kubectl-shell plugin

### DIFF
--- a/plugins/shell.yaml
+++ b/plugins/shell.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   homepage: https://gitlab.com/hojerst/kubectl-shell
   shortDescription: "Kubernetes Shell Spawner with Mounting"
-  version: "v1.3.0"
+  version: "v1.3.1"
   description: |
     Allows to spawn a shell image in a kubernetes cluster and attach to it.
     It is similar to "kubectl run" but allows to easily mount hostPath, secret
@@ -18,8 +18,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://gitlab.com/hojerst/kubectl-shell/-/releases/v1.3.0/downloads/kubectl-shell-1.3.0.tar.gz
-    sha256: e452adff991e204ce287bf664cc6011da75097dcb933dc3b51eb0d7cd8192dfe
+    uri: https://gitlab.com/hojerst/kubectl-shell/-/releases/v1.3.1/downloads/kubectl-shell-1.3.1.tar.gz
+    sha256: 46065039e78fcbc6985a7c447418340f3ca8b4205132015808ce5077b6883877
     bin: kubectl-shell
     files:
     - from: "kubectl-shell-*/*"

--- a/plugins/shell.yaml
+++ b/plugins/shell.yaml
@@ -1,0 +1,28 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: shell
+spec:
+  homepage: https://gitlab.com/hojerst/kubectl-shell
+  shortDescription: "Kubernetes Shell Spawner with Mounting"
+  version: "v1.1.1"
+  description: |
+    Allows to spawn a shell image in a kubernetes cluster and attach to it.
+    It is similar to "kubectl run" but allows to easily mount hostPath, secret
+    configmaps and pvcs into this Pod.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://gitlab.com/hojerst/kubectl-shell/-/archive/v1.1.1/kubectl-shell-v1.1.1.tar.gz
+    sha256: af3b9fa105fb24dc352f48580831751604d69feaa7aee60ee7522a258a88b322
+    bin: kubectl-shell
+    files:
+    - from: "kubectl-shell-*/kubectl-shell"
+      to: "."
+    - from: "kubectl-shell-*/LICENSE"
+      to: "."

--- a/plugins/shell.yaml
+++ b/plugins/shell.yaml
@@ -19,7 +19,7 @@ spec:
         - darwin
         - linux
     uri: https://gitlab.com/hojerst/kubectl-shell/-/releases/v1.3.1/downloads/kubectl-shell-1.3.1.tar.gz
-    sha256: 46065039e78fcbc6985a7c447418340f3ca8b4205132015808ce5077b6883877
+    sha256: 00e33b8592bb7a3ac230cbff6f347aa6cb15e9660cc47039f8728a0637520009
     bin: kubectl-shell
     files:
     - from: "kubectl-shell-*/*"

--- a/plugins/shell.yaml
+++ b/plugins/shell.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   homepage: https://gitlab.com/hojerst/kubectl-shell
   shortDescription: "Kubernetes Shell Spawner with Mounting"
-  version: "v1.1.1"
+  version: "v1.3.0"
   description: |
     Allows to spawn a shell image in a kubernetes cluster and attach to it.
     It is similar to "kubectl run" but allows to easily mount hostPath, secret
@@ -18,11 +18,9 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://gitlab.com/hojerst/kubectl-shell/-/archive/v1.1.1/kubectl-shell-v1.1.1.tar.gz
-    sha256: af3b9fa105fb24dc352f48580831751604d69feaa7aee60ee7522a258a88b322
+    uri: https://gitlab.com/hojerst/kubectl-shell/-/releases/v1.3.0/downloads/kubectl-shell-1.3.0.tar.gz
+    sha256: e452adff991e204ce287bf664cc6011da75097dcb933dc3b51eb0d7cd8192dfe
     bin: kubectl-shell
     files:
-    - from: "kubectl-shell-*/kubectl-shell"
-      to: "."
-    - from: "kubectl-shell-*/LICENSE"
+    - from: "kubectl-shell-*/*"
       to: "."


### PR DESCRIPTION
The plugin allows to spawn a interactive shell in the cluster and also
allows to mount volumes to this shell.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
