### PR TITLE
Add ```autons``` plugin manifest

### DIFF
--- a/plugins/autons.yaml
+++ b/plugins/autons.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: autons
 spec:
-  version: v0.2.0
+  version: v0.2.2
   homepage: https://github.com/ragrag/kubectl-autons
   shortDescription: Automatic namespace detection for kubectl commands
   description: |

--- a/plugins/autons.yaml
+++ b/plugins/autons.yaml
@@ -16,26 +16,26 @@ spec:
           os: darwin
           arch: amd64
       uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-darwin-amd64.tar.gz
-      sha256: eb5f25f0f07f2a752906e95706a3a4676d787d06377b4e434ffd33583ec7194a
+      sha256: 65b54c67a53b5a6ab510d1b360bd803b5e41061adc7c1595948ef1f19c69e532
       bin: kubectl-autons
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
       uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-darwin-arm64.tar.gz
-      sha256: ddddfbb786f4dc38863e2e83679fdb72b6082c1f9dfea202fb6b35f5d92cba54
+      sha256: fdfe8c3c38ed7bbf3a2bc0238438f24dae494b8f1df2145a16890835d450ad4b
       bin: kubectl-autons
     - selector:
         matchLabels:
           os: linux
           arch: amd64
       uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-linux-amd64.tar.gz
-      sha256: eeac6e57d46c59b30515ea2615bd621abdd09c7ad84e15bc8c0c49d21af0d863
+      sha256: 567bb2676fa419c169eada7519100bde00141a8eb8f13301f21659e3064b42f8
       bin: kubectl-autons
     - selector:
         matchLabels:
           os: windows
           arch: amd64
       uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-windows-amd64.tar.gz
-      sha256: 1fc3d3dd776d4b2929fcf55bdb84177d933d9e7b3056b025c26984de619933f9
+      sha256: f8d671122dc09605fd10951e0252fa4792fb60148e88c4eb7f74b1a1ec0357f1
       bin: kubectl-autons.exe

--- a/plugins/autons.yaml
+++ b/plugins/autons.yaml
@@ -5,11 +5,9 @@ metadata:
 spec:
   version: v0.2.2
   homepage: https://github.com/ragrag/kubectl-autons
-  shortDescription: Automatic namespace detection for kubectl commands
+  shortDescription: Automatic namespace detection
   description: |
-    Automatically detect namespaces for resources in kubectl commands and adding the --namespace flag
-  caveats: |
-    * In cases where a resource is found in multiple namespaces, an error is expected and you will have to specify the desired namespace manually
+    Automatically detect namespaces for resources and adding the --namespace flag
   platforms:
     - selector:
         matchLabels:

--- a/plugins/autons.yaml
+++ b/plugins/autons.yaml
@@ -7,7 +7,7 @@ spec:
   homepage: https://github.com/ragrag/kubectl-autons
   shortDescription: Automatic namespace detection
   description: |
-    Automatically detect namespaces for resources and adding the --namespace flag
+    Automatically detect namespaces for resources without the --namespace flag.
   platforms:
     - selector:
         matchLabels:

--- a/plugins/autons.yaml
+++ b/plugins/autons.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: autons
+spec:
+  version: v0.2.0
+  homepage: https://github.com/ragrag/kubectl-autons
+  shortDescription: Automatic namespace detection for kubectl commands
+  description: |
+    Automatically detect namespaces for resources in kubectl commands and adding the --namespace flag
+  caveats: |
+    * In cases where a resource is found in multiple namespaces, an error is expected and you will have to specify the desired namespace manually
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-darwin-amd64.tar.gz
+      sha256: eb5f25f0f07f2a752906e95706a3a4676d787d06377b4e434ffd33583ec7194a
+      bin: kubectl-autons
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-darwin-arm64.tar.gz
+      sha256: ddddfbb786f4dc38863e2e83679fdb72b6082c1f9dfea202fb6b35f5d92cba54
+      bin: kubectl-autons
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-linux-amd64.tar.gz
+      sha256: eeac6e57d46c59b30515ea2615bd621abdd09c7ad84e15bc8c0c49d21af0d863
+      bin: kubectl-autons
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/ragrag/kubectl-autons/releases/download/v0.2.2/kubectl-autons-windows-amd64.tar.gz
+      sha256: 1fc3d3dd776d4b2929fcf55bdb84177d933d9e7b3056b025c26984de619933f9
+      bin: kubectl-autons.exe


### PR DESCRIPTION
Adding [kubectl-autons](https://github.com/ragrag/kubectl-autons) plugin

```autons``` automatically detects namespaces for kubectl commands and adds the corresponding --namespace flag.

e.g: 
running ```kubectl autons logs my-pod``` where ```my-pod``` is in namespace ```prod```,  ```autons``` will run  ```kubectl autons logs my-pod --namespace prod```