### PR TITLE
add config-doctor plugin

### DIFF
--- a/plugins/config-doctor.yaml
+++ b/plugins/config-doctor.yaml
@@ -27,7 +27,7 @@ spec:
           arch: amd64
     - bin: ./kubectl-config-doctor
       uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.3/kubectl-config-doctor-darwin-amd64.tar.gz
-      sha256: b2cce8179217e8bbf9b88a9b13f9a8a370a169ae714735c60204d13ef88b7a57
+      sha256: 62182a4d5b6f9a6eb6c49868478ac4cb45eb70ac2f9e4a598b7252f806816e3b
       selector:
         matchLabels:
           os: darwin

--- a/plugins/config-doctor.yaml
+++ b/plugins/config-doctor.yaml
@@ -1,0 +1,41 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: config-doctor
+  shortDescription: Validate and test kubeconfigs 
+  homepage: https://github.com/aptakube/kubectl-config-doctor
+  description: This plugin validates and test different kubeconfigs settings 
+spec:
+  version: v0.3.2
+  shortDescription: Add, update, or remove conditions on Kubernetes nodes
+  homepage: https://github.com/aptakube/kubectl-config-doctor
+  description: 
+  platforms:
+    - bin: ./kubectl-config-doctor.exe
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-windows-amd64.zip
+      sha256: 7ffbe4fa65dea8db8be07987142c418be7938d1e46c00d87d34a1a9a802110d9
+      selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+    - bin: ./kubectl-config-doctor
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-linux-amd64.tar.gz
+      sha256: 02003fd3497f356df774a9e63b641d2201c0495c0787cf16b6d101232c5ec551
+      selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+    - bin: ./kubectl-config-doctor
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-darwin-amd64.tar.gz
+      sha256: 324751f42993a4149a8d0756e946c2ab04599a0dc902e022fdd9bad0c039ff18
+      selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+    - bin: ./kubectl-config-doctor
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-darwin-arm64.tar.gz
+      sha256: 62334188b2f586180f998395488cb574a98ce167ce6ed22dc9985f2f565fb879
+      selector:
+        matchLabels:
+          os: darwin
+          arch: arm64

--- a/plugins/config-doctor.yaml
+++ b/plugins/config-doctor.yaml
@@ -6,35 +6,35 @@ metadata:
   homepage: https://github.com/aptakube/kubectl-config-doctor
   description: This plugin validates and test different kubeconfigs settings 
 spec:
-  version: v0.3.2
+  version: v0.3.3
   shortDescription: Add, update, or remove conditions on Kubernetes nodes
   homepage: https://github.com/aptakube/kubectl-config-doctor
   description: 
   platforms:
     - bin: ./kubectl-config-doctor.exe
-      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-windows-amd64.zip
-      sha256: 7ffbe4fa65dea8db8be07987142c418be7938d1e46c00d87d34a1a9a802110d9
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.3/kubectl-config-doctor-windows-amd64.zip
+      sha256: 3a4d594462f88fc4ec3a287a5ef425a88a4a2bf33e2ac7d2c195a1f5d240adaf
       selector:
         matchLabels:
           os: windows
           arch: amd64
     - bin: ./kubectl-config-doctor
-      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-linux-amd64.tar.gz
-      sha256: 02003fd3497f356df774a9e63b641d2201c0495c0787cf16b6d101232c5ec551
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.3/kubectl-config-doctor-linux-amd64.tar.gz
+      sha256: f5ad1faef3a1a814336d86fc2615de98eb713c15e749e52b78ff1c9dc936e342
       selector:
         matchLabels:
           os: linux
           arch: amd64
     - bin: ./kubectl-config-doctor
-      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-darwin-amd64.tar.gz
-      sha256: 324751f42993a4149a8d0756e946c2ab04599a0dc902e022fdd9bad0c039ff18
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.3/kubectl-config-doctor-darwin-amd64.tar.gz
+      sha256: b2cce8179217e8bbf9b88a9b13f9a8a370a169ae714735c60204d13ef88b7a57
       selector:
         matchLabels:
           os: darwin
           arch: amd64
     - bin: ./kubectl-config-doctor
-      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.2/kubectl-config-doctor-darwin-arm64.tar.gz
-      sha256: 62334188b2f586180f998395488cb574a98ce167ce6ed22dc9985f2f565fb879
+      uri: https://github.com/aptakube/kubectl-config-doctor/releases/download/v0.3.3/kubectl-config-doctor-darwin-arm64.tar.gz
+      sha256: b2cce8179217e8bbf9b88a9b13f9a8a370a169ae714735c60204d13ef88b7a57
       selector:
         matchLabels:
           os: darwin


### PR DESCRIPTION
`kubectl-config-doctor` is a plugin that can help you diagnose common issues with your kubeconfig file, such as:

- Duplicate contexts/clusters/users
- Missing contexts/clusters/users
- Incorrectly formatted kubeconfig files
- Unreachable proxy api
- Unreachable cluster api
- Invalid authentication methods
- Files that don't exist
- ... and more!

![image](https://github.com/user-attachments/assets/64665ba8-45d2-4d85-b63b-299ceef95a2f)

