### PR TITLE
Add new plugin mexec

### DIFF
--- a/plugins/mexec.yaml
+++ b/plugins/mexec.yaml
@@ -1,0 +1,31 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mexec
+spec:
+  version: "v0.1.1"
+  homepage: https://github.com/major1201/kubectl-mexec
+  shortDescription: "Execute on multiple pods in parallel"
+  description: A fast way to run kubectl exec/cp on multiple pods in parallel.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/major1201/kubectl-mexec/archive/refs/tags/v0.1.1.tar.gz
+    sha256: 7839aa8918fd433542d1a0b194a549b9d3a5bcdafa93f35cf8dfcf14da4e8817
+    files:
+    - from: "kubectl-mexec-*/kubectl-mexec"
+      to: "."
+    - from: "kubectl-mexec-*/mexec-*"
+      to: "."
+    - from: "kubectl-mexec-*/display-help.sh"
+      to: "."
+    - from: "kubectl-mexec-*/scripts"
+      to: "."
+    - from: "kubectl-mexec-*/LICENSE"
+      to: "."
+    bin: kubectl-mexec


### PR DESCRIPTION
Hi, this is a plugin to make a fast way to run kubectl exec/cp on multiple pods in parallel.

More detailed information: <https://github.com/major1201/kubectl-batch>.