### PR TITLE
Add kubectl-output plugin

### DIFF
--- a/plugins/output.yaml
+++ b/plugins/output.yaml
@@ -1,0 +1,85 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: output
+spec:
+  version: v0.1.5
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_linux_amd64.tar.gz
+      sha256: 1a98d0c1f937a74819568d48a714dba97d67c0e308df9336d3b4c1db437a2df3
+      files:
+        - from: "./output"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "output"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_linux_arm64.tar.gz
+      sha256: 9e98a381643ae03a57c8098ed24263b0ba034261ddb65a156fa21064e885a509
+      files:
+        - from: "./output"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "output"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_darwin_amd64.tar.gz
+      sha256: c0b529871d649d37d9a8fdf79dbc37961e1cb071dbc899cc223d63b4387cb71e
+      files:
+        - from: "./output"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "output"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_darwin_arm64.tar.gz
+      sha256: 0aebe1eb8fb2e814a613f577469e945ae685d0b07def22fd5253a0a9a1b4b52f
+      files:
+        - from: "./output"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "output"
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_windows_amd64.zip
+      sha256: ae6f38872be81fd257ad405be947d2c7da2a8d3f897ca5110045492da3d360f1
+      files:
+        - from: "/output.exe"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "output.exe"
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_windows_arm64.zip
+      sha256: 16653f3eb8314095a82bf73ae5fdbe27b6f7e8d7914dd0942d86c4f9ac3d92e9
+      files:
+        - from: "/output.exe"
+          to: "."
+        - from: LICENSE
+          to: "."
+      bin: "output.exe"
+  shortDescription: Set custom output format for specific resources/namespaces.
+  homepage: https://github.com/GrigoriyMikhalkin/kubectl-output
+  description: |
+    This plugin allows you to set custom outputs for specific resources/namespaces. 
+    For that to work you'll need to use kubectl-output as a wrapper for `kubectl get ...` command.
+    Either by running `kubectl output get ...` or using alias `ko="kubectl output"; ko get ...`.

--- a/plugins/output.yaml
+++ b/plugins/output.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: output
 spec:
-  version: v0.1.5
+  version: v0.1.6
   platforms:
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_linux_amd64.tar.gz
-      sha256: 1a98d0c1f937a74819568d48a714dba97d67c0e308df9336d3b4c1db437a2df3
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.6/output_linux_amd64.tar.gz
+      sha256: 1347a20c44bffbf02ae16f2d64e333634a82a1842a3253cdc2f38092d46bbb76
       files:
         - from: "./output"
           to: "."
@@ -21,8 +21,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_linux_arm64.tar.gz
-      sha256: 9e98a381643ae03a57c8098ed24263b0ba034261ddb65a156fa21064e885a509
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.6/output_linux_arm64.tar.gz
+      sha256: d5809e3ce0c515094b4aaacdcd59919fb575eadc1c232f1308709b491e855934
       files:
         - from: "./output"
           to: "."
@@ -33,8 +33,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_darwin_amd64.tar.gz
-      sha256: c0b529871d649d37d9a8fdf79dbc37961e1cb071dbc899cc223d63b4387cb71e
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.6/output_darwin_amd64.tar.gz
+      sha256: 8fe68f09fba75334f039bcd3013611c3efdfe91fa8bbe5bb61be7c62ab878424
       files:
         - from: "./output"
           to: "."
@@ -45,8 +45,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_darwin_arm64.tar.gz
-      sha256: 0aebe1eb8fb2e814a613f577469e945ae685d0b07def22fd5253a0a9a1b4b52f
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.6/output_darwin_arm64.tar.gz
+      sha256: d4fba52daacad4cd7b3d32b2141ca2fdf98ea19f4b0a2df87777a8501674e1ee
       files:
         - from: "./output"
           to: "."
@@ -57,8 +57,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_windows_amd64.zip
-      sha256: ae6f38872be81fd257ad405be947d2c7da2a8d3f897ca5110045492da3d360f1
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.6/output_windows_amd64.zip
+      sha256: 63b9a4cb6ba383892fc35fe1d23a4c301932d6710a589100044d2c0c8aa26204
       files:
         - from: "/output.exe"
           to: "."
@@ -69,8 +69,8 @@ spec:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.5/output_windows_arm64.zip
-      sha256: 16653f3eb8314095a82bf73ae5fdbe27b6f7e8d7914dd0942d86c4f9ac3d92e9
+      uri: https://github.com/GrigoriyMikhalkin/kubectl-output/releases/download/v0.1.6/output_windows_arm64.zip
+      sha256: bb530bec3207c8221fe589d02d426035c6e038866a684cd7bbe7edfdeefea61d
       files:
         - from: "/output.exe"
           to: "."

--- a/plugins/output.yaml
+++ b/plugins/output.yaml
@@ -77,9 +77,9 @@ spec:
         - from: LICENSE
           to: "."
       bin: "output.exe"
-  shortDescription: Set custom output format for specific resources/namespaces.
+  shortDescription: Set custom output format for resources/namespaces
   homepage: https://github.com/GrigoriyMikhalkin/kubectl-output
   description: |
-    This plugin allows you to set custom outputs for specific resources/namespaces. 
-    For that to work you'll need to use kubectl-output as a wrapper for `kubectl get ...` command.
-    Either by running `kubectl output get ...` or using alias `ko="kubectl output"; ko get ...`.
+    This plugin allows you to set custom outputs for specific resources/namespaces.
+    Supports both custom-column and custom-column-file formats for templates.
+    When running get command serves as a wrapper for kubectl command.


### PR DESCRIPTION
`kubectl-output` is a plugin for `kubectl` that allows users to set custom output format for specific resources/namespaces.
Custom output format is based on [custom-columns](https://kubernetes.io/docs/reference/kubectl/#custom-columns).

Example usage:
```shell
# create default template
kubectl output set pod --name=test -c=NAME:.metadata.name

# create template for kube-system namespace from file
cat pod.tmpl
# NAME          RSRC
# metadata.name metadata.resourceVersion

kubectl output pod --name=test-file --namespace=kube-system -c=./pod.tmpl

# list all templates for pod
kubectl output template pod -a
# test
# test-file

# get pods with default template
kubectl output get pods -A
# NAME
# pod1

# override default template
kubectl output get pods -A -o test-file
# NAME                 RSRC
# pod1                 123
```


Plugin repo: https://github.com/GrigoriyMikhalkin/kubectl-output