### PR TITLE
Add `armadactl` plugin

### DIFF
--- a/plugins/armadactl.yaml
+++ b/plugins/armadactl.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: armadactl
 spec:
-  version: v0.3.85
+  version: v0.3.8655
   homepage: https://github.com/armadaproject/armada
   shortDescription: Command line utility to submit many jobs to armada
   description: |
@@ -17,20 +17,20 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-linux-amd64.tar.gz
-    sha256: 34bf064f9a3da8cf5918c7a7ab74e53089f6bf503f21c69ef5a9dc3b346fab79
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.8655/armadactl_0.3.8655_linux_amd64.tar.gz
+    sha256: 0078f43119cd992b5af0c5c6bab5a0780c7449d38a35ea572d959fe500aa766c
     bin: armadactl
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-darwin-amd64.tar.gz
-    sha256: a260ba48fdf4128fe166f95f03e648bb8884b3c386f3b0be5ef0f4b30d00298e
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.8655/armadactl_0.3.8655_darwin_all.tar.gz
+    sha256: 7f49ea0851dd83303e3e3553834571313b66415f3d4edd99e10f56532849300f
     bin: armadactl
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-windows-amd64.zip
-    sha256: 6a3b1cecd4e102840b26674019cfc03c6b0c4cf3e668fc6db6203716d4c721af
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.8655/armadactl_0.3.8655_windows_amd64.zip
+    sha256: 27774e39b8a29603671c21ed9487fbd073eb408535afe5de5f336e84dc13998b
     bin: armadactl.exe

--- a/plugins/armadactl.yaml
+++ b/plugins/armadactl.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: armadactl
+spec:
+  version: v0.3.85
+  homepage: https://github.com/armadaproject/armada
+  shortDescription: Command line utility to submit many jobs to armada
+  description: |
+    armadactl is a command-line tool used for managing jobs in the Armada workload orchestration system.
+    It provides functionality for creating, updating, and deleting jobs, as well as monitoring job status and resource usage.
+  caveats: |
+    Before using the Armada CLI, make sure you have working armada enviornment
+    or a armadactl.yaml file that points to a valid armada cluster.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-linux-amd64.tar.gz
+    sha256: 34bf064f9a3da8cf5918c7a7ab74e53089f6bf503f21c69ef5a9dc3b346fab79
+    bin: armadactl
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-darwin-amd64.tar.gz
+    sha256: a260ba48fdf4128fe166f95f03e648bb8884b3c386f3b0be5ef0f4b30d00298e
+    bin: armadactl
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/armadaproject/armada/releases/download/v0.3.85/armadactl-v0.3.85-windows-amd64.zip
+    sha256: 6a3b1cecd4e102840b26674019cfc03c6b0c4cf3e668fc6db6203716d4c721af
+    bin: armadactl.exe


### PR DESCRIPTION
-  `armadactl` is a command-line tool used for managing jobs in the Armada workload orchestration system.
    It provides functionality for creating, updating, and deleting jobs, as well as monitoring job status and resource usage.
    
- [Armada](https://github.com/armadaproject/armada) is a CNCF Sandbox project. Armada is a multi-kubernetes-cluster batch job meta-scheduler.
  It helps organizations distribute millions of batch jobs per day across many nodes across many clusters.
