### PR TITLE
Add mirrord to krew

### DIFF
--- a/plugins/mirrord.yaml
+++ b/plugins/mirrord.yaml
@@ -1,0 +1,25 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mirrord
+spec:
+  shortDescription: Easily mirror traffic from your Kubernetes cluster to your development environment.
+  description: |
+    Run your service in the context of your cloud environment, with access 
+    to other microservices, databases, queues, and managed services, 
+    all without leaving the local setup you know and love.
+  version: v2.10.1
+  homepage: https://github.com/metalbear-co/mirrord
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+      uri: https://github.com/metalbear-co/mirrord/releases/download/2.10.1/mirrord_mac_universal.zip
+      sha256: 5d65b523bcf97cd10e52c5bbba0ca58cf84c3f866e3bb4349c2a6c5f70c9cbbe
+      bin: mirrord
+    - selector:
+        matchLabels:
+          os: linux
+      uri: https://github.com/metalbear-co/mirrord/releases/download/2.10.1/mirrord_linux_x86_64.zip
+      sha256: 3f1b2420001fbf7bb3bb010167571e7b351d08ccdbf75d64526877f8fa63c027
+      bin: mirrord


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
mirrord lets developers run local processes in the context of their cloud environment. It’s meant to provide the benefits of running your service on a cloud environment (e.g. staging) without actually going through the hassle of deploying it there, and without disrupting the environment by deploying untested code.
https://github.com/metalbear-co/mirrord/issues/282