### PR TITLE
Add dup plugin

### DIFF
--- a/plugins/dup.yaml
+++ b/plugins/dup.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.2.0
   homepage: https://github.com/vash/dup
-  shortDescription: Efficiently duplicate existing k8s resources.
+  shortDescription: Duplicate existing Kubernetes resources
   description: |
     This plugin is designed for on-the-fly duplication of Kubernetes resources.
     It focuses on providing a convenient way to edit resources before duplication,

--- a/plugins/dup.yaml
+++ b/plugins/dup.yaml
@@ -1,0 +1,50 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: dup
+spec:
+  version: v0.2.0
+  homepage: https://github.com/vash/dup
+  shortDescription: Easily and powerfully create duplicates of existing Kubernetes resources and pods that are managed by them.
+  description: |
+    This plugin is designed for on-the-fly duplication of Kubernetes resources.
+    It focuses on providing a convenient way to edit resources before duplication,
+    with a specific emphasis on Pods to create a fine-tuned resource quickly.
+    This tool can be used for debugging running containers without them crashing,
+    and simplifying the administration and general interaction with Kubernetes clusters.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/vash/dup/releases/download/v0.2.0/dup_v0.2.0_darwin_amd64.tar.gz
+      sha256: 2a8a04b3f4023e87c2a44438ad04c815fb784fe9faa93cb6fedf4dc9d7986803
+      bin: kubectl-dup
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/vash/dup/releases/download/v0.2.0/dup_v0.2.0_darwin_arm64.tar.gz
+      sha256: aafaa38f9f233a65e646addebaa258cec1d0ba0192e33d79a38530be26ed91a9
+      bin: kubectl-dup
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/vash/dup/releases/download/v0.2.0/dup_v0.2.0_linux_amd64.tar.gz
+      sha256: 5aba56834cffe134ff2c39bebe5049e5f2d76f18631921d2caaf92c6d0f55fcd
+      bin: kubectl-dup
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/vash/dup/releases/download/v0.2.0/dup_v0.2.0_linux_arm64.tar.gz
+      sha256: aaf21feee7c31b58ba1eec8c79ec0eaf00924ac87ffa34e32aaac3c54c4782cf
+      bin: kubectl-dup
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/vash/dup/releases/download/v0.2.0/dup_v0.2.0_windows_amd64.tar.gz
+      sha256: ff11b1dd8c771f4fb75e6bfd5f340c50e1813a7b5f60ec3f37a4bd31b9e16f79
+      bin: kubectl-dup.exe

--- a/plugins/dup.yaml
+++ b/plugins/dup.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.2.0
   homepage: https://github.com/vash/dup
-  shortDescription: Easily and powerfully create duplicates of existing Kubernetes resources and pods that are managed by them.
+  shortDescription: Efficiently duplicate existing k8s resources.
   description: |
     This plugin is designed for on-the-fly duplication of Kubernetes resources.
     It focuses on providing a convenient way to edit resources before duplication,


### PR DESCRIPTION
Hi,
I would like to suggest adding `dup` plugin to the krew index.

The plugin is meant to provide capabilities that I was frustrated with the absence of in `kubectl debug`.
It provides the user with the ability to duplicate any resource within the cluster,
with additional focus on resources that produce pods, and opens an editor (by default) for them to modify the resources'
manifest prior to applying them.

It has been useful for debugging on-the-fly, and even a necessity when attempting to attach to single-process containers
with probes attached to them due to the ability to disable health and readiness probes.

I would love to hear your opinion about this.

Thanks.