### PR TITLE
Adding Linux ARM64 support

### DIFF
--- a/plugins/kuttl.yaml
+++ b/plugins/kuttl.yaml
@@ -27,6 +27,13 @@ spec:
     bin: "./kubectl-kuttl"
   - selector:
       matchLabels:
+        os: "linux"
+        arch: "arm64"
+    uri: https://github.com/kudobuilder/kuttl/releases/download/v0.13.0/kuttl_0.13.0_linux_arm64.tar.gz
+    sha256: "4e12ff05c3b10d80af4211f330f614520fa029a0ff1c7aeef2e5045fbbb053d2"
+    bin: "./kubectl-kuttl"
+  - selector:
+      matchLabels:
         os: "darwin"
         arch: "amd64"
     uri: https://github.com/kudobuilder/kuttl/releases/download/v0.13.0/kuttl_0.13.0_darwin_x86_64.tar.gz


### PR DESCRIPTION
Adding a Linux Arm 64 Architecture 

Signed-off-by: Ken Sipe <kensipe@gmail.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
