### PR TITLE
Add encrypted-kubeconfig to krew plugins

### DIFF
--- a/plugins/encrypted-kubeconfig.yaml
+++ b/plugins/encrypted-kubeconfig.yaml
@@ -1,0 +1,49 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: encrypted-kubeconfig
+spec:
+  version: "v1.0.1"
+  # 'homepage' usually links to the GitHub repository of the plugin
+  homepage: 
+  shortDescription: "Authentication plugin for encrypted KUBECONFIG files."
+  description: |
+    This plugin allows to authenticate to Kubernetes API by decrypting the accesstoken inside of an encrypted KUBECONFIG.
+    This is done using the system keyring.
+  platforms:
+  - bin: encrypted-kubeconfig
+    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.1/encrypted-kubeconfig-linux-amd64.tar.gz
+    sha256: fe36f5c700b3241f6343426965cc9d0dbaa5c32275237d8148e34129ee8a2368
+    files:
+      - from: LICENSE
+        to: .
+      - from: encrypted-kubeconfig
+        to: .
+    selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+  - bin: encrypted-kubeconfig
+    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.1/encrypted-kubeconfig-darwin-arm64.tar.gz
+    sha256: 432bec988c75c68cd037aa823d0b2331118d56859dc6e025c0e5a14f5a1be857
+    files:
+      - from: LICENSE
+        to: .
+      - from: encrypted-kubeconfig
+        to: .
+    selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+  - bin: encrypted-kubeconfig.exe
+    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.1/encrypted-kubeconfig-windows-amd64.zip
+    sha256: 4d184ac5cc6279f50ccfce83ec084a5b55909cc0834a41dcdbb9f42e0b8419da
+    files:
+      - from: LICENSE
+        to: .
+      - from: encrypted-kubeconfig.exe
+        to: .
+    selector:
+      matchLabels:
+        os: windows
+        arch: amd64

--- a/plugins/encrypted-kubeconfig.yaml
+++ b/plugins/encrypted-kubeconfig.yaml
@@ -3,17 +3,25 @@ kind: Plugin
 metadata:
   name: encrypted-kubeconfig
 spec:
-  version: "v1.0.1"
-  # 'homepage' usually links to the GitHub repository of the plugin
-  homepage: 
-  shortDescription: "Authentication plugin for encrypted KUBECONFIG files."
+  version: "v1.0.2"
+  homepage: https://github.com/n4-de/kubectl-encrypted-kubeconfig
+  shortDescription: "Encrypt KUBECONFIG files"
   description: |
-    This plugin allows to authenticate to Kubernetes API by decrypting the accesstoken inside of an encrypted KUBECONFIG.
-    This is done using the system keyring.
+    This plugin provides a way to work with encrypted KUBECONFIG files.
+    The plugin itself can also convert an unencrypted KUBECONFIG file into
+    an encrypted one.
+    The encryption part is done using the age library and the key used to
+    decrypt the KUBECONFIG file is stored in the system's keyring. This is
+    done using the go-keyring library, which supports Linux, Mac and and
+    Windows systems.
+    The idea behind the plugin is to provide additional protection for
+    KUBECONFIG files using Encryption at Rest, so that in the worst-case
+    scenario of a data leak, there is no need to worry about compromised
+    clusters.
   platforms:
   - bin: encrypted-kubeconfig
-    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.1/encrypted-kubeconfig-linux-amd64.tar.gz
-    sha256: fe36f5c700b3241f6343426965cc9d0dbaa5c32275237d8148e34129ee8a2368
+    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.2/encrypted-kubeconfig-linux-amd64.tar.gz
+    sha256: 9516b25b495d8ac973799e7c46573e0794997afdc829eb67406fa9318c8de4bf
     files:
       - from: LICENSE
         to: .
@@ -24,8 +32,8 @@ spec:
         os: linux
         arch: amd64
   - bin: encrypted-kubeconfig
-    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.1/encrypted-kubeconfig-darwin-arm64.tar.gz
-    sha256: 432bec988c75c68cd037aa823d0b2331118d56859dc6e025c0e5a14f5a1be857
+    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.2/encrypted-kubeconfig-darwin-arm64.tar.gz
+    sha256: ef6db0649742fd5c80ef96ac9a52c989bf28e46ca88b385f490e3701af6de684
     files:
       - from: LICENSE
         to: .
@@ -36,8 +44,8 @@ spec:
         os: darwin
         arch: arm64
   - bin: encrypted-kubeconfig.exe
-    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.1/encrypted-kubeconfig-windows-amd64.zip
-    sha256: 4d184ac5cc6279f50ccfce83ec084a5b55909cc0834a41dcdbb9f42e0b8419da
+    uri: https://github.com/n4-de/kubectl-encrypted-kubeconfig/releases/download/v1.0.2/encrypted-kubeconfig-windows-amd64.zip
+    sha256: 37094edbe6d856989c336e3b9fffaf3633ddc07931b433febbaabb796ce8e1e9
     files:
       - from: LICENSE
         to: .


### PR DESCRIPTION
This change adds [encrypted-kubeconfig](https://github.com/n4-de/kubectl-encrypted-kubeconfig) to the list of krew plugins.

The plugin encrypted-kubeconfig provides a way to work with encrypted KUBECONFIG files. The plugin itself is also able to convert a non encrypted KUBECONFIG file into an encrypted file.
The encryption part is done using [age](https://github.com/FiloSottile/age) and the key used to decrypt the KUBECONFIG file later on gets stored into the systems keyring (Linux, Mac and Windows is supported) using the [go-keyring library](https://github.com/zalando/go-keyring).

The idea behind this plugin is to provide encryption at rest for KUBECONFIG files and thus providing an additional security layer for worst case scenarios.