### PR TITLE
release new version v1.14.1 of cert-manager

### DIFF
--- a/plugins/cert-manager.yaml
+++ b/plugins/cert-manager.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: cert-manager
 spec:
-  version: v1.13.0
+  version: v1.14.1
   homepage: https://github.com/cert-manager/cert-manager
   shortDescription: Manage cert-manager resources inside your cluster
   description: |
@@ -15,41 +15,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/kubectl-cert_manager-darwin-amd64.tar.gz
-    sha256: 9b6ede8ba12af5df914cbce215f930ee8eb4608689034e4585eceada8b0afe6e
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/kubectl-cert_manager-darwin-amd64.tar.gz
+    sha256: c958543f0453938e99114a2a097d42be04f14c4fea7f84e7ac1c212f2161db2d
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/kubectl-cert_manager-darwin-arm64.tar.gz
-    sha256: b174d26a3a5b2f68809dfdbf88f471556a63835ce6ca0b5c7e435ecceeba3bba
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/kubectl-cert_manager-darwin-arm64.tar.gz
+    sha256: d891fcd5698ab1473fdb8ff6602c6621f66fdfa93660edc81b61cff5887889dd
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/kubectl-cert_manager-linux-amd64.tar.gz
-    sha256: f7fae7058e093d6b456ae0660fe8b365c482011c28d55984df314bf80886c07b
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/kubectl-cert_manager-linux-amd64.tar.gz
+    sha256: 84817ac2e562a2b2ab04a5105e5e5a0e53ae1e7338c3c7e174e23cbc320c280f
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/kubectl-cert_manager-linux-arm.tar.gz
-    sha256: 0c714df837acb507d3fd203ef5b30f87da4368cfb75766f86214b1ffb4e8e868
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/kubectl-cert_manager-linux-arm.tar.gz
+    sha256: 9372f23c521e71d089884de5a139cff9fd581362cd4e099eafcf323d15c4822f
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/kubectl-cert_manager-linux-arm64.tar.gz
-    sha256: bc50d70a696923efcefce6151931008d33cf643dff78c06d6d8cba0998d5f1e1
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/kubectl-cert_manager-linux-arm64.tar.gz
+    sha256: d947f6e3ea94f282dae9308874e6c44b3379e7523fa735e29f72550f1cc83c7a
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.13.0/kubectl-cert_manager-windows-amd64.zip
-    sha256: aa38c5d44360e350abb75f346cf9bd06a5ee2818f652f976dbb9b1aea3b3a324
+    uri: https://github.com/cert-manager/cert-manager/releases/download/v1.14.1/kubectl-cert_manager-windows-amd64.zip
+    sha256: 22c23a2c331a34b4ba2f5f0f1adbb5cd369d2163b55ed74559b8a2c45f519249
     bin: kubectl-cert_manager.exe


### PR DESCRIPTION
cert-manager v1.14.1 was released on Friday 2 February 2024. 
* [Release Notes](https://cert-manager.io/docs/releases/release-notes/release-notes-1.14)
* [Upgrade Notes[(https://cert-manager.io/docs/releases/upgrading/upgrading-1.13-1.14)
* https://github.com/cert-manager/cert-manager/issues/6710

Tested as follows:

```sh
$ kubectl krew install --manifest plugins/cert-manager.yaml
Installing plugin: cert-manager
Installed plugin: cert-manager
\
 | Use this plugin:
 |      kubectl cert-manager
 | Documentation:
 |      https://github.com/cert-manager/cert-manager
/
```

```sh
$ kubectl cert-manager version -o yaml
clientVersion:
  compiler: gc
  gitCommit: c7b1e30ee03c0df36d03a5cd9964894b4b78b966
  gitTreeState: ""
  gitVersion: v1.14.1
  goVersion: go1.21.6
  platform: linux/amd64
serverVersion:
  detected: v1.14.1
  sources:
    crdLabelVersion: v1.14.1
```