### PR TITLE
Add alfred plugin

### DIFF
--- a/plugins/alfred.yaml
+++ b/plugins/alfred.yaml
@@ -10,7 +10,7 @@ spec:
           os: linux
           arch: amd64
       uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Linux_x86_64.tar.gz
-      sha256: 8dcb8eda64534b6b4d8cbb14e1b333e4e9a7eb61288264ead8f8d8c850d4463b
+      sha256: 9a6411da8787c884ecc46efacf39bc092f8bd02c34d5c77e3cf9b2ea2d1b8745
       files:
         - from: "kube-alfred"
           to: "."
@@ -22,7 +22,7 @@ spec:
           os: linux
           arch: arm64
       uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Linux_arm64.tar.gz
-      sha256: 0f61ef40be6479fe89745f85af66c781005c092f9dc0f2ed9a6842a912996bac
+      sha256: ce7317f9b7fa373592d8c1c0c021660ffc6fac3ad11ab2d153db3e6dd4971081
       files:
         - from: "kube-alfred"
           to: "."
@@ -34,7 +34,7 @@ spec:
           os: darwin
           arch: amd64
       uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Darwin_x86_64.tar.gz
-      sha256: f04f9fb09e149012a5f844fc054f5ae7ee66093bb890f1b3916f90e44ed4b4fd
+      sha256: fa4bc46b3ec14bd9ea8a0be98b64b954b0acf1f6593b3cd4932af67ab4c1327c
       files:
         - from: "kube-alfred"
           to: "."
@@ -46,7 +46,7 @@ spec:
           os: darwin
           arch: arm64
       uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Darwin_arm64.tar.gz
-      sha256: 7724cdc8cc1aed237d037be1b4cc9bf858f8df913df5601fc2fdcd832cbe25e4
+      sha256: 68d4dfd4484eb26878f8e7aabbb93167408d630ca929be44e25fb24cc88792dd
       files:
         - from: "kube-alfred"
           to: "."
@@ -58,7 +58,7 @@ spec:
           os: windows
           arch: amd64
       uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Windows_x86_64.zip
-      sha256: 33186710597e53b53742d9f296b49d0d211b94b4eab2dd047b9360d26793bba5
+      sha256: 54c7e61a9b5c3b2639ac4084a1f739fb0f4f60761122e4ea059773ace16972b7
       files:
         - from: "kube-alfred.exe"
           to: "."

--- a/plugins/alfred.yaml
+++ b/plugins/alfred.yaml
@@ -14,6 +14,8 @@ spec:
       files:
         - from: "kube-alfred"
           to: "."
+        - from: "LICENSE"
+          to: "."
       bin: "kube-alfred"
     - selector:
         matchLabels:
@@ -23,6 +25,8 @@ spec:
       sha256: 0f61ef40be6479fe89745f85af66c781005c092f9dc0f2ed9a6842a912996bac
       files:
         - from: "kube-alfred"
+          to: "."
+        - from: "LICENSE"
           to: "."
       bin: "kube-alfred"
     - selector:
@@ -34,6 +38,8 @@ spec:
       files:
         - from: "kube-alfred"
           to: "."
+        - from: "LICENSE"
+          to: "."
       bin: "kube-alfred"
     - selector:
         matchLabels:
@@ -44,6 +50,8 @@ spec:
       files:
         - from: "kube-alfred"
           to: "."
+        - from: "LICENSE"
+          to: "."
       bin: "kube-alfred"
     - selector:
         matchLabels:
@@ -53,6 +61,8 @@ spec:
       sha256: 33186710597e53b53742d9f296b49d0d211b94b4eab2dd047b9360d26793bba5
       files:
         - from: "kube-alfred.exe"
+          to: "."
+        - from: "LICENSE"
           to: "."
       bin: "kube-alfred.exe"
   shortDescription: AI-powered Kubernetes assistant

--- a/plugins/alfred.yaml
+++ b/plugins/alfred.yaml
@@ -1,0 +1,63 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: alfred
+spec:
+  version: "v0.1.0"
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Linux_x86_64.tar.gz
+      sha256: 8dcb8eda64534b6b4d8cbb14e1b333e4e9a7eb61288264ead8f8d8c850d4463b
+      files:
+        - from: "kube-alfred"
+          to: "."
+      bin: "kube-alfred"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Linux_arm64.tar.gz
+      sha256: 0f61ef40be6479fe89745f85af66c781005c092f9dc0f2ed9a6842a912996bac
+      files:
+        - from: "kube-alfred"
+          to: "."
+      bin: "kube-alfred"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Darwin_x86_64.tar.gz
+      sha256: f04f9fb09e149012a5f844fc054f5ae7ee66093bb890f1b3916f90e44ed4b4fd
+      files:
+        - from: "kube-alfred"
+          to: "."
+      bin: "kube-alfred"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Darwin_arm64.tar.gz
+      sha256: 7724cdc8cc1aed237d037be1b4cc9bf858f8df913df5601fc2fdcd832cbe25e4
+      files:
+        - from: "kube-alfred"
+          to: "."
+      bin: "kube-alfred"
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/kemalcanbora/kube-alfred/releases/download/v0.1.0/kube-alfred_Windows_x86_64.zip
+      sha256: 33186710597e53b53742d9f296b49d0d211b94b4eab2dd047b9360d26793bba5
+      files:
+        - from: "kube-alfred.exe"
+          to: "."
+      bin: "kube-alfred.exe"
+  shortDescription: AI-powered Kubernetes assistant
+  description: |
+    Alfred is an AI-powered assistant for Kubernetes. It allows you to ask
+    questions about Kubernetes directly from kubectl, providing intelligent
+    responses using the Anthropic API.
+  homepage: https://github.com/kemalcanbora/kube-alfred


### PR DESCRIPTION
Added Alfred, a plugin to assist your project. [Kube-Alfred](https://github.com/kemalcanbora/kube-alfred) is an AI-powered assistant for Kubernetes. It allows you to ask questions about Kubernetes directly from kubectl, providing intelligent responses using the Anthropic API.

- [x] Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- [x] Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]
- [x] ShortDescription
- [x] Readme