### PR TITLE
Add clog plugin manifest

### DIFF
--- a/plugins/clog.yaml
+++ b/plugins/clog.yaml
@@ -9,7 +9,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_linux_amd64.tar.gz"
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/v0.1.1/clog_linux_amd64.tar.gz"
     sha256: cf9039f6ee2a28d641a849b80dd1c070702775956e00974baf61b4a6646564bb
     files:
     - from: "./clog"
@@ -21,7 +21,7 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_linux_arm64.tar.gz"
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/v0.1.1/clog_linux_arm64.tar.gz"
     sha256: 0e3e534f26c8d17a25b42315dab1e9a2eb8e9260cb56c19d79c96dc3d8ce5c06
     files:
     - from: "./clog"
@@ -33,7 +33,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_darwin_amd64.tar.gz"
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/v0.1.1/clog_darwin_amd64.tar.gz"
     sha256: df65d528c4ad967d59706fe1d6710b7558f8a53db9c3919bd30fd3f6f42578ac
     files:
     - from: "./clog"
@@ -45,7 +45,7 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_darwin_arm64.tar.gz"
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/v0.1.1/clog_darwin_arm64.tar.gz"
     sha256: 94320bcff6717ad2ad3565a93a1d5f8b20252780cd788a1f0327d5e9e0a5e45e
     files:
     - from: "./clog"
@@ -57,7 +57,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_windows_amd64.zip"
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/v0.1.1/clog_windows_amd64.zip"
     sha256: 75c85ea50cb3089d3beaa9c63b14ed28a318c04b8409d8a467ab6d9356fc5329
     files:
     - from: "/clog.exe"
@@ -69,7 +69,7 @@ spec:
       matchLabels:
         os: windows
         arch: arm64
-    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_windows_arm64.zip"
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/v0.1.1/clog_windows_arm64.zip"
     sha256: 78f94391d38a2f60968daa6b835d1b13abca31e0ad95f7f661ac228c2165cec2
     files:
     - from: "/clog.exe"

--- a/plugins/clog.yaml
+++ b/plugins/clog.yaml
@@ -77,17 +77,8 @@ spec:
     - from: LICENSE
       to: "."
     bin: "clog.exe"
-  shortDescription: A kubectl plugin to colorize logs.
+  shortDescription: Colorize log outputs.
   homepage: https://github.com/orangetangerine/kubectl-clog
-  caveats: |
-    Usage:
-      # just like kubectl logs ...
-      $ kubectl clog ... 
-
-    For additional options:
-      $ kubectl clog --help
-      or https://github.com/orangetangerine/kubectl-clog/blob/v0.1.1/doc/USAGE.md
-
   description: |
     This is a new plugin to colorize your kubectl logs. 
     clog is just a wrapper of built-in kubectl logs, with same command usage,

--- a/plugins/clog.yaml
+++ b/plugins/clog.yaml
@@ -1,0 +1,95 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: clog
+spec:
+  version: "v0.1.1"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_linux_amd64.tar.gz" .TagName }}
+    files:
+    - from: "./clog"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "clog"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_linux_arm64.tar.gz" .TagName }}
+    files:
+    - from: "./clog"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "clog"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_darwin_amd64.tar.gz" .TagName }}
+    files:
+    - from: "./clog"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "clog"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_darwin_arm64.tar.gz" .TagName }}
+    files:
+    - from: "./clog"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "clog"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_windows_amd64.zip" .TagName }}
+    files:
+    - from: "/clog.exe"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "clog.exe"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_windows_arm64.zip" .TagName }}
+    files:
+    - from: "/clog.exe"
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: "clog.exe"
+  shortDescription: A kubectl plugin to colorize logs.
+  homepage: https://github.com/orangetangerine/kubectl-clog
+  caveats: |
+    Usage:
+      # just like kubectl logs ...
+      $ kubectl clog ... 
+
+    For additional options:
+      $ kubectl clog --help
+      or https://github.com/orangetangerine/kubectl-clog/blob/v0.1.1/doc/USAGE.md
+
+  description: |
+    This is a new plugin to colorize your kubectl logs. 
+    clog is just a wrapper of built-in kubectl logs, with same command usage,
+    just replace `kubectl logs` with `kubectl clog`. 
+    
+    Some frequent log content is detected to colorizing.
+    * json format log with level field. e.g. `{"level":"debug"}`
+    * envoy format log via istio-proxy. e.g. `2023-12-26T07:01:24.212130Z     debug   envoy upstream`
+    * istio access log. e.g. `[2023-12-26T05:45:58.421Z] "POST /package.service/method HTTP/2" 200 ...` 
+    
+

--- a/plugins/clog.yaml
+++ b/plugins/clog.yaml
@@ -9,7 +9,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_linux_amd64.tar.gz" .TagName }}
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_linux_amd64.tar.gz"
+    sha256: cf9039f6ee2a28d641a849b80dd1c070702775956e00974baf61b4a6646564bb
     files:
     - from: "./clog"
       to: "."
@@ -20,7 +21,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_linux_arm64.tar.gz" .TagName }}
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_linux_arm64.tar.gz"
+    sha256: 0e3e534f26c8d17a25b42315dab1e9a2eb8e9260cb56c19d79c96dc3d8ce5c06
     files:
     - from: "./clog"
       to: "."
@@ -31,7 +33,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_darwin_amd64.tar.gz" .TagName }}
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_darwin_amd64.tar.gz"
+    sha256: df65d528c4ad967d59706fe1d6710b7558f8a53db9c3919bd30fd3f6f42578ac
     files:
     - from: "./clog"
       to: "."
@@ -42,7 +45,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_darwin_arm64.tar.gz" .TagName }}
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_darwin_arm64.tar.gz"
+    sha256: 94320bcff6717ad2ad3565a93a1d5f8b20252780cd788a1f0327d5e9e0a5e45e
     files:
     - from: "./clog"
       to: "."
@@ -53,7 +57,8 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_windows_amd64.zip" .TagName }}
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_windows_amd64.zip"
+    sha256: 75c85ea50cb3089d3beaa9c63b14ed28a318c04b8409d8a467ab6d9356fc5329
     files:
     - from: "/clog.exe"
       to: "."
@@ -64,7 +69,8 @@ spec:
       matchLabels:
         os: windows
         arch: arm64
-    {{addURIAndSha "https://github.com/orangetangerine/kubectl-clog/releases/download/{{ .TagName }}/clog_windows_arm64.zip" .TagName }}
+    uri: "https://github.com/orangetangerine/kubectl-clog/releases/download/0.1.1/clog_windows_arm64.zip"
+    sha256: 78f94391d38a2f60968daa6b835d1b13abca31e0ad95f7f661ac228c2165cec2
     files:
     - from: "/clog.exe"
       to: "."


### PR DESCRIPTION
Hi everyone 👋

I'm adding the [kubectl-clog](https://github.com/orangetangerine/kubectl-clog) plugin to wrap built-in kubectl logs to colorize logs 

Thank you!
