### PR TITLE
New plugin for listing community-images

### DIFF
--- a/plugins/community-images.yaml
+++ b/plugins/community-images.yaml
@@ -1,0 +1,78 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: community-images
+spec:
+  version: v0.1.4
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/dims/community-images/releases/download/v0.1.4/community-images_linux_amd64.tar.gz
+    sha256: 9aa5c637fa4feed0396b6644ee36da4a731870525c48e7df163df9ecc2947e79
+    files:
+    - from: community-images
+      to: .
+    - from: LICENSE
+      to: .
+    bin: community-images
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/dims/community-images/releases/download/v0.1.4/community-images_linux_arm64.tar.gz
+    sha256: 57e048b12e804d5dba14221412353876812d4841785d69b058756221011b5866
+    files:
+    - from: community-images
+      to: .
+    - from: LICENSE
+      to: .
+    bin: community-images
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/dims/community-images/releases/download/v0.1.4/community-images_darwin_amd64.tar.gz
+    sha256: d6d0f800bccd76c08067e24f4b4fdec784921d30d29d2d41119a6f1bad5d0058
+    files:
+    - from: community-images
+      to: .
+    - from: LICENSE
+      to: .
+    bin: community-images
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/dims/community-images/releases/download/v0.1.4/community-images_darwin_arm64.tar.gz
+    sha256: 70880a65352f00536ca59728260c7f24515a2d3dc058c6509f7b33d0d5337fd0
+    files:
+    - from: community-images
+      to: .
+    - from: LICENSE
+      to: .
+    bin: community-images
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/dims/community-images/releases/download/v0.1.4/community-images_windows_amd64.zip
+    sha256: 13ee8fdcaf3c10c0da80683c9ace0b5bb50c8cad5f2373fd860bcd5d51b0e44b
+    files:
+    - from: community-images.exe
+      to: .
+    - from: LICENSE
+      to: .
+    bin: community-images.exe
+  shortDescription: List community owned container images running
+  homepage: https://github.com/dims/community-images
+  description: |
+    The plugin will scan for all pods in all namespaces that you have at least
+    read access to. The output is a list of all images, with the community
+    owned images in red, and the rest of the images in green. It also prints
+    some tips to ensure you are using the correct official repository.
+
+    For additional options:
+      $ kubectl community-images --help
+      or https://github.com/dims/community-images/blob/master/doc/USAGE.md


### PR DESCRIPTION
Creating a new plugin https://github.com/dims/community-images that will help the community identify images that are pulled from kubernetes team owned repository and encourage them to create their own repository or at the very least ask them to switch to the `registry.k8s.io` repository being rolled out.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
