### PR TITLE
Add rsh plugin

### DIFF
--- a/plugins/rsh.yaml
+++ b/plugins/rsh.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: rsh
 spec:
-  version: "v0.0.3"
+  version: "v0.1.0"
   homepage: https://github.com/nilic/kubectl-rsh
   shortDescription: Open a remote shell session to a container
   description: |
@@ -16,34 +16,34 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_darwin_amd64.tar.gz"
-      sha256: "ac9f51486202ed2f135bb0e3756aed0816e4d147c9e775e1d55b60fdcd626119"
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.1.0/kubectl-rsh_v0.1.0_darwin_amd64.tar.gz"
+      sha256: "d68c5944cacd16e067960d6a840e849d01ea862366a688f78b5fbf707cf823e1"
       bin: kubectl-rsh
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_darwin_arm64.tar.gz"
-      sha256: "6ed2447937938b932e77bf8cc1c806bdfb681ecbe6a967d86b0f51abc810546a"
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.1.0/kubectl-rsh_v0.1.0_darwin_arm64.tar.gz"
+      sha256: "a9cdc57a8b5f78f73e12266304018cae206b53ea07fb7443fd31c8d5eea95abb"
       bin: kubectl-rsh
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_linux_amd64.tar.gz"
-      sha256: "69ab19b2f4254e135f710edcf24a9e67b3b1c0fa345e7bf8c89a14f91a49dc3f"
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.1.0/kubectl-rsh_v0.1.0_linux_amd64.tar.gz"
+      sha256: "b595797a56254357f38d25e48c012dfc6d843bce5dfb0b16fa793cb0d8438086"
       bin: kubectl-rsh
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_linux_arm64.tar.gz"
-      sha256: "991caeb9686d80ed46975ee4fddcba2514b421fb56699a021bd6d8fc50e67248"
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.1.0/kubectl-rsh_v0.1.0_linux_arm64.tar.gz"
+      sha256: "1aaae6cce16ed1c3722cebe00dc8b08dde325753b28bb089d3a979ea41785d8e"
       bin: kubectl-rsh
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_windows_amd64.zip"
-      sha256: "5d28a72ff349bee737cef88582d5406d36f401cd1f38f586c7a3c42c9f989d23"
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.1.0/kubectl-rsh_v0.1.0_windows_amd64.zip"
+      sha256: "ca538645328e342ea160bb97072b4715c970849d83e6a6f6562189eda57f8a68"
       bin: kubectl-rsh.exe

--- a/plugins/rsh.yaml
+++ b/plugins/rsh.yaml
@@ -1,0 +1,49 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rsh
+spec:
+  version: "v0.0.3"
+  homepage: https://github.com/nilic/kubectl-rsh
+  shortDescription: Open a remote shell session to a container
+  description: |
+    This command will attempt to start a remote shell session in a pod for the specified resource.
+    It works with pods, deployments, jobs, daemon sets, replication controllers and replica sets.
+    Shell can be specified (by default /bin/sh is used) and optionally a command can be executed
+    instead of a login shell.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_darwin_amd64.tar.gz"
+      sha256: "ac9f51486202ed2f135bb0e3756aed0816e4d147c9e775e1d55b60fdcd626119"
+      bin: kubectl-rsh
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_darwin_arm64.tar.gz"
+      sha256: "6ed2447937938b932e77bf8cc1c806bdfb681ecbe6a967d86b0f51abc810546a"
+      bin: kubectl-rsh
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_linux_amd64.tar.gz"
+      sha256: "69ab19b2f4254e135f710edcf24a9e67b3b1c0fa345e7bf8c89a14f91a49dc3f"
+      bin: kubectl-rsh
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_linux_arm64.tar.gz"
+      sha256: "991caeb9686d80ed46975ee4fddcba2514b421fb56699a021bd6d8fc50e67248"
+      bin: kubectl-rsh
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: "https://github.com/nilic/kubectl-rsh/releases/download/v0.0.3/kubectl-rsh_v0.0.3_windows_amd64.zip"
+      sha256: "5d28a72ff349bee737cef88582d5406d36f401cd1f38f586c7a3c42c9f989d23"
+      bin: kubectl-rsh.exe


### PR DESCRIPTION
This is a port of OpenShift client's `oc rsh` command to a `kubectl` plugin.

It opens a remote shell session to a running container (shell is configurable, `/bin/sh` is used by default) but can also be used for running a one-time command on a container instead of a login shell.

It works with pods, deployments, jobs, daemon sets, replication controllers and replica sets. When something other than a pod is targeted, it will be resolved to a ready pod. Container is configurable, by default first container is used.

I find this feature of `oc` very useful for troubleshooting and haven't been able to find a similar plugin which uses `exec` in the background.