### PR TITLE
added plugin cpbase64 to index

### DIFF
--- a/plugins/cpbase64.yaml
+++ b/plugins/cpbase64.yaml
@@ -10,11 +10,11 @@ spec:
   # 'homepage' usually links to the GitHub repository of the plugin
   homepage: https://github.com/freeella/kubectl-cpbase64
   # 'shortDescription' explains what the plugin does in only a few words
-  shortDescription: "Alternative to 'kubectl cp' when 'tar' is not available"
+  shortDescription: "Alternative to 'cp' using base64 instead of tar"
   description: |
-    Distributions that do not ship busybox often do not ship 'tar' by default.
-    This command 'kubectl cpbase64' uses 'base64' instead while trying to be in syn 
-    with syntax of 'kubectl cp'.
+    Not busybox based Docker images often do not ship 'tar' by default.
+    This command 'kubectl cpbase64' uses 'base64' instead.
+    The goal is to be in sync with command line syntax of 'kubectl cp'.
   # 'platforms' specify installation methods for various platforms (os/arch)
   # See all supported platforms below.
   platforms:

--- a/plugins/cpbase64.yaml
+++ b/plugins/cpbase64.yaml
@@ -1,22 +1,15 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  # 'name' must match the filename of the manifest. The name defines how
-  # the plugin is invoked, for example: `kubectl restart`
   name: cpbase64
 spec:
-  # 'version' is a valid semantic version string (see semver.org). Note the prefix 'v' is required.
   version: "v0.1.7"
-  # 'homepage' usually links to the GitHub repository of the plugin
   homepage: https://github.com/freeella/kubectl-cpbase64
-  # 'shortDescription' explains what the plugin does in only a few words
   shortDescription: "Alternative to 'cp' using base64 instead of tar"
   description: |
     Not busybox based Docker images often do not ship 'tar' by default.
     This command 'kubectl cpbase64' uses 'base64' instead.
     The goal is to be in sync with command line syntax of 'kubectl cp'.
-  # 'platforms' specify installation methods for various platforms (os/arch)
-  # See all supported platforms below.
   platforms:
   - selector:
       matchExpressions:
@@ -25,15 +18,11 @@ spec:
         values:
         - darwin
         - linux
-    # 'uri' specifies .zip or .tar.gz archive URL of a plugin
     uri: https://github.com/freeella/kubectl-cpbase64/releases/download/v0.1.7/kubectl-cpbase64.release-v0.1.7.zip
-    # 'sha256' is the sha256sum of the url (archive file) above
     sha256: 924b96ff5b642e859c942beeb6f9d4bbb2a03a11ca1b806ffee7ba6159719b43
-    # 'files' lists which files should be extracted out from downloaded archive
     files:
     - from: "kubectl-cpbase64"
       to: "cpbase64.bash"
     - from: "LICENSE"
       to: "."
-    # 'bin' specifies the path to the the plugin executable among extracted files
     bin: cpbase64.bash

--- a/plugins/cpbase64.yaml
+++ b/plugins/cpbase64.yaml
@@ -1,0 +1,39 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  # 'name' must match the filename of the manifest. The name defines how
+  # the plugin is invoked, for example: `kubectl restart`
+  name: cpbase64
+spec:
+  # 'version' is a valid semantic version string (see semver.org). Note the prefix 'v' is required.
+  version: "v0.1.7"
+  # 'homepage' usually links to the GitHub repository of the plugin
+  homepage: https://github.com/freeella/kubectl-cpbase64
+  # 'shortDescription' explains what the plugin does in only a few words
+  shortDescription: "Alternative to 'kubectl cp' when 'tar' is not available"
+  description: |
+    Distributions that do not ship busybox often do not ship 'tar' by default.
+    This command 'kubectl cpbase64' uses 'base64' instead while trying to be in syn 
+    with syntax of 'kubectl cp'.
+  # 'platforms' specify installation methods for various platforms (os/arch)
+  # See all supported platforms below.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    # 'uri' specifies .zip or .tar.gz archive URL of a plugin
+    uri: https://github.com/freeella/kubectl-cpbase64/releases/download/v0.1.7/kubectl-cpbase64.release-v0.1.7.zip
+    # 'sha256' is the sha256sum of the url (archive file) above
+    sha256: 924b96ff5b642e859c942beeb6f9d4bbb2a03a11ca1b806ffee7ba6159719b43
+    # 'files' lists which files should be extracted out from downloaded archive
+    files:
+    - from: "kubectl-cpbase64"
+      to: "cpbase64.bash"
+    - from: "LICENSE"
+      to: "."
+    # 'bin' specifies the path to the the plugin executable among extracted files
+    bin: cpbase64.bash


### PR DESCRIPTION
- The plug-in is open source and was developed by me because more and more Kubernetes PODs do not come with TAR. 

One very widely used example is Amazon Corretto based Java images, that still come with BASE64 command line tool installed but miss TAR.

Even the file transfer size of a BASE64 based transfer is four times the TAR based transfer size, it is at least a way to have a chance to access needed runtime debug data without releasing new docker images.

- Installation has been tested locally.