### PR TITLE
Publishing v0.8.0 of VolSync plugin

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.7.0
+  version: v0.8.0
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.7.0/kubectl-volsync.tar.gz
-      sha256: 89c263d72379340d8dfc5249173f6500f092f8f7c94db95fa76584e65b23ed19
+      uri: https://github.com/backube/volsync/releases/download/v0.8.0/kubectl-volsync.tar.gz
+      sha256: dfe05cf608fa3c0a4b723444753d9ff65baa2557f7949aa533336c314fb2d7bf
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
Publishing v0.8.0 for volsync plugin.

Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/