### PR TITLE
new 0.5.0 of volsync plugin

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.4.0
+  version: v0.5.0
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.4.0/kubectl-volsync.tar.gz
-      sha256: 6753a9ea4ba44d67133a4c68d21fe55c1a535a71b6cf85cf9573326f0dcee560
+      uri: https://github.com/backube/volsync/releases/download/v0.5.0/kubectl-volsync.tar.gz
+      sha256: 349a26736501c6840477e7afe0eb9a03ffed92b93e29d76b5272ce89424fe038
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
Signed-off-by: Tesshu Flower <tflower@redhat.com>

Publishing v0.5.0 for volsync plugin.

Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
