### PR TITLE
Publishing v0.10.0 of volsync plugin.

### DIFF
--- a/plugins/volsync.yaml
+++ b/plugins/volsync.yaml
@@ -4,7 +4,7 @@ kind: Plugin
 metadata:
   name: volsync
 spec:
-  version: v0.9.1
+  version: v0.10.0
   homepage: https://github.com/backube/volsync
   shortDescription: "Manage replication with the VolSync operator"
   description: |
@@ -20,8 +20,8 @@ spec:
           arch: amd64
       # This URL requires the artifact to be added to the release page as an
       # "Asset"
-      uri: https://github.com/backube/volsync/releases/download/v0.9.1/kubectl-volsync.tar.gz
-      sha256: a89a359fe4d2da27abf9c0710cc4fb26f8541ab4aa250cbf77d6a213ca778ba0
+      uri: https://github.com/backube/volsync/releases/download/v0.10.0/kubectl-volsync.tar.gz
+      sha256: 3eaa78fe4e1d56e0bf6f8ba1c29a457543b50b737fc83cbbcae6def42e616fbb
       files:
         - from: "./kubectl-volsync"
           to: "."


### PR DESCRIPTION
Publishing v0.10.0 for volsync plugin.

Operator repo: https://github.com/backube/volsync
Documentation: https://volsync.readthedocs.io/en/latest/
