### PR TITLE
release new version v0.0.17 of retina

### DIFF
--- a/plugins/retina.yaml
+++ b/plugins/retina.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: retina
 spec:
-  version: v0.0.16
+  version: v0.0.17
   homepage: https://github.com/microsoft/retina
   shortDescription: Distributed network captures and telemetry
   description: |
@@ -18,42 +18,42 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-darwin-amd64-v0.0.16.tar.gz
-    sha256: a4964ec99370a5f4589d5bf8b7ab672cb1986f6514d24583ecba2cae615cf158
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-darwin-amd64-v0.0.17.tar.gz
+    sha256: 07800415ba15d5720d97eeddd56f0a4c77dea2e0f25ab9b2fd347d022162212a
     bin: kubectl-retina-darwin-amd64
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-darwin-arm64-v0.0.16.tar.gz
-    sha256: fd77ad9e04af42fd22384ba28c14640d7cf33689aa2642e14d050ad9572c781c
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-darwin-arm64-v0.0.17.tar.gz
+    sha256: 0e16b97175d9c906b1d976fd785df921f68410d9f09422e10f409e0339ad71c5
     bin: kubectl-retina-darwin-arm64
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-linux-amd64-v0.0.16.tar.gz
-    sha256: a37510e9d9acc807feb8aecba0af0c5e4df291252819dd5fe8fa12624400a1a0
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-linux-amd64-v0.0.17.tar.gz
+    sha256: 23a8c417786c3609d68b86b4951c9564116da51be4d2beba07ba0317197c74ac
     bin: kubectl-retina-linux-amd64
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-linux-arm64-v0.0.16.tar.gz
-    sha256: b447ac4191022c4697f8c34f12f77dfeafce4624d4e36b8ca3548b520a493fb9
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-linux-arm64-v0.0.17.tar.gz
+    sha256: 69eae11f4a4f788ba19a899f5bb9b6e285bd8e6bbcfa4e2a8c79c0ce221049f0
     bin: kubectl-retina-linux-arm64
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-windows-amd64-v0.0.16.zip
-    sha256: 9e18afd2283be807385254e9d6da9390e442aa545cd134818679fd5dab5402e7
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-windows-amd64-v0.0.17.zip
+    sha256: 285807d8093d0c8b846a28f3e0c0d23500e44c2efc88cfd91e48caa74ee50b5b
     bin: kubectl-retina-windows-amd64.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/microsoft/retina/releases/download/v0.0.16/kubectl-retina-windows-arm64-v0.0.16.zip
-    sha256: 9916ef91ff9470fe194db362ec040e296b4eda9642c32989cc778abd4d39dea0
+    uri: https://github.com/microsoft/retina/releases/download/v0.0.17/kubectl-retina-windows-arm64-v0.0.17.zip
+    sha256: 28ba51fe06cca739eb0a72a4c7944a8cb75e51c30df2cb03fbbff01d0215b1d4
     bin: kubectl-retina-windows-arm64.exe
 


### PR DESCRIPTION
For some reason the bot did not pick up this change. I suspect because the initial v0.0.17 PR had to be reverted yesterday. Please review/merge this. Thanks.

**Relates to:**
- https://github.com/kubernetes-sigs/krew-index/pull/4216
- https://github.com/kubernetes-sigs/krew-index/pull/4219

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
