### PR TITLE
Initial release of helm plugin.

### DIFF
--- a/plugins/helm.yaml
+++ b/plugins/helm.yaml
@@ -45,7 +45,7 @@ spec:
     bin: kubectl-helm
   - selector:
       matchLabels:
-        os: macos
+        os: darwin
         arch: amd64
     # 'uri' specifies .zip or .tar.gz archive URL of a plugin
     uri: https://github.com/sandipchitale/kubectl-helm/releases/download/v0.0.25/kubectl-helm_v0.0.25_darwin_amd64.tar.gz


### PR DESCRIPTION
Kubectl plugin to run helm commands including custom commands like

get templates RELEASENAME [--revision N]

Other commands are passed thru to helm.
