### PR TITLE
improve shortDescription for aks plugin

### DIFF
--- a/plugins/aks.yaml
+++ b/plugins/aks.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.2.0
   homepage: https://github.com/Azure/kubectl-aks
-  shortDescription: Interact with and debug AKS clusters even in challenging situations
+  shortDescription: Interact with and debug AKS clusters
   description: |
     This plugin provides a set of commands that enable users to interact with an
     AKS cluster even when the control plane is not functioning as expected. For


### PR DESCRIPTION
This PR improves the short description for [aks plugin](https://github.com/Azure/kubectl-aks) as discussed [here](https://github.com/kubernetes-sigs/krew-index/pull/3052#discussion_r1177980846):

> Just fyi this will get truncated a lot. I believe 50 chars is the cutoff.
>> Oh, I thought it was 80. I'll change it to just "Interact with and debug AKS clusters" in another PR.
