### PR TITLE
Bump shell-ctx version

### DIFF
--- a/plugins/shell-ctx.yaml
+++ b/plugins/shell-ctx.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: shell-ctx
 spec:
-  version: "v1.0.5"
+  version: "v1.0.6"
   homepage: https://github.com/glemsom/shell-ctx
   shortDescription: "Shell independent context switching"
   description: |
@@ -23,8 +23,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/glemsom/shell-ctx/releases/download/v1.0.5/v1.0.5.zip
-    sha256: b958f3c9141a222ad7dd684d6d55eca8c44b8bdff53302121f92d73a94eb77be
+    uri: https://github.com/glemsom/shell-ctx/releases/download/v1.0.6/v1.0.6.zip
+    sha256: f34bfb452dbea818a064adf46d724e85fbef756ff005f153efb731e9ed315c0c
     files:
     - from: "shell-ctx*/kubectl-shell_ctx"
       to: "."


### PR DESCRIPTION
## v1.0.6
 * Added support for having an empty KUBECONFIG