### PR TITLE
add colorize applied plugin

### DIFF
--- a/plugins/colorize-applied.yaml
+++ b/plugins/colorize-applied.yaml
@@ -1,0 +1,46 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: colorize-applied
+spec:
+  version: v0.0.1
+  homepage: https://github.com/cappyzawa/kubectl-colorize-applied
+  shortDescription: "Colorize the applied result"
+  description: |
+    Enjoy coloring the applied results.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/cappyzawa/kubectl-colorize-applied/releases/download/v0.0.1/kubectl-colorize-applied-darwin-amd64.tar.gz
+    sha256: 1dd5de5f4dd342eb85bfbb2c409e2caff18dfc21bc6d387aa77a81c3c3ad5559
+    bin: kubectl-colorize-applied
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/cappyzawa/kubectl-colorize-applied/releases/download/v0.0.1/kubectl-colorize-applied-darwin-arm64.tar.gz
+    sha256: d3688c6a74ee280284b9d043ac90c1461a875beb9688c012b54a307bdbcfca6c
+    bin: kubectl-colorize-applied
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/cappyzawa/kubectl-colorize-applied/releases/download/v0.0.1/kubectl-colorize-applied-linux-amd64.tar.gz
+    sha256: a768d63005517bd28aa3f00e1fd4a5928079e5c98b5d509e0cc58515fe6227e1
+    bin: kubectl-colorize-applied
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/cappyzawa/kubectl-colorize-applied/releases/download/v0.0.1/kubectl-colorize-applied-linux-arm64.tar.gz
+    sha256: e207fa9fe8aca3adaddaf154c849f1752f0e0433d37c39c2f83b406285d481ea
+    bin: kubectl-colorize-applied
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/cappyzawa/kubectl-colorize-applied/releases/download/v0.0.1/kubectl-colorize-applied-windows-amd64.tar.gz
+    sha256: 93e4272c96c7a4e0349cb8d150602609f9f5cfeff9bed4333a4b7f2db55f37fc
+    bin: kubectl-colorize-applied.exe

--- a/plugins/colorize-applied.yaml
+++ b/plugins/colorize-applied.yaml
@@ -5,9 +5,11 @@ metadata:
 spec:
   version: v0.0.1
   homepage: https://github.com/cappyzawa/kubectl-colorize-applied
-  shortDescription: "Colorize the applied result"
+  shortDescription: "Colorize results of apply/dry-run"
   description: |
-    Enjoy coloring the applied results.
+    This plugin colorizes the results of apply/dry-run.
+    Each line containing the following strings is colored:
+    "pruned", "configured", "created", and "unchanged".
   platforms:
   - selector:
       matchLabels:


### PR DESCRIPTION
Hi.
I implemented a plugin to help confirm the applied results.

<img width="1144" alt="ss 2022-08-19 23 55 14" src="https://user-images.githubusercontent.com/12455284/185646899-a51c8207-16d9-4c8f-b0e9-073f3666d9d9.png">



- [x] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
```
kubectl krew install --manifest=plugins/colorize-applied.yaml
Installing plugin: colorize-applied
Installed plugin: colorize-applied
\
 | Use this plugin:
 |      kubectl colorize-applied
 | Documentation:
 |      https://github.com/cappyzawa/kubectl-colorize-applied
/
```
-->
