### PR TITLE
Add inject-shell plugin

### DIFF
--- a/plugins/inject-shell.yaml
+++ b/plugins/inject-shell.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: inject-shell
 spec:
-  version: "v0.0.5"
+  version: "v0.0.6"
   homepage: https://github.com/inerplat/kubectl-inject-shell
   shortDescription: "Injects a BusyBox environment into running Kubernetes containers for debugging."
   description: |
@@ -17,8 +17,8 @@ spec:
         values:
         - darwin
         - linux
-    uri: https://github.com/inerplat/kubectl-inject-shell/releases/download/v0.0.5/kubectl-inject-shell.tar.gz
-    sha256: 9961bf83ab060b96b5b1af1b1cf801b36d3c4bb2d206c0163d472c4f07ccd92c
+    uri: https://github.com/inerplat/kubectl-inject-shell/releases/download/v0.0.6/kubectl-inject-shell.tar.gz
+    sha256: 9ccfbfd63cd2ffe10b8c71f4e199aea5fa95797d64813b9d9bf13c363530093b
     files:
     - from: "kubectl-inject-shell"
       to: "inject-shell.bash"

--- a/plugins/inject-shell.yaml
+++ b/plugins/inject-shell.yaml
@@ -1,0 +1,27 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: inject-shell
+spec:
+  version: "v0.0.5"
+  homepage: https://github.com/inerplat/kubectl-inject-shell
+  shortDescription: "Injects a BusyBox environment into running Kubernetes containers for debugging."
+  description: |
+    kubectl-inject-shell injects a BusyBox environment into a running Kubernetes container, 
+    enabling debugging and filesystem access, even in shell-less environments like distroless images.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/inerplat/kubectl-inject-shell/releases/download/v0.0.5/kubectl-inject-shell.tar.gz
+    sha256: 9961bf83ab060b96b5b1af1b1cf801b36d3c4bb2d206c0163d472c4f07ccd92c
+    files:
+    - from: "kubectl-inject-shell"
+      to: "inject-shell.bash"
+    - from: "LICENSE"
+      to: "."
+    bin: inject-shell.bash


### PR DESCRIPTION
### Add `inject-shell` Plugin

**Description:** `kubectl-inject-shell` is a tool for injecting a BusyBox environment into a running Kubernetes container, even if it lacks a shell. It sets up a privileged container on the same node as the target pod, allowing you to debug and access the container's filesystem. It supports specifying various options like namespace, image, and container for customized execution.

**Features:**
- Injects BusyBox into running containers
- Supports containers without shells (e.g., distroless images)
- Creates a privileged container on the same node for debugging
- Allows customization through options for namespace, image, and container

**Usage:**
```sh
kubectl inject-shell <pod-name> [options]
```

For detailed usage and additional information, please refer to the [GitHub repository README](https://github.com/inerplat/kubectl-inject-shell).
