### PR TITLE
add forward-exec plugin

### DIFF
--- a/plugins/forward-exec.yaml
+++ b/plugins/forward-exec.yaml
@@ -1,0 +1,24 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: forward-exec
+spec:
+  version: "v0.0.1"
+  homepage: https://github.com/tgunsch/kubectl-forward-exec
+  shortDescription: "Forward a port to a pod, run a command on local machine and finally stop the port forward."
+  description: |
+    A convenience wrapper around `kubectl port-forward`.
+    
+    Start a forward one or more local ports to a pod in background. Then run a command on local machine and finally stop the port forward.
+  platforms:
+    - uri: https://github.com/tgunsch/kubectl-forward-exec/archive/v0.0.1.tar.gz
+      sha256: "96cb0b416a13a37032f2ed87328ee26d3dc809b5cb5939d3b0dea18e25de56ce"
+      bin: kubectl-forward-exec
+      files:
+        - from: "./kubectl-forward-exec-*/kubectl-forward-exec"
+          to: "."
+        - from: "./kubectl-forward-exec-*/LICENSE"
+          to: "."
+      selector:
+        matchExpressions:
+          - { key: os, operator: In, values: [ darwin, linux ] }


### PR DESCRIPTION
Hi,

not sure if this really worth a plugin and useful for others.

For our integration and functional tests we often needed a smoke test, where we need to 
* create a port-forward to a pod /service
* execute a curl command to  test the pod or get data from them.
   * for security reasons we only have scratch images without a curl command, so we execute the curl locally / in CI system
*  finally we drop the port-forward.

Until now we had a simple helper script to do this. Now I have experimented with kubectl plugins, so I converted the script to a plugin.

Example usage:

```
kubectl forward-exec --context prod -n my-namespace svc/my-service 8080:80 -- curl --connect-timeout 5 --retry 3 --retry-connrefused http://localhost:8080/whatever
```

BTW: We currently implement a go version, which waits until the port-forward is established before starting the command. 
