### PR TITLE
Add `kubectl-create-limitrange` plugin to Krew index

### DIFF
--- a/plugins/limitrange.yaml
+++ b/plugins/limitrange.yaml
@@ -3,33 +3,31 @@ kind: Plugin
 metadata:
   name: limitrange
 spec:
-  version: v1.0.2
+  version: v1.0.3
   homepage: https://github.com/mfenerich/kubectl-lr
   shortDescription: "Creates limitrange resources in Kubernetes"
   description: |
-    kubectl-limitrange is a kubectl plugin that allows easy creation of
-    LimitRange resources in Kubernetes namespaces with configurable
-    CPU and memory limits.
+    kubectl create-limitrange is a kubectl plugin that extends the standard 'kubectl create' command, allowing easy creation of LimitRange resources in Kubernetes namespaces with configurable CPU and memory limits.
   platforms:
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.2/kubectl-limitrange-darwin-amd64.tar.gz
-    sha256: d01f4e27579e57cc6c66448983a695c788039c900927b7ec9d27fbc1d799cf3d
+    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.3/kubectl-limitrange-darwin-arm64.tar.gz
+    sha256: 0597e012578fbc08b483fa0cdf73e84bf3e91c807f057f1039b9239397f298b1
     bin: kubectl-limitrange
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.2/kubectl-limitrange-linux-amd64.tar.gz
-    sha256: 614d16cc2ca4d4becd7247da9d40c70114759384d9a10b3820dc8d80b1d2e0db
+    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.3/kubectl-limitrange-linux-amd64.tar.gz
+    sha256: 97a1792fb9df9ba483dea2c0e82ced8a7740b629c24c912288657563982f22e7
     bin: kubectl-limitrange
   - selector:
       matchExpressions:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.2/kubectl-limitrange-windows-amd64.zip
-    sha256: 0fe51745b27bbe12f81d716a027d6d42d41a0670feb5d5747e741dc0df153968
+    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.3/kubectl-limitrange-windows-amd64.zip
+    sha256: 78a07428730d9ca66b072ad089ee928f9364c0e87ae97040a383b4cfd4a9a564
     bin: kubectl-limitrange.exe

--- a/plugins/limitrange.yaml
+++ b/plugins/limitrange.yaml
@@ -1,0 +1,35 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: limitrange
+spec:
+  version: v1.0.2
+  homepage: https://github.com/mfenerich/kubectl-lr
+  shortDescription: "Creates limitrange resources in Kubernetes"
+  description: |
+    kubectl-limitrange is a kubectl plugin that allows easy creation of
+    LimitRange resources in Kubernetes namespaces with configurable
+    CPU and memory limits.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.2/kubectl-limitrange-darwin-amd64.tar.gz
+    sha256: d01f4e27579e57cc6c66448983a695c788039c900927b7ec9d27fbc1d799cf3d
+    bin: kubectl-limitrange
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.2/kubectl-limitrange-linux-amd64.tar.gz
+    sha256: 614d16cc2ca4d4becd7247da9d40c70114759384d9a10b3820dc8d80b1d2e0db
+    bin: kubectl-limitrange
+  - selector:
+      matchExpressions:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/mfenerich/kubectl-lr/releases/download/v1.0.2/kubectl-limitrange-windows-amd64.zip
+    sha256: 0fe51745b27bbe12f81d716a027d6d42d41a0670feb5d5747e741dc0df153968
+    bin: kubectl-limitrange.exe


### PR DESCRIPTION
**Title**: Add `kubectl-create-limitrange` plugin to Krew index
**Description**:
This PR adds the `kubectl-create-limitrange` plugin to the Krew plugin index.
**Plugin Name**: `kubectl-create-limitrange`
**Plugin Repository**: [https://github.com/mfenerich/kubectl-lr](https://github.com/mfenerich/kubectl-lr)

### Overview
`kubectl create-limitrange` is a kubectl plugin that extends the standard `kubectl create` command, allowing easy creation of [LimitRange](https://kubernetes.io/docs/concepts/policy/limit-range/) resources in Kubernetes namespaces with configurable CPU and memory limits. It helps cluster administrators enforce resource constraints and optimize cluster performance.

### Key Features
- **Easy Creation of LimitRanges**: Streamlines the process of creating LimitRange resources without the need to write YAML manifests manually.
- **Configurable Resource Limits**: Allows users to specify minimum and maximum CPU and memory limits according to their requirements.
- **Namespace Support**: Can target specific namespaces, making it flexible for multi-tenant environments.
- **Cross-Platform Availability**: Binaries are available for macOS (darwin), Linux, and Windows on amd64 architectures.

### Why This Plugin Should Be Accepted
- **Enhances Productivity**: Automates repetitive tasks, saving time and reducing the potential for human error in resource configuration.
- **Promotes Best Practices**: Encourages the use of LimitRanges, which are essential for resource management and ensuring fair resource allocation among pods.
- **Community Benefit**: Fills a gap in the current plugin ecosystem by providing a dedicated tool for managing LimitRanges.
- **Follows kubectl Conventions**: Uses the standard verb-noun pattern (`create limitrange`) that aligns with kubectl's command structure.

### Compliance with Krew Guidelines
- **Manifest Validation**: The plugin manifest has been validated and complies with Krew's [plugin manifest specification](https://krew.sigs.k8s.io/docs/developer-guide/plugin-manifest/).
- **License**: The plugin is open-sourced under the [Apache License 2.0](https://github.com/mfenerich/kubectl-lr/blob/main/LICENSE), aligning with Krew's licensing requirements.
- **Naming Convention**: The plugin name follows the `kubectl-<verb>-<noun>` format, adhering to kubectl's command structure.

### Testing and Verification
- **Installation**: Successfully tested installation via Krew on macOS and Linux systems.
- **Functionality**: Verified that the plugin correctly creates LimitRange resources with specified CPU and memory limits.
- **Documentation**: Usage instructions and examples are provided in the plugin's [README](https://github.com/mfenerich/kubectl-lr/blob/main/README.md).

### Example Usage
```bash
# Create a LimitRange in the 'development' namespace with custom limits
kubectl create limitrange my-limitrange --namespace=development --min-cpu=100m --max-cpu=500m --min-memory=128Mi --max-memory=1Gi
```

### Related Links
- **Plugin Homepage**: [https://github.com/mfenerich/kubectl-lr](https://github.com/mfenerich/kubectl-lr)
- **Documentation**: [[README.md](https://github.com/mfenerich/kubectl-lr/blob/main/README.md)](https://github.com/mfenerich/kubectl-lr/blob/main/README.md)
- **Kubernetes LimitRange Docs**: [[Limit Ranges](https://kubernetes.io/docs/concepts/policy/limit-range/)](https://kubernetes.io/docs/concepts/policy/limit-range/)