### PR TITLE
Add ttsum plugin

### DIFF
--- a/plugins/ttsum.yaml
+++ b/plugins/ttsum.yaml
@@ -1,0 +1,46 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ttsum
+spec:
+  version: v0.1.3
+  homepage: https://github.com/eytan-avisror/ttsum
+  shortDescription: Visualize taints and tolerations
+  description: |
+    This plugin makes viewing taints/tolerations across cluster resources easier
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_darwin_amd64.tar.gz
+    sha256: 8e6646df12d9be5f54bae40333f3bc5aee4239d4f0afdf491d33914e2ca0cdc5
+    bin: ttsum
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_darwin_arm64.tar.gz
+    sha256: 3890a818fa0638cebd5e6fccbfc4ca4cb0f74bdf0390770deeff162323abe803
+    bin: ttsum
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_linux_amd64.tar.gz
+    sha256: 7948b592dd18d95235c7af3701c400ab5c2322fabc8b45f420319950208b5b0c
+    bin: ttsum
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_linux_arm64.tar.gz
+    sha256: bb02c503f255fe684ab802a49d5ade2dd83f56cfe0ec0971cf4f0d9c23b94ef7
+    bin: ttsum
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_windows_amd64.tar.gz
+    sha256: c65993735c7fbad0ac491406ba24a7c433946d325b815df00e1b7caef954f77c
+    bin: ttsum.exe

--- a/plugins/ttsum.yaml
+++ b/plugins/ttsum.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: ttsum
 spec:
-  version: v0.1.3
+  version: v0.1.4
   homepage: https://github.com/eytan-avisror/ttsum
   shortDescription: Visualize taints and tolerations
   description: |
@@ -13,34 +13,34 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_darwin_amd64.tar.gz
-    sha256: 8e6646df12d9be5f54bae40333f3bc5aee4239d4f0afdf491d33914e2ca0cdc5
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.4/ttsum_v0.1.4_darwin_amd64.tar.gz
+    sha256: 614223cf0a951195c1fc437c5dda546866328b7732b348bd0199342bb5b868f4
     bin: ttsum
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_darwin_arm64.tar.gz
-    sha256: 3890a818fa0638cebd5e6fccbfc4ca4cb0f74bdf0390770deeff162323abe803
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.4/ttsum_v0.1.4_darwin_arm64.tar.gz
+    sha256: 6437332d51cf731fc88aafe433d0943a427bd5e3bb59e91ce06d32780a37c117
     bin: ttsum
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_linux_amd64.tar.gz
-    sha256: 7948b592dd18d95235c7af3701c400ab5c2322fabc8b45f420319950208b5b0c
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.4/ttsum_v0.1.4_linux_amd64.tar.gz
+    sha256: 6d285535652ce1e28e79cdd7a0c45ea31966af302a635ec62f2405c7b4f4f9a8
     bin: ttsum
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_linux_arm64.tar.gz
-    sha256: bb02c503f255fe684ab802a49d5ade2dd83f56cfe0ec0971cf4f0d9c23b94ef7
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.4/ttsum_v0.1.4_linux_arm64.tar.gz
+    sha256: 93925fbdf73154d1eb4c362bd08f018e0220a9b9a6f8e9f5d93fc48db46bd258
     bin: ttsum
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.3/ttsum_v0.1.3_windows_amd64.tar.gz
-    sha256: c65993735c7fbad0ac491406ba24a7c433946d325b815df00e1b7caef954f77c
+    uri: https://github.com/eytan-avisror/ttsum/releases/download/v0.1.4/ttsum_v0.1.4_windows_amd64.tar.gz
+    sha256: 2766842f9a7a73b70ccbd12e13dbe0eb0c29259ac22677d008a523921ca5afaf
     bin: ttsum.exe


### PR DESCRIPTION
This plugin makes viewing taints/tolerations across cluster resources easier
ttsum = taint & toleration summary

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
