### PR TITLE
adds envx@v0.2.0

### DIFF
--- a/plugins/envx.yaml
+++ b/plugins/envx.yaml
@@ -1,0 +1,28 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: envx
+spec:
+  version: "v0.2.0"
+  homepage: https://github.com/majodev/kubectl-envx
+  shortDescription: "Extract and inject Kubernetes environment variables to local commands"
+  description: |
+    A kubectl plugin to extract environment variables from Kubernetes resources including
+    those defined in envFrom references (ConfigMaps and Secrets). It can display these
+    variables or use them to run local commands with the extracted environment.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/majodev/kubectl-envx/releases/download/v0.2.0/kubectl-envx.tar.gz
+    sha256: "fee2b88bba77ff1d3fa00b046513416531aef67898be8f5f4b1159ac5f73e710"
+    files:
+    - from: "kubectl-envx"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: kubectl-envx

--- a/plugins/envx.yaml
+++ b/plugins/envx.yaml
@@ -5,11 +5,12 @@ metadata:
 spec:
   version: "v0.2.0"
   homepage: https://github.com/majodev/kubectl-envx
-  shortDescription: "Extract and inject Kubernetes environment variables to local commands"
+  shortDescription: "Run with env vars from Kubernetes resource"
   description: |
-    A kubectl plugin to extract environment variables from Kubernetes resources including
-    those defined in envFrom references (ConfigMaps and Secrets). It can display these
-    variables or use them to run local commands with the extracted environment.
+    A kubectl plugin to extract environment variables from Kubernetes resources
+    including those defined in envFrom references (ConfigMaps and Secrets). It can
+    display these variables or use them to run local commands with the extracted
+    environment.
   platforms:
   - selector:
       matchExpressions:


### PR DESCRIPTION
# envx - Extract and inject Kubernetes environment variables

This PR adds the `envx` plugin that helps extract environment variables from Kubernetes resources and optionally injects them into local commands.


- ✅ Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
  - **env** + **x** for extract/execute
  - short, descriptive, action-oriented
  - an official `kubectl` subcommand will typically use `kubectl view env` or `kubectl env` - thus should be safe.
- ✅ Verified I can install `envx` locally: `kubectl krew install --manifest=plugins/envx.yaml`

Key features:
* Lists environment variables from any Kubernetes resource
* Resolves `envFrom` references (ConfigMaps and Secrets) - a current limitation of `kubectl set env --resolve --list`
* Supports variable overrides
* Can execute commands with extracted variables
* Works with Pods, Deployments, StatefulSets, CronJobs, etc.

Requirements:
* bash, sed, kubectl, jq
* Supports Linux and macOS

| Dep         | Supported Versions           |
| ----------- | ---------------------------- |
| `kubectl`   | 1.28, 1.29, 1.30, 1.31, 1.32 |
| `jq`        | 1.6, 1.7.1                   |
| `bash`      | 5.2                          |
| (GNU) `sed` | 4.9                          |

Both Linux and MacOS tested.

Examples:

```bash
# Print all environment variables of a resource, e.g.
kubectl envx deployment/myapp
kubectl envx pod/myapp
kubectl envx job/myapp
kubectl envx cronjob/myapp
kubectl envx daemonset/myapp

# Print variables from specific namespace and container
kubectl envx deployment/myapp -n prod -c nginx

# Override variables
kubectl envx deployment/myapp DEBUG=true API_URL=http://localhost:8080

# Run command with variables
kubectl envx deployment/myapp -- env

# Use with docker (e.g. to run a local container with the extracted ENV variables)
# Note: This example uses process substitution, which is a bash feature.
# If you are using a different shell, you can save the output of `kubectl envx` to a file and use `--env-file` instead.
docker run --env-file <(kubectl envx deployment/postgres) -it alpine env
```