### PR TITLE
Add ns-inspect plugin

### DIFF
--- a/plugins/ns-inspect.yaml
+++ b/plugins/ns-inspect.yaml
@@ -1,0 +1,18 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ns-inspect
+spec:
+  version: "v1.2.0"
+  homepage: "https://github.com/Rookie0031/kubectl-ns-inspect"
+  shortDescription: "Inspect if there is useless namespace and optionally delete it"
+  description: |
+    This plugin checks Kubernetes namespaces for resources and allows users to delete empty namespaces.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: "https://github.com/Rookie0031/kubectl-ns-inspect/releases/download/v1.2.0/kubectl-ns-inspect_1.2.0_darwin_arm64.tar.gz"
+      sha256: "b708b3865061b5a4f199d8620aaf741fec65e3e0a5f4b0580db9294ee0cb9378"
+      bin: "kubectl-ns-inspect"


### PR DESCRIPTION
## Description
This PR adds the kubectl-ns-inspect plugin to the Krew index. kubectl-ns-inspect is a utility plugin that inspects all the namespaces in current Kubernetes cluster and see if it contains any resources (e.g., Pods, Services, ConfigMaps, ResourceQuotas, etc.) judge it is useless or not. 

If the namespace is deemed useless (there is no Pod, Service, ResourceQuotas), the plugin can optionally prompt the user to delete the namespace.

## Features
#### 1. Namespace Resource Inspection:
- The plugin inspects all namespaces within a cluster to check for resources such as Pods, Services, ConfigMaps, and ResourceQuotas.
If a namespace is considered useless, the plugin lists all remaining resources within the namespace and prompts the user to delete it.

#### 2. Dry-run Option:
- The plugin supports a dry-run mode, which allows users to list the namespaces and their contents without performing any deletions.

#### 3. Current Context-Based Operation:
- The plugin operates based on the current Kubernetes context.
It uses the context specified in the KUBECONFIG environment variable, or defaults to $HOME/.kube/config if the variable is not set.


## Usage
```
kubectl ns-inspect
```


<img width="825" alt="image" src="https://github.com/user-attachments/assets/b8dcacb0-c2bb-4b5a-a1ea-d693e1d73d5a">



## Check
1. It follows Plugin Naming Guide
2. Verified I can install my plugin locally


