### PR TITLE
Add confirm plugin

### DIFF
--- a/plugins/confirm.yaml
+++ b/plugins/confirm.yaml
@@ -1,0 +1,59 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: confirm
+spec:
+  version: v0.1.0
+  homepage: https://github.com/brianpursley/kubectl-confirm
+  shortDescription: Dry-run / diff / confirm before running a command
+  description: |
+    This plugin shows the current configuration, performs a dry-run 
+    (if available), and displays a diff (if available), and then prompts 
+    you to confirm by typing 'yes' before proceeding to execute the kubectl 
+    command.
+
+    It shows the current configuration and prompts for confirmation for all 
+    kubectl commands.
+
+    It performs a dry-run for the following kubectl commands: annotate, apply, 
+    autoscale, cordon, create, delete, drain, expose, label, patch, replace, 
+    run, scale, set, taint, uncordon.
+
+    It performs a diff for the following kubectl commands: annotate, apply, 
+    autoscale, create, expose, label, patch, replace, run, scale, set, taint.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/brianpursley/kubectl-confirm/releases/download/v0.1.0/kubectl-confirm-darwin-amd64.tar.gz
+      sha256: 147c053a5f9d8bdb281c6ca7a40576f22186ed49fb510510da7d14a3d56bf6bf
+      bin: kubectl-confirm
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/brianpursley/kubectl-confirm/releases/download/v0.1.0/kubectl-confirm-darwin-arm64.tar.gz
+      sha256: 53188a1efca52663fdf829317367811cb959769e60c471bd552a0d64a4eb93aa
+      bin: kubectl-confirm
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/brianpursley/kubectl-confirm/releases/download/v0.1.0/kubectl-confirm-linux-amd64.tar.gz
+      sha256: cdc0ae10906291608691e2dec8cc6acc123189df0bf3cb5bc7ad0913283ff48b
+      bin: kubectl-confirm
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/brianpursley/kubectl-confirm/releases/download/v0.1.0/kubectl-confirm-linux-arm64.tar.gz
+      sha256: a73b01e7d04a87b03be1d8c23e9275d8bf653552c4b86ca246afc1420c5d89d0
+      bin: kubectl-confirm
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/brianpursley/kubectl-confirm/releases/download/v0.1.0/kubectl-confirm-windows-amd64.tar.gz
+      sha256: 7cfa6a8694b77515a86a4291413a18ddd96b3943c6c4cd72d5fe41dfb1190ac5
+      bin: kubectl-confirm.exe


### PR DESCRIPTION
# Kubectl Confirm Plugin

Kubectl Confirm is a plugin for Kubectl that displays information and asked for confirmation before executing a command.

The following information is displayed:
* Configuration: Context name, Cluster, User, and Namespace
* Dry Run Output (if the executed command supports the `--dry-run` flag)
* Diff Output (if the executed command supports the `--dry-run` and `--output` flags)

## Example Output
```
$ kubectl confirm apply -f ~/changed.yaml
========== Config ===========
Context:    kind-kind
Cluster:    kind-kind
User:       kind-kind
Namespace:  default

========== Dry Run ==========
deployment.apps/foo configured (server dry run)

========== Diff =============
diff -u -N /tmp/LIVE-2275701238/apps.v1.Deployment.default.foo /tmp/MERGED-1055657464/apps.v1.Deployment.default.foo
--- /tmp/LIVE-2275701238/apps.v1.Deployment.default.foo	2022-07-28 10:27:25.690604172 -0400
+++ /tmp/MERGED-1055657464/apps.v1.Deployment.default.foo	2022-07-28 10:27:25.694604038 -0400
@@ -6,7 +6,7 @@
     kubectl.kubernetes.io/last-applied-configuration: |
       {"apiVersion":"apps/v1","kind":"Deployment","metadata":{"annotations":{},"name":"foo","namespace":"default"},"spec":{"replicas":1,"revisionHistoryLimit":10,"selector":{"matchLabels":{"app":"foo"}},"template":{"metadata":{"labels":{"app":"foo"}},"spec":{"containers":[{"command":["sh","-c","echo Container bar is running! \u0026\u0026 sleep 9999999"],"image":"busybox:1.30","name":"bar"}]}}}}
   creationTimestamp: "2022-07-28T11:43:58Z"
-  generation: 1
+  generation: 2
   managedFields:
   - apiVersion: apps/v1
     fieldsType: FieldsV1
@@ -90,7 +90,7 @@
 spec:
   progressDeadlineSeconds: 600
   replicas: 1
-  revisionHistoryLimit: 10
+  revisionHistoryLimit: 11
   selector:
     matchLabels:
       app: foo

========== Confirm ==========
The following command will be executed:
kubectl apply -f /home/bpursley/changed.yaml

Enter 'yes' to continue: 
```

If you enter `yes` (exactly) then it will proceed:
```
Enter 'yes' to continue: yes

deployment.apps/foo configured
```

If you enter anything other than `yes` (exactly), then it will stop:
```
Enter 'yes' to continue: no

Command aborted.
```
