### PR TITLE
feat: add dpm plugin

### DIFF
--- a/plugins/dpm.yaml
+++ b/plugins/dpm.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: dpm
 spec:
-  version: "v0.0.3"
+  version: "v0.1.0"
   homepage: https://github.com/bavarianbidi/kubectl-dpm
   shortDescription: "Manages custom debug profiles for pods"
   description: |
@@ -14,27 +14,27 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_darwin_amd64.tar.gz
-      sha256: 562717c88292255ef585b409a7f7510084a4cc238787f70f66219898b48e34ab
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.1.0/kubectl-dpm_0.1.0_darwin_amd64.tar.gz
+      sha256: 5d5cc0e1c762fb4bcd18428329d199393796a4b070e11511115578fdf9103f88
       bin: kubectl-dpm
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_darwin_arm64.tar.gz
-      sha256: e5e8f765f06ab8a70da960b86be786c69d14faae72a2194612e2bbdedd30cab4
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.1.0/kubectl-dpm_0.1.0_darwin_arm64.tar.gz
+      sha256: 1e5d3d8ef3ac8d8aa134e7d98041ca1dc245e59f1de8282ec621fe25fcd7622b
       bin: kubectl-dpm
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_linux_amd64.tar.gz
-      sha256: 3c3d3bbbed19ece0901e1d92aa7ac686ec7fe33f439a3e9aa6ecb65fbbdedf7f
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.1.0/kubectl-dpm_0.1.0_linux_amd64.tar.gz
+      sha256: 9260d9261b7ff8591fc6351532c43fa4292d296bb9be30280d575cf0d12537aa
       bin: kubectl-dpm
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_linux_arm64.tar.gz
-      sha256: e17a15dffb0355bf5c1f8f1472e3cc86d568955a0c46d8efc7df7c6498957f47
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.1.0/kubectl-dpm_0.1.0_linux_arm64.tar.gz
+      sha256: b35bfc181b63683436ead08ef71165deb705de55d109bbc5480d195ca00498a6
       bin: kubectl-dpm

--- a/plugins/dpm.yaml
+++ b/plugins/dpm.yaml
@@ -1,0 +1,40 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: dpm
+spec:
+  version: "v0.0.3"
+  homepage: https://github.com/bavarianbidi/kubectl-dpm
+  shortDescription: "Manages custom debug profiles for pods"
+  description: |
+    Wraps the custom debug profile subcommand to make it easier 
+    to switch between different debug profiles for pods.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_darwin_amd64.tar.gz
+      sha256: 562717c88292255ef585b409a7f7510084a4cc238787f70f66219898b48e34ab
+      bin: kubectl-dpm
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_darwin_arm64.tar.gz
+      sha256: e5e8f765f06ab8a70da960b86be786c69d14faae72a2194612e2bbdedd30cab4
+      bin: kubectl-dpm
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_linux_amd64.tar.gz
+      sha256: 3c3d3bbbed19ece0901e1d92aa7ac686ec7fe33f439a3e9aa6ecb65fbbdedf7f
+      bin: kubectl-dpm
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/bavarianbidi/kubectl-dpm/releases/download/v0.0.3/kubectl-dpm_0.0.3_linux_arm64.tar.gz
+      sha256: e17a15dffb0355bf5c1f8f1472e3cc86d568955a0c46d8efc7df7c6498957f47
+      bin: kubectl-dpm


### PR DESCRIPTION
dpm stands for debug profile manager and is able to make the usage of custom debug profiles much more easier.

custom debug profiles depends on ephemeral containers (which are GA in 1.25).

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
