### PR TITLE
Add `armadactl` plugin

### DIFF
--- a/plugins/armadactl.yaml
+++ b/plugins/armadactl.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: armadactl
+spec:
+  version: v0.3.85
+  homepage: https://github.com/armadaproject/armada
+  shortDescription: Command line utility to submit many jobs to armada
+  description: |
+    armadactl is a command-line tool used for managing jobs in the Armada workload orchestration system.
+    It provides functionality for creating, updating, and deleting jobs, as well as monitoring job status and resource usage.
+  caveats: |
+    Before using the Armada CLI, make sure you have working armada enviornment
+    or a armadactl.yaml file that points to a valid armada cluster.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-linux-amd64.tar.gz
+    sha256: 34bf064f9a3da8cf5918c7a7ab74e53089f6bf503f21c69ef5a9dc3b346fab79
+    bin: armadactl
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-darwin-amd64.tar.gz
+    sha256: a260ba48fdf4128fe166f95f03e648bb8884b3c386f3b0be5ef0f4b30d00298e
+    bin: armadactl
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-windows-amd64.zip
+    sha256: 6a3b1cecd4e102840b26674019cfc03c6b0c4cf3e668fc6db6203716d4c721af
+    bin: armadactl.exe


### PR DESCRIPTION
-  armadactl is a command-line tool used for managing jobs in the Armada workload orchestration system.
    It provides functionality for creating, updating, and deleting jobs, as well as monitoring job status and resource usage.
    
- [Armada](https://armadaproject.io/) is a CNCF Sandbox project. Armada is a multi-kubernetes-cluster batch job meta-scheduler.
  It helps organizations distribute millions of batch jobs per day across many nodes across many clusters.
