### PR TITLE
upgrade jfs plugin to v0.2.0

### DIFF
--- a/plugins/jfs.yaml
+++ b/plugins/jfs.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   homepage: https://juicefs.com
   shortDescription: Debug JuiceFS issues in Kubernetes
-  version: v0.1.2
+  version: v0.2.0
   description: |
     JuiceFS is an open-source, high-performance distributed file system designed for the cloud.
     This plugin helps debugging issues with the JuiceFS CSI driver.
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.1.2/kubectl-jfs-plugin-0.1.2-darwin-arm64.tar.gz
-      sha256: "080608ef8ce8d39f5a280b81d01f80a0ecfb6ed20a9b79282d29659d21849e79"
+      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.2.0/kubectl-jfs-plugin-0.2.0-darwin-arm64.tar.gz
+      sha256: "f58765653969d53ae3c141d6b4fbd3a1a64e115d2088a6141882b3843f112f61"
       bin: "./kubectl-jfs"
       files:
         - from: kubectl-jfs-plugin
@@ -27,8 +27,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.1.2/kubectl-jfs-plugin-0.1.2-darwin-amd64.tar.gz
-      sha256: "3ae9f8623da0c4d26d8adc6e8e92fe8bec3b3b1a6b72c6ca2330508870b96748"
+      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.2.0/kubectl-jfs-plugin-0.2.0-darwin-amd64.tar.gz
+      sha256: "be41f46f1e83a487b4062282088f7a85f88d317c885aaa52eff65db04a24d94d"
       bin: "./kubectl-jfs"
       files:
         - from: kubectl-jfs-plugin
@@ -39,8 +39,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.1.2/kubectl-jfs-plugin-0.1.2-linux-arm64.tar.gz
-      sha256: "beec451cbca8c7bdf281379f2c8abd1b2bc21f5791b42a0d5e2c06c61765d370"
+      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.2.0/kubectl-jfs-plugin-0.2.0-linux-arm64.tar.gz
+      sha256: "8d129e2d2071da343c9a0144db1e33b8c5af7edc9c0e2a1ec646d4963b7946e7"
       bin: "./kubectl-jfs"
       files:
         - from: kubectl-jfs-plugin
@@ -51,8 +51,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.1.2/kubectl-jfs-plugin-0.1.2-linux-amd64.tar.gz
-      sha256: "d0e6790e06a57e967b3a4662cfc5a12c497f33e9194222e0a0cabc850ae5a24d"
+      uri: https://github.com/juicedata/kubectl-jfs-plugin/releases/download/v0.2.0/kubectl-jfs-plugin-0.2.0-linux-amd64.tar.gz
+      sha256: "6e8cc6971e366d5af114fc7b88317ea34e89da8054aea2356e01f096cfc78f8d"
       bin: "./kubectl-jfs"
       files:
         - from: kubectl-jfs-plugin


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
upgrade jfs plugin to v0.2.0
