### PR TITLE
release new version v1.2.8 of slice

### DIFF
--- a/plugins/slice.yaml
+++ b/plugins/slice.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: slice
 spec:
-  version: v1.2.7
+  version: v1.2.8
   homepage: https://github.com/patrickdappollonio/kubectl-slice
   shortDescription: Split a multi-YAML file into individual files.
   description: |
@@ -15,41 +15,41 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.7/kubectl-slice_darwin_arm64.tar.gz
-      sha256: d1020c5a14857bf09ff3b4c74836570d05d57342925f50afe72a1e697d0eb785
+      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.8/kubectl-slice_darwin_arm64.tar.gz
+      sha256: 69a741b74f90fe9cc7496340df6fe20abd25287d8bd993c8266ea6c0c8c8b837
       bin: kubectl-slice
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.7/kubectl-slice_darwin_x86_64.tar.gz
-      sha256: 6236cb38281535b673bebeb97cc1d17dbb7235e08ae7e5f7e87940e31c00507c
+      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.8/kubectl-slice_darwin_x86_64.tar.gz
+      sha256: dba19ba7299119d6cc6759fbdfc5078833a2d8e90c927f0cf360dbe505467d4f
       bin: kubectl-slice
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.7/kubectl-slice_linux_arm64.tar.gz
-      sha256: 6f9ae83941869a2ce4e580cadd5248a8df3908113e375c305b6e83cddcf37e51
+      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.8/kubectl-slice_linux_arm64.tar.gz
+      sha256: 0af5a1fed1a7e6fa511e7887795e2f38d32b5433246e4ea466f418eabe000d4f
       bin: kubectl-slice
     - selector:
         matchLabels:
           os: linux
           arch: arm
-      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.7/kubectl-slice_linux_arm.tar.gz
-      sha256: 9df3abf16ba4f3bc05443358aa7a5ef33d3500e25c1e923b33b8ba11f9daec3e
+      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.8/kubectl-slice_linux_arm.tar.gz
+      sha256: 3eeee1ae567d6f3f43bb78df7493cbc6c60ae3f61b870666080500ef83c9d196
       bin: kubectl-slice
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.7/kubectl-slice_linux_x86_64.tar.gz
-      sha256: 23ca9427039c02235c4b808399f01eeee5bbb449345aaefe7d609111f2e7154d
+      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.8/kubectl-slice_linux_x86_64.tar.gz
+      sha256: 044067e4419eb4834112e8b22200ef06a7f568395b6ee511cec28bb3edc5fce4
       bin: kubectl-slice
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.7/kubectl-slice_windows_x86_64.tar.gz
-      sha256: 003f5603de2214a7715cbfa8aeb6c596e2f43134da75d31cabf9a08d24394724
+      uri: https://github.com/patrickdappollonio/kubectl-slice/releases/download/v1.2.8/kubectl-slice_windows_x86_64.tar.gz
+      sha256: 8d773ee7b38425e2d8c64714e0923b4469eccb9468f891b42d25109fae497dbe
       bin: kubectl-slice.exe


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Hello!

Had to do this by hand because the API used by `krew-release-bot` was having TLS issues due to an issue with Netlify. I would like to publish the new version `v1.2.8` of `slice` to the index.

Thank you!