### PR TITLE
Apply templated resources

### DIFF
--- a/plugins/applier.yaml
+++ b/plugins/applier.yaml
@@ -1,0 +1,49 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: applier
+spec:
+  version: v1.2.1
+  homepage: https://github.com/stolostron/applier
+  shortDescription: Provides an apply and render commands for template based resources.
+  description: |
+    This plugin allows you apply on kubernetes template resources (golang text/template) or just render them.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_darwin_amd64.tar.gz
+    sha256: ac14316d0fe2b7761207c0bf4d0d635cc47c6a5422420de893803c79953806dc
+    bin: applier
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_darwin_arm64.tar.gz
+    sha256: 4e33b236e144ea9eaa87e42cdd5e73f81596dabc9514b6ff581bccd012069314
+    bin: applier
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_linux_amd64.tar.gz
+    sha256: 8a077c7bdb18ca3082db99018e0ffc247fa843f9fed5316079fd08abcdc0f6bd
+    bin: applier
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_linux_arm64.tar.gz
+    sha256: e3eed9e72713736237856b8d5b3a4374a2471608a984ef529addb9a4849e07ba
+    bin: applier
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_windows_amd64.zip
+    sha256: 6b8434edfbfc2b94f5d85d548e9ef4b685687c5b129868e0ed11a45e598bc885
+    bin: applier.exe
+

--- a/plugins/applier.yaml
+++ b/plugins/applier.yaml
@@ -1,49 +1,49 @@
-# Copyright Contributors to the Open Cluster Management project
+# Copyright Red Hat
 
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
   name: applier
 spec:
-  version: v1.2.1
+  version: v1.2.2
   homepage: https://github.com/stolostron/applier
-  shortDescription: Provides an apply and render commands for template based resources.
+  shortDescription: Apply 'go text/template' files on k8s.
   description: |
-    This plugin allows you apply on kubernetes template resources (golang text/template) or just render them.
+    This plugin allows you apply 'go text/template' files on k8s or just render them.
   platforms:
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_darwin_amd64.tar.gz
-    sha256: ac14316d0fe2b7761207c0bf4d0d635cc47c6a5422420de893803c79953806dc
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.2/applier_darwin_amd64.tar.gz
+    sha256: 84bfca6acfb4a9d383dcef0520790405345e44e5930e6fddba91512b8db41aa0
     bin: applier
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_darwin_arm64.tar.gz
-    sha256: 4e33b236e144ea9eaa87e42cdd5e73f81596dabc9514b6ff581bccd012069314
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.2/applier_darwin_arm64.tar.gz
+    sha256: 6664f221c5cf2937333a96114f59f14fccbf163127cd5c28a27f38bd2d48a222
     bin: applier
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_linux_amd64.tar.gz
-    sha256: 8a077c7bdb18ca3082db99018e0ffc247fa843f9fed5316079fd08abcdc0f6bd
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.2/applier_linux_amd64.tar.gz
+    sha256: 835307fe326d685b403aa26f8efbd5ba851b5cf6af6c39b94e02e2bf2c8b03c1
     bin: applier
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_linux_arm64.tar.gz
-    sha256: e3eed9e72713736237856b8d5b3a4374a2471608a984ef529addb9a4849e07ba
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.2/applier_linux_arm64.tar.gz
+    sha256: 78c11441d32614ce48851a9e9365c67a22991d0e6bd35ceb804077130c24e8a7
     bin: applier
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/stolostron/applier/releases/download/v1.2.1/applier_windows_amd64.zip
-    sha256: 6b8434edfbfc2b94f5d85d548e9ef4b685687c5b129868e0ed11a45e598bc885
+    uri: https://github.com/stolostron/applier/releases/download/v1.2.2/applier_windows_amd64.zip
+    sha256: 77276d0e21acf70d15897200780dcbe69f12f9ced5d3f80bb9345980617f9d84
     bin: applier.exe
 


### PR DESCRIPTION
Signed-off-by: Dominique Vernier <dvernier@redhat.com>

This plugin allows you to apply templated resources. The templated resources are `golang text/template` files and you can pass a yaml containing the values for the parameters.

https://github.com/stolostron/applier/blob/main/README.md
