### PR TITLE
Release cert-manager v1.10.1

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v1.9.0
+  version: v1.10.1
   homepage: https://github.com/cert-manager/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -15,41 +15,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 8a5b7b89ddb7ac036ffdb7cef550fa74004ad613d915a42021dfc1ab9b2546ee
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: f780dc3940ca9eed8616ead70171420296fd0c33afbe8a55b000c9f26cd7e3d0
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-darwin-arm64.tar.gz
-    sha256: b717ba3305724cf01fd0d400ce521405180934533ee8793c5ae25cf42ecbf8a9
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/kubectl-cert_manager-darwin-arm64.tar.gz
+    sha256: 0197d7d307000b0ba9fa7843e8478fb9c99afc175478c1e869e5f00db9e09ef6
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: 198fe9a3554a44927b22491942809df2aaf3c16ef8c9a81b1266d4dd96a9a9ab
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 3c4118b6b0edb0e58e54e607a647e5fce5738c5296b2c8e5c7658cc5e40ea1e9
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 1369bbf8a6489115d5fa944bfba13d52ab4bf502a440c8c7d6c54633a4e04a66
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 8438c26ddf378a4d0d01351296ee5a377ebd4b432b79fdfebb6b97e8bd1e170c
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: 6859b9b5333dd8111735a2b5eae6d5218b0073ffd154d91605746b0a6feb3bf8
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: 532bdd1d7a6d794057e2ea70e21b7d6da3225f09ba0f387cac4ab455f1ac1ff0
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.9.0/kubectl-cert_manager-windows-amd64.zip
-    sha256: c3ec067a0c9ca779830c802eb0b30b06186857bc73d8d4493ce18256d49c6a7a
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.10.1/kubectl-cert_manager-windows-amd64.zip
+    sha256: 49fc5da4cdc018b56c7769c8ef7956c2e910189171c4df8bdf926bc0f08b9692
     bin: kubectl-cert_manager.exe


### PR DESCRIPTION
Updating the kubectl_cert-manager plugin as part of the cert-manager v1.10.1 release.
 * https://github.com/cert-manager/cert-manager/releases/tag/v1.10.1
 * https://cert-manager.io/docs/contributing/release-process/#minor-releases

### Testing

```terminal
$ kubectl krew install --manifest-url=https://raw.githubusercontent.com/wallrj/krew-index/cert-manager-v1.10.1/plugins/cert-manager.yaml
Updated the local copy of plugin index.
Installing plugin: cert-manager
Installed plugin: cert-manager
\
 | Use this plugin:
 | 	kubectl cert-manager
 | Documentation:
 | 	https://github.com/cert-manager/cert-manager
/


$ kubectl cert-manager x install
...
NAME: cert-manager
LAST DEPLOYED: Mon Nov 21 14:30:48 2022
NAMESPACE: cert-manager
STATUS: deployed
REVISION: 1
DESCRIPTION: Cert-manager was installed using the cert-manager CLI
NOTES:
cert-manager v1.10.1 has been deployed successfully!
...

$ kubectl cert-manager version -o yaml
clientVersion:
  compiler: gc
  gitCommit: a96bae172ddb1fcd4b57f1859ab9d1a9e94f7451
  gitTreeState: ""
  gitVersion: v1.10.1
  goVersion: go1.19.3
  platform: linux/amd64
serverVersion:
  detected: v1.10.1
  sources:
    crdLabelVersion: v1.10.1

```