### PR TITLE
Update netobserv plugin to v0.0.2

### DIFF
--- a/plugins/netobserv.yaml
+++ b/plugins/netobserv.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: netobserv
 spec:
-  version: "v0.0.1"
+  version: "v0.0.2"
   homepage: https://github.com/netobserv/network-observability-cli
   shortDescription: "Lightweight Flow and Packet visualization tool"
   description: |
@@ -18,8 +18,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: "https://github.com/netobserv/network-observability-cli/releases/download/v0.0.1/netobserv-cli.tar.gz"
-    sha256: "18ec3c3861d319179b04fc3c5a5e4834a36911997f39461b1d8316b73fc0419b"
+    uri: "https://github.com/netobserv/network-observability-cli/releases/download/v0.0.2/netobserv-cli.tar.gz"
+    sha256: "6278ef407ca4c2593b2163d02a23e76c42aa8d2028ce80cc44104743cc471cb4"
     files:
     - from: "build/netobserv"
       to: "netobserv"


### PR DESCRIPTION
```
$ kubectl krew install --manifest=./plugins/netobserv.yaml
Installing plugin: netobserv
Installed plugin: netobserv
\
 | Use this plugin:
 | 	kubectl netobserv
 | Documentation:
 | 	https://github.com/netobserv/network-observability-cli
/
```