### PR TITLE
Add new plugin: ray

### DIFF
--- a/plugins/ray.yaml
+++ b/plugins/ray.yaml
@@ -1,0 +1,40 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ray
+spec:
+  version: v1.2.2
+  homepage: https://github.com/ray-project/kuberay/kubectl-plugin
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.2.2/kubectl-ray_v1.2.2_darwin_amd64.tar.gz
+      sha256: f7ab82e46d61629d637b6370d4bd8057cbb8568ca26313f04acc62a34d3870e4
+      bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.2.2/kubectl-ray_v1.2.2_darwin_arm64.tar.gz
+      sha256: c4ef858eab5374e8b23a66fecb5c066e14adf76ae4b8b46e52244f5c6f753464
+      bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.2.2/kubectl-ray_v1.2.2_linux_amd64.tar.gz
+      sha256: c3f3615441834f39bb9a9bea8ea093f3fb4e4b4b5871b4c050ae6f76bdeaf4f6
+      bin: kubectl-ray
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.2.2/kubectl-ray_v1.2.2_linux_arm64.tar.gz
+      sha256: f1789b9ad1cc4664021dcd396e43c5bd6008e615196396b52bdcc39d3ffdd205
+      bin: kubectl-ray
+  shortDescription: Ray kubectl plugin
+  description: |
+    Kubectl plugin/extension for Kuberay CLI that provides the ability to manage ray resources.
+    Read more documentation at: https://github.com/ray-project/kuberay/tree/master/kubectl-plugin


### PR DESCRIPTION
This PR added a new plugin for [Ray project](https://github.com/ray-project/ray) on Kubernetes

Source code hosted on [KubeRay repo](https://github.com/ray-project/kuberay/tree/master/kubectl-plugin)

Closes ray-project/kuberay#2410