### PR TITLE
Add debug-pdb plugin

### DIFF
--- a/plugins/debug-pdb.yaml
+++ b/plugins/debug-pdb.yaml
@@ -1,0 +1,55 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: debug-pdb
+spec:
+  version: "v0.1.1"
+  homepage: https://github.com/dhenkel92/kubectl-debug-pdb
+  shortDescription: "Debug Pod Disruption Budgets (PDB)"
+  description: |
+    This Kubernetes plugin assists in debugging pod disruption budgets.
+    It helps in understanding the connection between PDBs and pods, and vice versa.
+    Additionally, you can run evictions to verify if the disruption budget is functioning as anticipated.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/dhenkel92/kubectl-debug-pdb/releases/download/v0.1.1/kubectl-debug-pdb_Darwin_arm64.tar.gz
+    sha256: dc295bd723b56c331a5392a5ff87e1a62f7e0b84a8cea6d0c137a2030b75d81a
+    bin: kubectl-debug_pdb
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/dhenkel92/kubectl-debug-pdb/releases/download/v0.1.1/kubectl-debug-pdb_Darwin_x86_64.tar.gz
+    sha256: 47b8d939012c55ad94048e1b3b01723ff9590ad614c3316cd694d1c2e66cb32c
+    bin: kubectl-debug_pdb
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/dhenkel92/kubectl-debug-pdb/releases/download/v0.1.1/kubectl-debug-pdb_Linux_arm64.tar.gz
+    sha256: 1438007677dd8896bbdf9f21af9a1ff1ded5417641f0f1c828317e33ef9af065
+    bin: kubectl-debug_pdb
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/dhenkel92/kubectl-debug-pdb/releases/download/v0.1.1/kubectl-debug-pdb_Linux_x86_64.tar.gz
+    sha256: 72b5ba621e3a9250b9408325cada87f7bc6828e752c218fefcd0dd8d15f969a0
+    bin: kubectl-debug_pdb
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/dhenkel92/kubectl-debug-pdb/releases/download/v0.1.1/kubectl-debug-pdb_Windows_arm64.zip
+    sha256: dbba5e16d5824c3cf3f24b327c27b5843572e75c3c9ea33b3a9a460baa1346da
+    bin: kubectl-debug_pdb.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/dhenkel92/kubectl-debug-pdb/releases/download/v0.1.1/kubectl-debug-pdb_Windows_x86_64.zip
+    sha256: 85811dc6343d47a65b5ebb65e1f034342bac30aa9a3e15b5d336fbd5ee08522c
+    bin: kubectl-debug_pdb.exe


### PR DESCRIPTION
This Kubernetes plugin assists in debugging pod disruption budgets.
It helps in understanding the connection between PDBs and pods, and vice versa.
Additionally, you can run evictions to verify if the disruption budget is functioning as 