### PR TITLE
adding `kube-lock` plugin

### DIFF
--- a/plugins/lock.yaml
+++ b/plugins/lock.yaml
@@ -1,0 +1,42 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: lock
+spec:
+  version: v0.0.4
+  homepage: https://github.com/chaosinthecrd/kube-lock
+  shortDescription: A pane of glass between you and your Kubernetes clusters
+  description: |
+    Sits as an intermediary between you and kubectl, allowing you to lock and unlock contexts.
+    Prevents misfires to production / high-value Kubernetes clusters that you might have strong IAM privileges on.
+    Supports custom 'Profiles', allowing you to restrict certain verbs from being passed to high-value clusters.
+  caveats: must alias `kubectl` to kubectl-lock kubectl in `.bashrc`/`.zshrc` (e.g., alias kubectl='kubectl-lock kubectl')
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/chaosinthecrd/kube-lock/releases/download/v0.0.4/kube-lock_v0.0.4_darwin_amd64.tar.gz
+    sha256: d9e87d41876ea0bbbb33deac37589877c81f17e5dea820c605e6d636a6267e9e
+    bin: kubectl-lock
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/chaosinthecrd/kube-lock/releases/download/v0.0.4/kube-lock_v0.0.4_darwin_arm64.tar.gz
+    sha256: c6498479a52cbfcfb303ea06b9c12fd0e4d05aac2035f505c0db4e8fd54a9e23
+    bin: kubectl-lock
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/chaosinthecrd/kube-lock/releases/download/v0.0.4/kube-lock_v0.0.4_linux_amd64.tar.gz
+    sha256: b8b7c140eff6c983d2d22127ea0617a333bdd88728782647b787e793e95bf346
+    bin: kubectl-lock
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/chaosinthecrd/kube-lock/releases/download/v0.0.4/kube-lock_v0.0.4_windows_amd64.tar.gz
+    sha256: cac8d24f8fe430b59327b98ba0181e2dc0f3a9b6bb8433a29144314501220e20
+    bin: kubectl-lock.exe

--- a/plugins/lock.yaml
+++ b/plugins/lock.yaml
@@ -7,9 +7,7 @@ spec:
   homepage: https://github.com/chaosinthecrd/kube-lock
   shortDescription: A pane of glass between you and your Kubernetes clusters
   description: |
-    Sits as an intermediary between you and kubectl, allowing you to lock and unlock contexts.
-    Prevents misfires to production / high-value Kubernetes clusters that you might have strong IAM privileges on.
-    Supports custom 'Profiles', allowing you to restrict certain verbs from being passed to high-value clusters.
+    An intermediary between you and kubectl, allowing you to lock/unlock contexts.
   caveats: must alias `kubectl` to kubectl-lock kubectl in `.bashrc`/`.zshrc` (e.g., alias kubectl='kubectl-lock kubectl')
   platforms:
   - selector:

--- a/plugins/lock.yaml
+++ b/plugins/lock.yaml
@@ -7,8 +7,11 @@ spec:
   homepage: https://github.com/chaosinthecrd/kube-lock
   shortDescription: A client-side lock for kubernetes contexts to prevent kubectl misfires.
   description: |
-    This tool allows you to `lock` and `unlock` contexts to prevent accidentally issuing destructive commands to the wrong contexts.
-    You can also set `profiles`, which let you lock the context while keeping certain verb/resource combinations available.
+    This tool allows you to `lock` and `unlock` contexts to prevent accidentally 
+    issuing destructive commands to the wrong contexts. You can also set `profiles`, 
+    which let you lock the context while keeping certain verb/resource combinations 
+    available. It achieves by acting as a wrapper around `kubectl` and assessing 
+    the command executed against a configuration file (at `~./kube-lock.yaml`).
   caveats: must alias `kubectl` to kubectl-lock kubectl in `.bashrc`/`.zshrc` (e.g., alias kubectl='kubectl-lock kubectl --')
   platforms:
   - selector:

--- a/plugins/lock.yaml
+++ b/plugins/lock.yaml
@@ -8,7 +8,7 @@ spec:
   shortDescription: A pane of glass between you and your Kubernetes clusters
   description: |
     An intermediary between you and kubectl, allowing you to lock/unlock contexts.
-  caveats: must alias `kubectl` to kubectl-lock kubectl in `.bashrc`/`.zshrc` (e.g., alias kubectl='kubectl-lock kubectl')
+  caveats: must alias `kubectl` to kubectl-lock kubectl in `.bashrc`/`.zshrc` (e.g., alias kubectl='kubectl-lock kubectl --')
   platforms:
   - selector:
       matchLabels:

--- a/plugins/lock.yaml
+++ b/plugins/lock.yaml
@@ -5,9 +5,10 @@ metadata:
 spec:
   version: v0.0.4
   homepage: https://github.com/chaosinthecrd/kube-lock
-  shortDescription: A pane of glass between you and your Kubernetes clusters
+  shortDescription: A client-side lock for kubernetes contexts to prevent kubectl misfires.
   description: |
-    An intermediary between you and kubectl, allowing you to lock/unlock contexts.
+    This tool allows you to `lock` and `unlock` contexts to prevent accidentally issuing destructive commands to the wrong contexts.
+    You can also set `profiles`, which let you lock the context while keeping certain verb/resource combinations available.
   caveats: must alias `kubectl` to kubectl-lock kubectl in `.bashrc`/`.zshrc` (e.g., alias kubectl='kubectl-lock kubectl --')
   platforms:
   - selector:


### PR DESCRIPTION
Hi there 👋

I wish to add my kubectl tool` kube-lock as a krew plugin under the command `lock`. This allows people to easily lock and unlock Kubernetes contexts locally (all performed client side). I have tested it locally and all seems to work fine!

thanks,