### PR TITLE
Add kubectl-envsubst

### DIFF
--- a/plugins/envsubst.yaml
+++ b/plugins/envsubst.yaml
@@ -1,0 +1,45 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: envsubst
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/hashmap-kz/kubectl-envsubst
+  shortDescription: A strict substitution of env-vars in Kubernetes manifests.
+  description: |
+    Expand environment-variables in manifests passed to kubectl, before applying them.
+    Variable expansion is fully predictable and controlled (managed by cli).
+    Supports all other flags passed by kubectl (by just proxying them, without any modification).
+    Just handles specially two main options from 'kubectl apply': 1) --filename=filename.yaml, 2) --recursive.
+    All other options are passed as is.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
+    bin: kubectl-envsubst
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
+    bin: kubectl-envsubst
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
+    bin: kubectl-envsubst
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
+    bin: kubectl-envsubst
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
+    bin: kubectl-envsubst.exe

--- a/plugins/envsubst.yaml
+++ b/plugins/envsubst.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: envsubst
 spec:
-  version: {{ .TagName }}
+  version: v1.0.3
   homepage: https://github.com/hashmap-kz/kubectl-envsubst
   shortDescription: A strict substitution of env-vars in Kubernetes manifests.
   description: |
@@ -13,33 +13,38 @@ spec:
     Just handles specially two main options from 'kubectl apply': 1) --filename=filename.yaml, 2) --recursive.
     All other options are passed as is.
   platforms:
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_darwin_amd64.tar.gz" .TagName }}
-    bin: kubectl-envsubst
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: arm64
-    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_darwin_arm64.tar.gz" .TagName }}
-    bin: kubectl-envsubst
-  - selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_linux_amd64.tar.gz" .TagName }}
-    bin: kubectl-envsubst
-  - selector:
-      matchLabels:
-        os: linux
-        arch: arm64
-    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_linux_arm64.tar.gz" .TagName }}
-    bin: kubectl-envsubst
-  - selector:
-      matchLabels:
-        os: windows
-        arch: amd64
-    {{addURIAndSha "https://github.com/hashmap-kz/kubectl-envsubst/releases/download/{{ .TagName }}/kubectl-envsubst_{{ .TagName }}_windows_amd64.tar.gz" .TagName }}
-    bin: kubectl-envsubst.exe
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_darwin_amd64.tar.gz
+      sha256: 03183e57f4d4945e4e8fb416fb6fb37278a082b37d1d1a6b065f8d6e92203083
+      bin: kubectl-envsubst
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_darwin_arm64.tar.gz
+      sha256: 4c65493169e3ac87e909294ee06e00817889cc89142f62151f8b0a07c9859636
+      bin: kubectl-envsubst
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_linux_amd64.tar.gz
+      sha256: e6f681001611471467c3782386d0fe3fa71c843cc0a26b4a862ad00519fde1c6
+      bin: kubectl-envsubst
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_linux_arm64.tar.gz
+      sha256: 0838bf7f920d238dc256766df3a5524d32cca4f0d8b264afbca22651a356a9f0
+      bin: kubectl-envsubst
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_windows_amd64.tar.gz
+      sha256: 13ded3070349fef0e2ff710f34f8cc70ead2ad178477e8288898d4727a5cd2b4
+      bin: kubectl-envsubst.exe

--- a/plugins/envsubst.yaml
+++ b/plugins/envsubst.yaml
@@ -7,10 +7,11 @@ spec:
   homepage: https://github.com/hashmap-kz/kubectl-envsubst
   shortDescription: A strict substitution of env-vars in Kubernetes manifests.
   description: |
-    Expand environment-variables in manifests passed to kubectl, before applying them.
+    Expand env-vars in manifests passed to kubectl, before applying them.
     Variable expansion is fully predictable and controlled (managed by cli).
-    Supports all other flags passed by kubectl (by just proxying them, without any modification).
-    Just handles specially two main options from 'kubectl apply': 1) --filename=filename.yaml, 2) --recursive.
+    Supports all flags passed by kubectl,
+    by just proxying them, without any modification.
+    Just handles specially two main options --filename and --recursive.
     All other options are passed as is.
   platforms:
     - selector:

--- a/plugins/envsubst.yaml
+++ b/plugins/envsubst.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: envsubst
 spec:
-  version: v1.0.3
+  version: v1.0.6
   homepage: https://github.com/hashmap-kz/kubectl-envsubst
   shortDescription: A strict substitution of env-vars in Kubernetes manifests.
   description: |
@@ -17,34 +17,34 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_darwin_amd64.tar.gz
-      sha256: 03183e57f4d4945e4e8fb416fb6fb37278a082b37d1d1a6b065f8d6e92203083
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_darwin_amd64.tar.gz
+      sha256: c6f25417476f01438330201509c00f8b007e775c211980ff68461842d7966045
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_darwin_arm64.tar.gz
-      sha256: 4c65493169e3ac87e909294ee06e00817889cc89142f62151f8b0a07c9859636
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_darwin_arm64.tar.gz
+      sha256: 0a607e688825a059b0c4a9ca566b59d97fe3d350141d4d5674143f6ed9ebd83d
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_linux_amd64.tar.gz
-      sha256: e6f681001611471467c3782386d0fe3fa71c843cc0a26b4a862ad00519fde1c6
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_linux_amd64.tar.gz
+      sha256: f408c21bbeae8934d7bf106a73c63039a870269f242495dcd6f9854c7da0754b
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_linux_arm64.tar.gz
-      sha256: 0838bf7f920d238dc256766df3a5524d32cca4f0d8b264afbca22651a356a9f0
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_linux_arm64.tar.gz
+      sha256: 6cd3082019a838a007718849a129a48962d03c4cd14e6c0046db8e3e4999de68
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.3/kubectl-envsubst_1.0.3_windows_amd64.tar.gz
-      sha256: 13ded3070349fef0e2ff710f34f8cc70ead2ad178477e8288898d4727a5cd2b4
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_windows_amd64.tar.gz
+      sha256: f1d9de1d592422f521508d4a14897bbdd497f314b59c9079f7353ae197b21497
       bin: kubectl-envsubst.exe

--- a/plugins/envsubst.yaml
+++ b/plugins/envsubst.yaml
@@ -17,34 +17,34 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_darwin_amd64.tar.gz
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_v1.0.6_darwin_amd64.tar.gz
       sha256: c6f25417476f01438330201509c00f8b007e775c211980ff68461842d7966045
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_darwin_arm64.tar.gz
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_v1.0.6_darwin_arm64.tar.gz
       sha256: 0a607e688825a059b0c4a9ca566b59d97fe3d350141d4d5674143f6ed9ebd83d
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_linux_amd64.tar.gz
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_v1.0.6_linux_amd64.tar.gz
       sha256: f408c21bbeae8934d7bf106a73c63039a870269f242495dcd6f9854c7da0754b
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_linux_arm64.tar.gz
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_v1.0.6_linux_arm64.tar.gz
       sha256: 6cd3082019a838a007718849a129a48962d03c4cd14e6c0046db8e3e4999de68
       bin: kubectl-envsubst
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_1.0.6_windows_amd64.tar.gz
+      uri: https://github.com/hashmap-kz/kubectl-envsubst/releases/download/v1.0.6/kubectl-envsubst_v1.0.6_windows_amd64.tar.gz
       sha256: f1d9de1d592422f521508d4a14897bbdd497f314b59c9079f7353ae197b21497
       bin: kubectl-envsubst.exe


### PR DESCRIPTION
A strict substitution of env-vars in Kubernetes manifests.

Project link: https://github.com/hashmap-kz/kubectl-envsubst

**Features available:**

- Expand environment-variables in manifests passed to kubectl, before applying them
- Uses prefixes, and allowed variables (you're able to be totally sure what it's going to be substituted)
- Has a strict mode (if some variables are not expanded, it fails)
- Uses all known kubectl args (by just proxying them as is, without any additional actions)
- ZERO dependencies, and I mean literally zero

**Tests:**

- All parts of plugin are heavily tested (substitution part, arguments handling, errors handling)

**Notes:** 

The main difference from using external tools: like envsubst, and then piping to kubectl - is we're able to 100% control the variables lists that needs to be substituted, handle all errors, use --dry-run and other options available in kubectl out of the box, implement more robust and predictable logic than substitute all available variables. And also we're able to test each part, and optimize execution flow. Options like substitute variables if and only if their names start with prefixes we want - are not available in external tools too.

Happy New Year !!!