### PR TITLE
Add otel

### DIFF
--- a/plugins/otel.yaml
+++ b/plugins/otel.yaml
@@ -21,3 +21,11 @@ spec:
         - darwin
         - linux
     uri: https://github.com/agardnerIT/kubectl-otel/archive/refs/tags/0.1.0.tar.gz
+    sha256: 345d6260820be1def9c51929fe16ad26bcbefde46794d141b0ba746516ee3eb4
+    files:
+    - from: kubectl-otel
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-otel
+    

--- a/plugins/otel.yaml
+++ b/plugins/otel.yaml
@@ -1,0 +1,23 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: otel
+spec:
+  homepage: https://github.com/agardnerit/kubectl-otel
+  shortDescription: Trace kubectl commands with OpenTelemetry
+  version: v0.1.0
+  description: |
+    Generate OpenTelemetry traces for any kubectl command
+  caveats: |
+    You must have the tracepusher binary in your path.
+    tracepusher is a standalone binary to generate OpenTelemetry spans.
+    See https://github.com/agardnerIT/kubectl-otel for details.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/agardnerIT/kubectl-otel/archive/refs/tags/0.1.0.tar.gz

--- a/plugins/otel.yaml
+++ b/plugins/otel.yaml
@@ -22,10 +22,4 @@ spec:
         - linux
     uri: https://github.com/agardnerIT/kubectl-otel/archive/refs/tags/0.1.0.tar.gz
     sha256: 345d6260820be1def9c51929fe16ad26bcbefde46794d141b0ba746516ee3eb4
-    files:
-    - from: kubectl-otel
-      to: .
-    - from: LICENSE
-      to: .
-    bin: kubectl-otel
-    
+    bin: ./kubectl-otel-0.1.0/kubectl-otel


### PR DESCRIPTION
# This PR

- Adds the `otel` plugin

# This Plugin

Uses [tracepusher](https://github.com/agardnerit/tracepusher) to generate [OpenTelemetry](https://opentelemetry.io) traces for `kubectl` commands.