### PR TITLE
fix(retina): revert #4216 with v0.0.17, release is deleted

### DIFF
--- a/plugins/retina.yaml
+++ b/plugins/retina.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: retina
 spec:
-  version: v0.0.17
+  version: v0.0.16
   homepage: https://github.com/microsoft/retina
   shortDescription: Distributed network captures and telemetry
   description: |
@@ -18,42 +18,42 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-darwin-amd64-v0.0.17.tar.gz
-    sha256: c494f0402ad6227e5e2a8e67c11ffe70a1988507e93328dd13fe8234744e262a
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-darwin-amd64-v0.0.16.tar.gz
+    sha256: a4964ec99370a5f4589d5bf8b7ab672cb1986f6514d24583ecba2cae615cf158
     bin: kubectl-retina-darwin-amd64
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-darwin-arm64-v0.0.17.tar.gz
-    sha256: e09c0af3b6bab918f4807d1b870ab4f5d8ce0585a85ef7487a91627b3e37a8fa
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-darwin-arm64-v0.0.16.tar.gz
+    sha256: fd77ad9e04af42fd22384ba28c14640d7cf33689aa2642e14d050ad9572c781c
     bin: kubectl-retina-darwin-arm64
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-linux-amd64-v0.0.17.tar.gz
-    sha256: 30f3ababf963878734d5c519395c9a4aaa5edd6c3e9f9b3a483792af38878a52
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-linux-amd64-v0.0.16.tar.gz
+    sha256: a37510e9d9acc807feb8aecba0af0c5e4df291252819dd5fe8fa12624400a1a0
     bin: kubectl-retina-linux-amd64
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-linux-arm64-v0.0.17.tar.gz
-    sha256: d68643d19159f30ea5f9bdc1d021f89e923c2463d485c440803d14b508010a2d
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-linux-arm64-v0.0.16.tar.gz
+    sha256: b447ac4191022c4697f8c34f12f77dfeafce4624d4e36b8ca3548b520a493fb9
     bin: kubectl-retina-linux-arm64
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-windows-amd64-v0.0.17.zip
-    sha256: 56a54628dbe2d9715bf8e070eb0f77bfa9c44a0fb3b0d20c7778e9aecd8c357c
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-windows-amd64-v0.0.16.zip
+    sha256: 9e18afd2283be807385254e9d6da9390e442aa545cd134818679fd5dab5402e7
     bin: kubectl-retina-windows-amd64.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-windows-arm64-v0.0.17.zip
-    sha256: a00025056f09c38aa00e0c8c61cbf263dbf7213189e3d0d9d560b2bdedebefd6
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-windows-arm64-v0.0.16.zip
+    sha256: 9916ef91ff9470fe194db362ec040e296b4eda9642c32989cc778abd4d39dea0
     bin: kubectl-retina-windows-arm64.exe
 


### PR DESCRIPTION
* Revert #4216 as tag/release v0.0.17 was deleted on retina upstream.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
