### PR TITLE
Publishing v0.6.1 for volsync plugin.

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.6.0
+  version: v0.6.1
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.6.0/kubectl-volsync.tar.gz
-      sha256: 5c4558208fa1bd71a5b9dd6baef4559ea9bfca40d50f6916cac6ce652feaaa8c
+      uri: https://github.com/backube/volsync/releases/download/v0.6.1/kubectl-volsync.tar.gz
+      sha256: c6d7afa0cad0df1b9beb21dcb3b63c634e4f407eba9dffc3497f6b50d4786114
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
Publishing v0.6.1 for volsync plugin.

Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
