### PR TITLE
add forward-exec plugin

### DIFF
--- a/plugins/forward-exec.yaml
+++ b/plugins/forward-exec.yaml
@@ -1,0 +1,40 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: forward-exec
+spec:
+  version: "v0.2.0"
+  homepage: https://github.com/tgunsch/kubectl-forward-exec
+  shortDescription: "Forward a port to a pod, run a command on local machine and finally stop the port forward."
+  description: |
+    This plugin forwards a port to a pod, run a command (e.g. curl) on local machine and finally stop the port forward.
+    The preferred use case is doing smoke tests in integration tests; i.e. execute a request with curl to an forwarded port on pod, which don't have a shell inside.
+  platforms:
+    - bin: kubectl-forward-exec
+      uri: https://github.com/tgunsch/kubectl-forward-exec/releases/download/v0.2.0/kubectl-forward-exec_v0.2.0_linux_arm64.tar.gz
+      sha256: "372daa5705bca78fe6ba8e8225a287bb18b9c5e1e5a1fcfbc036e3f20988b55f"
+      selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+    - bin: kubectl-forward-exec
+      uri: https://github.com/tgunsch/kubectl-forward-exec/releases/download/v0.2.0/kubectl-forward-exec_v0.2.0_linux_amd64.tar.gz
+      sha256: "0a9dfe45dc46747059aa921b72526ba88f89551eb0f93284db7155912aaa5d63"
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - bin: kubectl-forward-exec
+      uri: https://github.com/tgunsch/kubectl-forward-exec/releases/download/v0.2.0/kubectl-forward-exec_v0.2.0_darwin_arm64.tar.gz
+      sha256: "83f06e9e4099577a42406765b530142a28e31ad221f6bf3ce31f91c53c4076b2"
+      selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+    - bin: kubectl-forward-exec
+      uri: https://github.com/tgunsch/kubectl-forward-exec/releases/download/v0.2.0/kubectl-forward-exec_v0.2.0_darwin_amd64.tar.gz
+      sha256: "eb9164e1a023fc0373787ef5fed62c4face82ee1cc947e29e9b84e1ca6c1febf"
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64 

--- a/plugins/forward-exec.yaml
+++ b/plugins/forward-exec.yaml
@@ -6,7 +6,7 @@ spec:
   version: "v0.2.0"
   homepage: https://github.com/tgunsch/kubectl-forward-exec
   shortDescription: "Run a command after port forward is established."
-description: |
+  description: |
     This plugin forwards a port to a pod, run a command (e.g. curl) on local machine and finally stop the port forward.
     The preferred use case is doing smoke tests in integration tests; i.e. execute a request with curl to an forwarded 
     port on pod, which don't have a shell inside.

--- a/plugins/forward-exec.yaml
+++ b/plugins/forward-exec.yaml
@@ -5,10 +5,11 @@ metadata:
 spec:
   version: "v0.2.0"
   homepage: https://github.com/tgunsch/kubectl-forward-exec
-  shortDescription: "Forward a port to a pod, run a command on local machine and finally stop the port forward."
-  description: |
+  shortDescription: "Run a command after port forward is established."
+description: |
     This plugin forwards a port to a pod, run a command (e.g. curl) on local machine and finally stop the port forward.
-    The preferred use case is doing smoke tests in integration tests; i.e. execute a request with curl to an forwarded port on pod, which don't have a shell inside.
+    The preferred use case is doing smoke tests in integration tests; i.e. execute a request with curl to an forwarded 
+    port on pod, which don't have a shell inside.
   platforms:
     - bin: kubectl-forward-exec
       uri: https://github.com/tgunsch/kubectl-forward-exec/releases/download/v0.2.0/kubectl-forward-exec_v0.2.0_linux_arm64.tar.gz


### PR DESCRIPTION
Hi,

not sure if this really worth a plugin and useful for others.

For our integration and functional tests we often needed a smoke test, where we need to

* create a port-forward to a pod /service
* execute a curl command to test the pod or get data from them.
  * for security reasons we only have scratch images without a curl command, so we execute the curl locally / in CI system
* finally we drop the port-forward.

Until now we had a simple helper script to do this. Now I have experimented with kubectl plugins, so I converted the script to a go plugin.

Example usage:
```
kubectl forward-exec svc/my-service 8080:80 -- curl http://localhost:8080/validate-pod
```