### PR TITLE
new version v1.8.0 of node-shell

### DIFF
--- a/plugins/node-shell.yaml
+++ b/plugins/node-shell.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: node-shell
 spec:
-  version: v1.7.0
+  version: v1.8.0
   homepage: https://github.com/kvaps/kubectl-node-shell
   shortDescription: Spawn a root shell on a node via kubectl 
   description: |
@@ -15,6 +15,9 @@ spec:
       Get standard bash shell:
       $ kubectl node-shell <node>
       
+      Use X-mode (mount /host, and do not enter host namespace)
+      $ kubectl node-shell -x <node>
+
       Execute custom command:
       $ kubectl node-shell <node> -- echo 123
       
@@ -33,8 +36,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/kvaps/kubectl-node-shell/archive/v1.7.0.tar.gz
-    sha256: b42cb135d7caf8a9afa6764b1fa6e17bc48548fe420b6e48c4964ca6193e98da
+    uri: https://github.com/kvaps/kubectl-node-shell/archive/v1.8.0.tar.gz
+    sha256: 5b1665b045a3a3408d2ba0e556521fc450060600b1757c82f9427bf6c4298ce5
     files:
     - from: kubectl-node-shell-*/kubectl-node_shell
       to: .


### PR DESCRIPTION
## X-mode

X-mode can be useful for debugging minimal systems that do not have a built-in shell (eg. Talos).
Here's an example of how you can debug the network for a rootless kube-apiserver container without a filesystem:

```bash
kubectl node-shell -x <node>

# Download crictl
wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.28.0/crictl-v1.28.0-linux-amd64.tar.gz -O- | \
  tar -xzf- -C /usr/local/bin/

# Setup CRI endpoint
export CONTAINER_RUNTIME_ENDPOINT=unix:///host/run/containerd/containerd.sock

# Find your container
crictl ps | grep kube-apiserver
#3ff4626a9f10e       e7972205b6614       6 hours ago         Running             kube-apiserver         0                   215107b47bd7e       kube-apiserver-talos-rzq-nkg

# Find pid of the container
crictl inspect 3ff4626a9f10e | grep pid
#    "pid": 2152,
#            "pid": 1
#            "type": "pid"
#                "getpid",
#                "getppid",
#                "pidfd_open",
#                "pidfd_send_signal",
#                "waitpid",

# Go to network namespace of the pid, but keep mount namespace of the debug container
nsenter -t 2152 -n
```
