### PR TITLE
Add history plugin

### DIFF
--- a/plugins/history.yaml
+++ b/plugins/history.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v1.1.8
   homepage: https://github.com/wd/kubectl-history
-  shortDescription: Plugin to List and diff history reversions of deployment/daemonset/statefulset
+  shortDescription: List & diff revisions of workload resources
   description: |
     This plugin allows viewing history reversions of deployment/daemonset/statefulset and shows diff between reversions.
   platforms:

--- a/plugins/history.yaml
+++ b/plugins/history.yaml
@@ -1,0 +1,32 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: history
+spec:
+  version: v1.1.8
+  homepage: https://github.com/wd/kubectl-history
+  shortDescription: Plugin to List and diff history reversions of deployment/daemonset/statefulset
+  description: |
+    This plugin allows viewing history reversions of deployment/daemonset/statefulset and shows diff between reversions.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/wd/kubectl-history/releases/download/v1.1.8/kubectl-history-v1.1.8-linux-amd64.tar.gz
+    sha256: fc662ec0121e382efcedfcc9f2a85675ca1a86f9d2e56bd0d987b0e8bbf2a293
+    bin: kubectl-history
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/wd/kubectl-history/releases/download/v1.1.8/kubectl-history-v1.1.8-darwin-arm64.tar.gz
+    sha256: a304dec8a88f3dec7904fdd5e322d3292ea08738b083071ef31f90d7cb638c30
+    bin: kubectl-history
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/wd/kubectl-history/releases/download/v1.1.8/kubectl-history-v1.1.8-darwin-amd64.tar.gz
+    sha256: 4e9bd8ce77dd72ca0d731651ae805ba82009db93004d5e1da30400a8c1b3569d
+    bin: kubectl-history


### PR DESCRIPTION
This plugin could help people list and diff versions of deployment/daemonset/statefulset. 

The detailed explanation could be found at here: https://github.com/wd/kubectl-history