### PR TITLE
Add a new plugin "eks-node"

### DIFF
--- a/plugins/eks-node.yaml
+++ b/plugins/eks-node.yaml
@@ -1,0 +1,28 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: eks-node
+spec:
+  homepage: https://github.com/flavono123/kubectl-eks-node
+  shortDescription: Print the informantions on AWS EKS nodes
+  version: v0.1.0
+  description: |
+    Easily print, filter EKS nodes rather than using verbose named labels
+  caveats: |
+    [yq](https://github.com/mikefarah/yq#install) is required for now.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/flavono123/kubectl-eks-node/archive/v0.1.0.tar.gz
+    sha256: e525ef161b39af4eef1d4787e3de68b7b43346013e66df14363c0e87f1c8da89
+    bin: kubectl-eks_node
+    files:
+    - from: kubectl-eks-node-*/kubectl-eks_node
+      to: .
+    - from: kubectl-eks-node-*/LICENSE
+      to: .


### PR DESCRIPTION
The plugin print and filter AWS EKS nodes easily rather than selecting verbose named labels.

This is the first version and would be improved like following:
- Options for print formats(table, yaml, json)
- Re-implement with Go; remove the yq dependency

Signed-off-by: flavono123 <flavono123@gmail.com>

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
