### PR TITLE
plugins/gadget: Update install instructions

### DIFF
--- a/plugins/gadget.yaml
+++ b/plugins/gadget.yaml
@@ -21,7 +21,7 @@ spec:
   caveats: |
     Inspektor Gadget needs to be deployed to each node:
 
-    $ kubectl gadget deploy | kubectl apply -f -
+    $ kubectl gadget deploy
 
     Read the documentation available at https://github.com/kinvolk/inspektor-gadget
     to get more information about the server side installation process.


### PR DESCRIPTION
In v0.7.0 (about to be released at the time of writing this message) we
changed the way to deploy Inspektor Gadget to the cluster.

