### PR TITLE
Bump shell-ctx kubectl plugin to v1.0.3

### DIFF
--- a/plugins/shell-ctx.yaml
+++ b/plugins/shell-ctx.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: shell-ctx
 spec:
-  version: "v1.0.2"
+  version: "v1.0.3"
   homepage: https://github.com/glemsom/shell-ctx
   shortDescription: "Shell independent context switching"
   description: |
@@ -23,11 +23,11 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/glemsom/shell-ctx/archive/refs/tags/v1.0.2.zip
-    sha256: 541977b3e4060e6a350aa1b62a2e6c2ff1085fd7fe86fd5d1f965759bc3bdbd3
+    uri: https://github.com/glemsom/shell-ctx/releases/download/v1.0.3/v1.0.3.zip
+    sha256: 205b153c9b51ad432ea5e61a2d807ab836138308040f4fe984bf412378076491
     files:
-    - from: "shell-ctx-*/kubectl-shell_ctx"
+    - from: "shell-ctx*/kubectl-shell_ctx"
       to: "."
-    - from: "shell-ctx-*/LICENSE"
+    - from: "shell-ctx*/LICENSE"
       to: "."
     bin: kubectl-shell_ctx

--- a/plugins/shell-ctx.yaml
+++ b/plugins/shell-ctx.yaml
@@ -7,7 +7,7 @@ spec:
   homepage: https://github.com/glemsom/shell-ctx
   shortDescription: "Shell independent context switching"
   description: |
-    Enabled each instance of a shell to operate in its own isolated Kubernetes context.
+    Enables each instance of a shell to operate in its own isolated Kubernetes context.
     Supported shells: bash, zsh and fish.
   caveats: |
     Requirements: bash, awk, sed, fzf and kubectl


### PR DESCRIPTION
Update to version v1.0.3.
### Fixes
 - Incorrect redirection of error messages during shell-hook
 - Minor spelling error in krew description