### PR TITLE
add capsh

### DIFF
--- a/plugins/capsh.yaml
+++ b/plugins/capsh.yaml
@@ -1,0 +1,34 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: capsh
+spec:
+  shortDescription: check the capabilities(7) of a running Pod.
+  homepage: https://github.com/appdevgbb/utils-capsh
+  description: |
+    check the capabilities(7) of a running Pod.
+  caveats: |
+    kubectl-capsh needs capsh to run, so when executed for the first time it 
+    will download that file from this repository and install it under .kube/capsh 
+
+    Usage:
+      kubectl capsh <pod>
+  version: v0.1.1
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/appdevgbb/utils-capsh/releases/download/v0.1.1/capsh-0.1.1.tar.gz
+    sha256: 592b689b9eb3069530895bd485c313df97184f49ad0777a4b85bd3eaeeb51094
+    bin: kubectl-capsh
+    files: 
+    - from: ./kubectl-capsh
+      to: .
+    - from: LICENSE
+      to: .
+    - from: bin/libcap2-2.25-capsh-STATIC
+      to: .


### PR DESCRIPTION
This adds a refactored  version of capsh. Worth mentioning:

- With this version we do not copy the static linked capsh file to /usr/local/bin. 
- A static version of capsh will be copied to ~/.kube/capsh 
- Having a static version of capsh allows us to run this against a running pod and it has been tested on macOS and Linux.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
