### PR TITLE
Enable bilibilipro tool plugin

### DIFF
--- a/plugins/bilipro.yaml
+++ b/plugins/bilipro.yaml
@@ -1,0 +1,28 @@
+# This is the manifest template
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: bilipro
+spec:
+  # very initial version
+  version: "v0.0.1"
+  homepage: https://github.com/RayWangQvQ/BiliBiliToolPro
+  shortDescription: "Manage bilibili pro in your k8s cluster"
+  description: |
+    Deploy bilibili tool in your k8s cluster,
+    update it, Get its status and delete it.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - linux
+    uri: https://github.com/RayWangQvQ/BiliBiliToolPro/krew/bilipro.tar.gz
+    sha256: 0341702a20f7bee2d78867196d136d02a1c6b09b83093bec7387cb3395a0961d
+    files:
+    - from: LICENSE
+      to: .
+    - from: kubectl-bilipro
+      to: .
+    bin: kubectl-bilipro


### PR DESCRIPTION
Signed-off-by: chenliu1993 <lc17319031387@163.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

This plugin is used to enable bilibilipro tool management in kubernetes cluster. Simply create, update, delete and gets it.
Tested locally with  `kubectl krew install --manifest=[...] --archive=[...]` and it is working as expected