### PR TITLE
chore: update mayastor to 2.7.0

### DIFF
--- a/plugins/mayastor.yaml
+++ b/plugins/mayastor.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: mayastor
 spec:
-  version: v2.6.1
+  version: v2.7.0
   homepage: https://openebs.io/docs/
   shortDescription: Provides commands for OpenEBS Mayastor.
   description: |
@@ -13,34 +13,34 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-x86_64-apple-darwin.tar.gz
-    sha256: 6aae01229f820f698891d1404a08c9202b013c449500f6184c5455e9f00338bb
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.7.0/kubectl-mayastor-x86_64-apple-darwin.tar.gz
+    sha256: 737269fae05cdc85c11f21028a10a45825f58c0cbd84fdb451399e0ee33f81a3
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-aarch64-apple-darwin.tar.gz
-    sha256: 1eae9401d19955a22cc638184c0ed9895384509c2133d68a1807cf35d507e451
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.7.0/kubectl-mayastor-aarch64-apple-darwin.tar.gz
+    sha256: 6b55ca3a178fd9542ba3f0ac111046ef01a356a1d03cc531f4db5e804033c4db
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-x86_64-linux-musl.tar.gz
-    sha256: e1eaa365560c94d107d94f12c6f624d659847ea858abc11ca04517bee3f6de5b
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.7.0/kubectl-mayastor-x86_64-linux-musl.tar.gz
+    sha256: 3b076f989920e673753ec75542e5d6eaefc41ca267f9bbc19a12648b55f028c2
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-aarch64-linux-musl.tar.gz
-    sha256: a3723d1c8b74f1023a0fa7bbb4b452d8d31ace443e1397a3b956be6b1d6dd0d7
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.7.0/kubectl-mayastor-aarch64-linux-musl.tar.gz
+    sha256: d029e5dd8b67e6d5aaf50f69f1445e4a51d28df4fbb07dc768988e7d2c19756e
     bin: kubectl-mayastor
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.6.1/kubectl-mayastor-x86_64-windows-gnu.tar.gz
-    sha256: 5c8d525432abe813b55686747f6ad18be62a58bc62b682508348910aab6f779c
+    uri: https://github.com/openebs/mayastor-extensions/releases/download/v2.7.0/kubectl-mayastor-x86_64-windows-gnu.tar.gz
+    sha256: beffb77b1dad5a407fdc766800410a27e71e3ed720f027937a7a4c97b309eee0
     bin: kubectl-mayastor.exe


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
Adds a new version the mayastor plugin, version 2.7.0.