### PR TITLE
Publishing v0.9.0 of VolSync plugin

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.8.1
+  version: v0.9.0
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.8.1/kubectl-volsync.tar.gz
-      sha256: 1dcbb113eacd2cb7192348d4f9a368220691a33f19a1e261ba68bbbdb7973335
+      uri: https://github.com/backube/volsync/releases/download/v0.9.0/kubectl-volsync.tar.gz
+      sha256: fa4f6c2cef64ce5c725a573e2b2b6077a3ec5642458fc25d83af187c2bb6599d
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION

Publishing v0.9.0 for volsync plugin.

Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/