### PR TITLE
Add backup-diff plugin to index

### DIFF
--- a/plugins/backup-diff.yaml
+++ b/plugins/backup-diff.yaml
@@ -1,0 +1,29 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: backup-diff
+spec:
+  version: "v1.0.2"
+  homepage: https://github.com/milapj/kubectl-backup-diff
+  shortDescription: "Backups a resource and diffs the state change with current"
+  description: |
+    Creates a backup of a resource and compares the change 
+    between the backed-up state at a specific point in time 
+    and the current state. Functions similar to git diff. 
+    Useful during diaster recovery.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/milapj/kubectl-backup-diff/archive/refs/tags/v1.0.2.tar.gz
+    sha256: 86f52e0bba84caa126720668f6c0401bc864bc850b60f2d07a18b6166ccf42f5
+    files:
+    - from: "kubectl-backup-diff-1.0.2/cmd/kubectl-backup-diff"
+      to: "kubectl-backup-diff"
+    - from: "kubectl-backup-diff-1.0.2/LICENSE"
+      to: "."
+    bin: kubectl-backup-diff

--- a/plugins/backup-diff.yaml
+++ b/plugins/backup-diff.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: "v1.0.2"
   homepage: https://github.com/milapj/kubectl-backup-diff
-  shortDescription: Backs up a resource, diffs state change with current
+  shortDescription: Back up a resource, shows state drift with current
   description: |
     Resource backup, git-diff like compare state for recovery
   platforms:

--- a/plugins/backup-diff.yaml
+++ b/plugins/backup-diff.yaml
@@ -5,12 +5,9 @@ metadata:
 spec:
   version: "v1.0.2"
   homepage: https://github.com/milapj/kubectl-backup-diff
-  shortDescription: "Backups a resource and diffs the state change with current"
+  shortDescription: Backs up a resource, diffs state change with current
   description: |
-    Creates a backup of a resource and compares the change 
-    between the backed-up state at a specific point in time 
-    and the current state. Functions similar to git diff. 
-    Useful during diaster recovery.
+    Resource backup, git-diff like compare state for recovery
   platforms:
   - selector:
       matchExpressions:


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
* `backup-diff` creates a backup of a resource and compares the change between the backed-up state at a specific point in time and the current state, showing the state drift. 
* Functions similar to git diff. This can be pretty useful during disaster recovery or debugging to recover previous states of resources that were updated on the fly w/o having to re-release.
* The backup is stored at `/tmp/backups/<resource-type>` by default, but it can be stored at a user-specified path. The resources can also be re-created using the backup files.

* [github repo](https://github.com/milapj/kubectl-backup-diff)


https://github.com/kubernetes-sigs/krew-index/assets/9828402/380264cf-1f04-44f7-b4e3-6c928f4c8fa7

