### PR TITLE
Add AWS RDS Proxy plugin

### DIFF
--- a/plugins/aws-rds-proxy.yaml
+++ b/plugins/aws-rds-proxy.yaml
@@ -1,0 +1,34 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: aws-rds-proxy
+spec:
+  version: v2.0.0
+  homepage: https://github.com/wojtekk/aws-rds-proxy
+  shortDescription: Proxy to AWS RDS Cluster or Instance via Kubernetes
+  description: |
+    Start socat with proxy in Kubernetes and forward local port to AWS RDS Cluster or Instance.
+
+    Usage:
+        $ kubectl aws-rds-proxy local_port:rds_cluster_or_instance_name
+
+    Example:
+        $ kubectl aws-rds-proxy 33061:my-rds-cluster-name
+        $ kubectl aws-rds-proxy 33062:my-rds-instance-name
+
+  platforms:
+    - selector:
+        matchExpressions:
+          - key: os
+            operator: In
+            values:
+              - darwin
+              - linux
+      uri: https://github.com/wojtekk/kubectl-aws-rds-proxy/archive/v2.0.0.tar.gz
+      sha256: df0d4a26c426e8a7fb42d5c02b10bdb7ce73d726f1f48059d836c1377601ea25
+      files:
+        - from: kubectl-aws-rds-proxy-*/kubectl-aws_rds_proxy
+          to: .
+        - from: kubectl-aws-rds-proxy-*/LICENSE
+          to: .
+      bin: "kubectl-aws_rds_proxy"

--- a/plugins/aws-rds-proxy.yaml
+++ b/plugins/aws-rds-proxy.yaml
@@ -4,7 +4,7 @@ metadata:
   name: aws-rds-proxy
 spec:
   version: v2.0.0
-  homepage: https://github.com/wojtekk/aws-rds-proxy
+  homepage: https://github.com/wojtekk/kubectl-aws-rds-proxy
   shortDescription: Proxy to AWS RDS Cluster or Instance via Kubernetes
   description: |
     Start socat with proxy in Kubernetes and forward local port to AWS RDS Cluster or Instance.


### PR DESCRIPTION
Creates proxy to [AWS RDS](https://aws.amazon.com/free/database/) Cluster or Instance.

It uses the plugin [net-forward](https://github.com/antitree/krew-net-forward) under the hood.

Documentation and example: [kubectl-aws-rds-proxy](https://github.com/wojtekk/kubectl-aws-rds-proxy)

![image](https://github.com/kubernetes-sigs/krew-index/assets/59187/ff9bab07-8968-44a9-a809-91ed77f7575e)
