### PR TITLE
Fix wrong link in ray plugin

### DIFF
--- a/plugins/ray.yaml
+++ b/plugins/ray.yaml
@@ -4,7 +4,7 @@ metadata:
   name: ray
 spec:
   version: v1.2.2
-  homepage: https://github.com/ray-project/kuberay/kubectl-plugin
+  homepage: https://github.com/ray-project/kuberay/tree/master/kubectl-plugin
   platforms:
     - selector:
         matchLabels:


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

I found that the homepage link for the Ray plugin is incorrect, so I submitted another PR to fix it. Thanks!






