### PR TITLE
Add `retina` plugin

### DIFF
--- a/plugins/retina.yaml
+++ b/plugins/retina.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: retina
 spec:
-  version: v0.0.2
+  version: v0.0.3
   homepage: https://github.com/microsoft/retina
   shortDescription: Distributed network captures and telemetry
   description: |
@@ -18,41 +18,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-darwin-amd64-v0.0.2.tar.gz
-    sha256: 8be0d2f6944ac483b79c640d3fd8e11357a64015fa5fc0efae710e640f62a24d
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.3/kubectl-retina-darwin-amd64-v0.0.3.tar.gz
+    sha256: 8b30aef25294d2418d9a49dc422e74cd06e3f3a13681656007352ba9231a7d2e
     bin: kubectl-retina-darwin-amd64
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-darwin-arm64-v0.0.2.tar.gz
-    sha256: f152ec338ccb8cd778a3c1bb33df22a73d9e3bfa57eabdac994efea59b6f1e09
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.3/kubectl-retina-darwin-arm64-v0.0.3.tar.gz
+    sha256: 850741d443eefd044943b1e869ee8c8f27275bbaced88eadae2b09b95a3d19cb
     bin: kubectl-retina-darwin-arm64
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-linux-amd64-v0.0.2.tar.gz
-    sha256: 95b18e63c8299d9c0bf95208e0d3c14c87aa3d0e9b5a85c293d8513c12b32137
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.3/kubectl-retina-linux-amd64-v0.0.3.tar.gz
+    sha256: ba70137917aa7fb3217a6a45f7e9a0c1b42c1733866551f656df5d21ce100124
     bin: kubectl-retina-linux-amd64
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-linux-arm64-v0.0.2.tar.gz
-    sha256: 570e52feeb62dc1116611c50863e33ba0e007bfdf5724634052b4d56629ba518
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.3/kubectl-retina-linux-arm64-v0.0.3.tar.gz
+    sha256: 91be8b476bbf1c38e0d38b8f590121d0d2be29ff09aee814eaca861b22a19563
     bin: kubectl-retina-linux-arm64
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-windows-amd64-v0.0.2.zip
-    sha256: ea908856a4e32649c1dc824b91ef7073f1826c217da946102fd2b149abe63f0a
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.3/kubectl-retina-windows-amd64-v0.0.3.zip
+    sha256: 6f93d804539c12522fec1731b76cd7e5c3774ce925b9958fd602f33062e432f8
     bin: kubectl-retina-windows-amd64.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-windows-arm64-v0.0.2.zip
-    sha256: 4058242b437f8c047ebaf38db8b10e4369595ff4ad421c95a5dd001c317cdc5d
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.3/kubectl-retina-windows-arm64-v0.0.3.zip
+    sha256: 9198a1e39137644c5787ba89d8b0c417b2d70b341dd01307869bbe87d4fa2b4c
     bin: kubectl-retina-windows-arm64.exe

--- a/plugins/retina.yaml
+++ b/plugins/retina.yaml
@@ -1,0 +1,56 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: retina
+spec:
+  version: v0.0.2
+  homepage: retina.sh
+  shortDescription: Retina CLI allows the user to capture network traffic and metadata for the capture target, and then send the capture file to the location by Output Configuration.
+  description: |
+    Retina is a cloud-agnostic, open-source Kubernetes network observability platform that provides a centralized hub for monitoring application health, network health, and security. 
+    It provides actionable insights to cluster network administrators, cluster security administrators, and DevOps engineers navigating DevOps, SecOps, and compliance use cases.
+    Retina collects customizable telemetry, which can be exported to multiple storage options (such as Prometheus, Azure Monitor, and other vendors) and visualized in a variety of ways 
+    (like Grafana, Azure Log Analytics, and other vendors). This CLI is a part of the Retina project, which allows the user to capture network traffic and metadata for the capture target.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-darwin-amd64-v0.0.2.tar.gz
+    sha256: 8be0d2f6944ac483b79c640d3fd8e11357a64015fa5fc0efae710e640f62a24d
+    bin: kubectl-retina-darwin-amd64
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-darwin-arm64-v0.0.2.tar.gz
+    sha256: f152ec338ccb8cd778a3c1bb33df22a73d9e3bfa57eabdac994efea59b6f1e09
+    bin: kubectl-retina-darwin-arm64
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-linux-amd64-v0.0.2.tar.gz
+    sha256: 95b18e63c8299d9c0bf95208e0d3c14c87aa3d0e9b5a85c293d8513c12b32137
+    bin: kubectl-retina-linux-amd64
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-linux-arm64-v0.0.2.tar.gz
+    sha256: 570e52feeb62dc1116611c50863e33ba0e007bfdf5724634052b4d56629ba518
+    bin: kubectl-retina-linux-arm64
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-windows-amd64-v0.0.2.zip
+    sha256: ea908856a4e32649c1dc824b91ef7073f1826c217da946102fd2b149abe63f0a
+    bin: kubectl-retina-windows-amd64.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.2/kubectl-retina-windows-arm64-v0.0.2.zip
+    sha256: 4058242b437f8c047ebaf38db8b10e4369595ff4ad421c95a5dd001c317cdc5d
+    bin: kubectl-retina-windows-arm64.exe

--- a/plugins/retina.yaml
+++ b/plugins/retina.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.0.2
   homepage: retina.sh
-  shortDescription: Retina CLI allows the user to capture network traffic and metadata for the capture target, and then send the capture file to the location by Output Configuration.
+  shortDescription: Distributed network captures and telemetry
   description: |
     Retina is a cloud-agnostic, open-source Kubernetes network observability platform that provides a centralized hub for monitoring application health, network health, and security. 
     It provides actionable insights to cluster network administrators, cluster security administrators, and DevOps engineers navigating DevOps, SecOps, and compliance use cases.

--- a/plugins/retina.yaml
+++ b/plugins/retina.yaml
@@ -4,13 +4,15 @@ metadata:
   name: retina
 spec:
   version: v0.0.2
-  homepage: retina.sh
+  homepage: https://github.com/microsoft/retina
   shortDescription: Distributed network captures and telemetry
   description: |
-    Retina is a cloud-agnostic, open-source Kubernetes network observability platform that provides a centralized hub for monitoring application health, network health, and security. 
-    It provides actionable insights to cluster network administrators, cluster security administrators, and DevOps engineers navigating DevOps, SecOps, and compliance use cases.
-    Retina collects customizable telemetry, which can be exported to multiple storage options (such as Prometheus, Azure Monitor, and other vendors) and visualized in a variety of ways 
-    (like Grafana, Azure Log Analytics, and other vendors). This CLI is a part of the Retina project, which allows the user to capture network traffic and metadata for the capture target.
+    The Retina CLI plugin enables users to collect distributed network captures in an
+    OS and vendor-agnostic way. Capture jobs can be created via the CLI to target specific
+    nodes or pods in a time-limited or size limited way. Capture jobs can also filter specific
+    network traffic based on the given configurations; more info on the configurations can be 
+    found on the official docs. The captures are collected in formats like pcap, etl and 
+    text files, and can then be stored at remote storage destinations.
   platforms:
   - selector:
       matchLabels:


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Hello! We want to add our Microsoft Retina CLI plugin https://retina.sh/docs/captures/cli

It allows users to capture network traffic and metadata for the capture target, and then send the capture file to the location by Output Configuration.