### PR TITLE
Add searchcm.yaml

### DIFF
--- a/plugins/searchcm.yaml
+++ b/plugins/searchcm.yaml
@@ -1,0 +1,26 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: searchcm
+spec:
+  homepage: https://github.com/pbletard/searchcm
+  shortDescription: Search for a value in all ConfigMaps from all namespaces
+  version: v0.0.1
+  description: |
+    Search for a value in all ConfigMaps from all namespaces
+    Similar to a "grep" in all ConfigMaps in all namespaces
+
+  caveats: |
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/pbletard/searchcm/releases/tag/v0.0.1/searchcm.tar.gz
+    sha256: 3e024564122feead30f22b471afdc2c16a578d0774dc69916be54f6dfc799c4d
+    files:
+    - from: "searchcm"
+      to: "searchcm"
+    - from: "LICENSE"
+      to: "."
+    bin: searchcm

--- a/plugins/searchcm.yaml
+++ b/plugins/searchcm.yaml
@@ -16,7 +16,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/pbletard/searchcm/releases/tag/v0.0.1/searchcm.tar.gz
+    uri: https://github.com/pbletard/searchcm/releases/download/v0.0.1/searchcm.tar.gz
     sha256: 3e024564122feead30f22b471afdc2c16a578d0774dc69916be54f6dfc799c4d
     files:
     - from: "searchcm"


### PR DESCRIPTION
This tool comes without pretention, not sure if this really worth a plugin and useful for others.
Until now we were looking through our gitlab and with classical 'kubectl get cm' trials. Decided to create a simple helper script to do this.
Example usage: kubectl searchcm -s valuetosearch