### PR TITLE
Update kubectl-cert_manager to v1.9

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v1.8.0
+  version: v1.9.0
   homepage: https://github.com/cert-manager/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -15,41 +15,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 3ede246673a2247509b63f5cf83280ff3b981a5bba635302051a3648ffbb7a28
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: 8a5b7b89ddb7ac036ffdb7cef550fa74004ad613d915a42021dfc1ab9b2546ee
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-darwin-arm64.tar.gz
-    sha256: acbade0918d50ce0e482d99ae30cc419ba11a44dd3ed7711a6389cfb260f981c
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-darwin-arm64.tar.gz
+    sha256: b717ba3305724cf01fd0d400ce521405180934533ee8793c5ae25cf42ecbf8a9
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: c707f95473444e56b35c0febc05088b4b8fa3061571d7bd2f09414ee7bf0e377
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 198fe9a3554a44927b22491942809df2aaf3c16ef8c9a81b1266d4dd96a9a9ab
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 675a3349145986ea2235daaaa339549f95cdbdbbe35accc2dcd1e66ca2d6759d
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 1369bbf8a6489115d5fa944bfba13d52ab4bf502a440c8c7d6c54633a4e04a66
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 90aaf3e12db27045f5170df7f396ea75a9a65f1a0c92a07b1f3fab618cd08102
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 6859b9b5333dd8111735a2b5eae6d5218b0073ffd154d91605746b0a6feb3bf8
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.8.0/kubectl-cert_manager-windows-amd64.zip
-    sha256: 97ca9470ef5c6147f7f461aa596a8356dc518b5742be0bbc5612c094f56f9e32
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-windows-amd64.zip
+    sha256: c3ec067a0c9ca779830c802eb0b30b06186857bc73d8d4493ce18256d49c6a7a
     bin: kubectl-cert_manager.exe


### PR DESCRIPTION
As in previous PRs such as #2145 this was done manually. This time, it's just a version bump :+1: 