### PR TITLE
Add `kubectl mapr-ticket` v0.1.2

### DIFF
--- a/plugins/mapr-ticket.yaml
+++ b/plugins/mapr-ticket.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mapr-ticket
+spec:
+  version: v0.1.2
+  homepage: https://github.com/nobbs/kubectl-mapr-ticket
+  shortDescription: "Get information about deployed MapR tickets"
+  description: |
+    This plugin allows you to get information about MapR tickets deployed in the
+    cluster, including data parsed from the ticket itself, e.g. ticket expiry
+    date, user name, etc.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/nobbs/kubectl-mapr-ticket/releases/download/v0.1.2/kubectl-mapr-ticket-amd64-darwin.tar.gz
+    sha256: 6e5b7264170437ca9d907012a2e8f78accc42328fc3b88d0832a4c134c9a5c4c
+    bin: kubectl-mapr-ticket
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/nobbs/kubectl-mapr-ticket/releases/download/v0.1.2/kubectl-mapr-ticket-arm64-darwin.tar.gz
+    sha256: cd66f117bfb66158d020acff1d2cb39656fa1a13224e2b05890e26548f4e64c6
+    bin: kubectl-mapr-ticket
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/nobbs/kubectl-mapr-ticket/releases/download/v0.1.2/kubectl-mapr-ticket-amd64-linux.tar.gz
+    sha256: 2a834e57015ddba43a4d1fa2ecdba4f8809451e161b392821f6ee8a914472ee0
+    bin: kubectl-mapr-ticket
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/nobbs/kubectl-mapr-ticket/releases/download/v0.1.2/kubectl-mapr-ticket-arm64-linux.tar.gz
+    sha256: cd52db49fac0d4c596eeaaac2137d2bd22d0c5a663ee5c3e7f67bc2fefd4f386
+    bin: kubectl-mapr-ticket


### PR DESCRIPTION
Hi folks 👋🏻

This PR adds an early version of the [`kubectl mapr-ticket`](https://github.com/nobbs/kubectl-mapr-ticket) plugin that provides some utility to inspect MapR ticket secrets deployed in a Kubernetes cluster. Right now, it's only limited to some basic `list` functionality, but I'm planning to add more inspection features in the future.

Automation of krew-index updates via GitHub Actions will be enabled once this PR is merged.

### Disclaimer

_I'm in no way affiliated with HPE or MapR. I'm just a user of the MapR CSI driver and trying to make life easier for the few other operators that have to deal with this ;)._ 

### Some background

[MapR](https://docs.mapr.com) is a Hadoop distribution by HPE, nowadays apparently called HPE Ezmeral Data Fabric. Part of the stack is MapR-FS, a distributed file system that is used to store data in a Hadoop cluster. HPE also provides a [MapR CSI driver](https://github.com/mapr/mapr-csi) to make use of the MapR-FS backed volumes in Kubernetes as PVs.

To do so, a "MapR ticket" is required, which basically holds some authentication information to access the volume in MapR-FS. These tickets are stored as Kubernetes secrets and are referenced in the PVs that make use of the MapR CSI driver in `spec.csi.volumeAttributes.nodePublishSecretRef`.

These tickets have an expiration date - by default, they are valid for 30 days. Once a ticket expires, the PVs that reference the ticket become unusable and the pods that use these PVs will start failing. **This can be a major problem once you have a lot different tickets in your cluster.**

Unfortunately, the MapR CSI driver does not provide any functionality to inspect these tickets or any kind of metrics. The only way to figure out which tickets are about to expire is to manually inspect the secrets, copy the ticket and use the `maprlogin` utility on a machine that has access to the MapR cluster. This is not very convenient and error prone - also, a lot of manual work. Often, expired tickets are only discovered once a pod fails for seemingly no reason.

This plugin doesn't need any access to the MapR cluster, it just uses the ticket secrets and parses the ticket information from them.

The CSI driver is also not open source, development is done in private repositories and only the compiled binaries are published as container images. Basically, no way to add any kind of functionality to the driver.
