### PR TITLE
chore: update mayastor to 2.6.1

### DIFF
--- a/plugins/mayastor.yaml
+++ b/plugins/mayastor.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: mayastor
 spec:
-  version: v2.6.0
+  version: v2.6.1
   homepage: https://openebs.io/docs/
   shortDescription: Provides commands for OpenEBS Mayastor.
   description: |
@@ -13,34 +13,34 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.0/kubectl-mayastor-x86_64-apple-darwin.tar.gz
-    sha256: 3f4010463e2c11bd02b3b84970d304f28f97075f3184124a7ba48a6129102410
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-x86_64-apple-darwin.tar.gz
+    sha256: 6aae01229f820f698891d1404a08c9202b013c449500f6184c5455e9f00338bb
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.0/kubectl-mayastor-aarch64-apple-darwin.tar.gz
-    sha256: 87d318d44cb58d67993fdd4b721b2ed44810fe1531f21b6d766ed880ece8b61b
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-aarch64-apple-darwin.tar.gz
+    sha256: 1eae9401d19955a22cc638184c0ed9895384509c2133d68a1807cf35d507e451
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.0/kubectl-mayastor-x86_64-linux-musl.tar.gz
-    sha256: dc2d4e649f75a7baada06b6961803362676e878b88a42687385c5f181be0d1f7
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-x86_64-linux-musl.tar.gz
+    sha256: e1eaa365560c94d107d94f12c6f624d659847ea858abc11ca04517bee3f6de5b
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.0/kubectl-mayastor-aarch64-linux-musl.tar.gz
-    sha256: 5273505052b7425db195524963e7e2fb448da82befbac7ca5a7a4a990f47cac5
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-aarch64-linux-musl.tar.gz
+    sha256: a3723d1c8b74f1023a0fa7bbb4b452d8d31ace443e1397a3b956be6b1d6dd0d7
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.0/kubectl-mayastor-x86_64-windows-gnu.tar.gz
-    sha256: 9dba757f211cef2858dab39cf47a26c973f5df1336db8f0d11333c63d70f1e52
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-x86_64-windows-gnu.tar.gz
+    sha256: 5c8d525432abe813b55686747f6ad18be62a58bc62b682508348910aab6f779c
     bin: kubectl-mayastor.exe


### PR DESCRIPTION
Brings a patch fix for older linux kernels (<5.8) (Although not officially supported)

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
