### PR TITLE
add darwin arm64 dumpy selector

### DIFF
--- a/plugins/dumpy.yaml
+++ b/plugins/dumpy.yaml
@@ -27,7 +27,7 @@ spec:
         os: darwin
         arch: arm64
     uri: https://github.com/larryTheSlap/dumpy/releases/download/v0.1.0/dumpy_Darwin_arm64.tar.gz
-    sha256: 514ee7efb5d88417186cd8e621711be96fff92292a81ae35b1bad11d96a66142
+    sha256: fd1bac124761f81718b212f087ff4d144fc9b3a524eaa7364e38f1afb01e0f6b
     bin: kubectl-dumpy
     files:
     - from: kubectl-dumpy

--- a/plugins/dumpy.yaml
+++ b/plugins/dumpy.yaml
@@ -24,6 +24,18 @@ spec:
       to: .
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/larryTheSlap/dumpy/releases/download/v0.1.0/dumpy_Darwin_arm64.tar.gz
+    sha256: 514ee7efb5d88417186cd8e621711be96fff92292a81ae35b1bad11d96a66142
+    bin: kubectl-dumpy
+    files:
+    - from: kubectl-dumpy
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     uri: https://github.com/larryTheSlap/dumpy/releases/download/v0.1.0/dumpy_Linux_x86_64.tar.gz


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
this pr adds darwin arm64 install support for the dumpy plugin

went to install this plugin experiment with and received this error:

```plaintext
failed to install some plugins: [dumpy]: plugin "dumpy" does not offer installation for this platform
```

i found that the plugin [release](https://github.com/larryTheSlap/dumpy/releases/tag/v0.1.0) does have darwin arm tar file but it was not included in the plugins/dumpy.yaml

anyway, thought i'd help :)