### PR TITLE
new version v0.6.0 of volsync plugin

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.5.2
+  version: v0.6.0
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.5.2/kubectl-volsync.tar.gz
-      sha256: 4dbd3872b9221192a48cb879aa09a0f5351693bd9b09ba626c43d108240e6503
+      uri: https://github.com/backube/volsync/releases/download/v0.6.0/kubectl-volsync.tar.gz
+      sha256: 5c4558208fa1bd71a5b9dd6baef4559ea9bfca40d50f6916cac6ce652feaaa8c
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
Publishing v0.6.0 for volsync plugin.

Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/