### PR TITLE
add wider

### DIFF
--- a/plugins/wider.yaml
+++ b/plugins/wider.yaml
@@ -1,0 +1,30 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: wider
+spec:
+  version: "v0.0.1"
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - windows
+        - darwin
+        - linux
+    uri: https://github.com/boriscosic/wider/releases/download/v0.0.1/v0.0.1.zip
+    sha256: 753d0a7eac6f25e68ec40ba01c86d6bcdeb981a6480c212bfe22b517b52f1385
+    files:
+    - from: "*"
+      to: "."
+    bin: kubectl-wider
+  shortDescription: >-
+    Get pod and associated node information with one command
+  homepage: https://github.com/boriscosic/wider
+  description: |
+    Get pods and associated node information. Extend the output with custom-columns 
+    by leveraging keys from pod or node specs. 
+    Examples:
+    `$ kubectl wider`
+    `$ kubectl wider -n istio-system -o custom-columns="NAME:.metadata.name,NODE:.node.metadata.name` 

--- a/plugins/wider.yaml
+++ b/plugins/wider.yaml
@@ -27,4 +27,4 @@ spec:
     by leveraging keys from pod or node specs. 
     Examples:
     `$ kubectl wider`
-    `$ kubectl wider -n istio-system -o custom-columns="NAME:.metadata.name,NODE:.node.metadata.name` 
+    `$ kubectl wider -n istio-system -o custom-columns="NAME:.metadata.name,NODE:.node.metadata.name`


### PR DESCRIPTION
# About

This plugin lets users query pod and associated node information with same command. There are multiple times when details of node, such as zone, provider etc need to be viewed alongside the pod and it requires two kubectl queries.

For example:
`k wider -o custom-columns="NAME:.metadata.name,NODE:.node.metadata.name,IP:.status.hostIP,ZONE:.node.metadata.labels.topology\.kubernetes\.io/zone" -n kube-system -l k8s-app=kube-dns`

```
NAME                      NODE                                          IP              ZONE
coredns-aaaaaaaaaa-mndf5  ip-10-111-222-333.us-west-2.compute.internal  10.111.122.162  us-west-2a
coredns-bbbbbbbbbb-sl7c5  ip-10-111-222-334.us-west-2.compute.internal  10.111.123.192  us-west-2b
coredns-cccccccccc-tpnxs  ip-10-111-222-335.us-west-2.compute.internal  10.111.124.250  us-west-2c
```