### PR TITLE
fix: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install kubectl
       run: |
         set -euo pipefail
-        sudo curl -fsSL -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.8/bin/linux/amd64/kubectl
+        sudo curl -fsSL -o /usr/bin/kubectl https://dl.k8s.io/release/v1.18.8/bin/linux/amd64/kubectl
         sudo chmod +x /usr/bin/kubectl
 
     - name: Install krew


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind deprecation

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396