### PR TITLE
Add kubectl-node-debug plugin

### DIFF
--- a/plugins/node-debug.yaml
+++ b/plugins/node-debug.yaml
@@ -14,5 +14,5 @@ spec:
           os: linux
           arch: amd64
       uri: "https://github.com/tayeh/kubectl-node-debug/releases/download/v1.0.0/kubectl-node-debug.tar.gz"
-      sha256: "5d7040551bc8d92cfa120306e78c410091a8314551b388d1fed3f60c3fe38033"
+      sha256: "1da0d631c144efd8e3a6611dace1c463a63fced6e5f7910f5030f4a095e9d00c"
       bin: "kubectl-node-debug"

--- a/plugins/node-debug.yaml
+++ b/plugins/node-debug.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: node-debug
 spec:
-  version: "{{ .TagName }}"
+  version: "v1.0.0"
   homepage: "https://github.com/tayeh/kubectl-node-debug"
   shortDescription: "Interactive fzf-based Kubernetes node debugger"
   description: |
@@ -13,5 +13,6 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      {{addURIAndSha "https://github.com/tayeh/kubectl-node-debug/releases/download/{{ .TagName }}/kubectl-node-debug.tar.gz" .TagName }}
+      uri: "https://github.com/tayeh/kubectl-node-debug/releases/download/v1.0.0/kubectl-node-debug.tar.gz"
+      sha256: "5d7040551bc8d92cfa120306e78c410091a8314551b388d1fed3f60c3fe38033"
       bin: "kubectl-node-debug"

--- a/plugins/node-debug.yaml
+++ b/plugins/node-debug.yaml
@@ -1,0 +1,17 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: node-debug
+spec:
+  version: "{{ .TagName }}"
+  homepage: "https://github.com/tayeh/kubectl-node-debug"
+  shortDescription: "Interactive fzf-based Kubernetes node debugger"
+  description: |
+    Provides a simple CLI to list all Kubernetes nodes and enter a debug shell on a selected node.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      {{addURIAndSha "https://github.com/tayeh/kubectl-node-debug/releases/download/{{ .TagName }}/kubectl-node-debug.tar.gz" .TagName }}
+      bin: "kubectl-node-debug"


### PR DESCRIPTION
This PR adds kubectl-node-debug, a Krew plugin that allows users to debug Kubernetes nodes (access shell).
