### PR TITLE
Add shell-ctx plugin

### DIFF
--- a/plugins/shell-ctx.yaml
+++ b/plugins/shell-ctx.yaml
@@ -1,0 +1,33 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: shell-ctx
+spec:
+  version: "v1.0.2"
+  homepage: https://github.com/glemsom/shell-ctx
+  shortDescription: "Kubernetes shell isolated context switcher"
+  description: |
+    Enabled each instance of a shell to operate in its own isolated Kubernetes context.
+    Supported shells: bash, zsh and fish.
+  caveats: |
+    Requirements: bash, awk, sed, fzf and kubectl
+    
+    To setup this plugin, please install the required shell-hook.
+    For details see:
+    kubectl shell-ctx -h
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/glemsom/shell-ctx/archive/refs/tags/v1.0.2.zip
+    sha256: 541977b3e4060e6a350aa1b62a2e6c2ff1085fd7fe86fd5d1f965759bc3bdbd3
+    files:
+    - from: "shell-ctx-*/kubectl-shell_ctx"
+      to: "."
+    - from: "shell-ctx-*/LICENSE"
+      to: "."
+    bin: kubectl-shell_ctx

--- a/plugins/shell-ctx.yaml
+++ b/plugins/shell-ctx.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: "v1.0.2"
   homepage: https://github.com/glemsom/shell-ctx
-  shortDescription: "Kubernetes shell isolated context switcher"
+  shortDescription: "Shell independent context switching"
   description: |
     Enabled each instance of a shell to operate in its own isolated Kubernetes context.
     Supported shells: bash, zsh and fish.


### PR DESCRIPTION
Simple plugin to enable each shell-instance to operate in its own isolated Kubernetex context