### PR TITLE
Add slowdrain kubectl plugin

### DIFF
--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: slowdrain
+spec:
+  version: v0.1.2
+  homepage: https://github.com/cturiel/kubectl-slowdrain
+  shortDescription: Drains a Kubernetes node deleting application pods one by one with a delay
+  description: |
+    This plugin drains a Kubernetes node by removing application pods one by one
+    with a configurable delay between each deletion. This is useful to avoid
+    application downtime when draining a node with a large number of pods.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_linux_amd64.tar.gz
+    sha256: 0598c9b021705405295cbc810be253234abb3ac90e5d034738471022590cf950
+    bin: kubectl-slowdrain
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_arm64.tar.gz
+    sha256: b08945fbd7c7d77d8fa2328c2201eef043988425ac6d909a6fcc540b27c1f720
+    bin: kubectl-slowdrain
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_amd64.tar.gz
+    sha256: 7857b0df0ba13c3a080cb5d79b31703dcaa017edf0f74d8b3a1b0ff377a8d9e5
+    bin: kubectl-slowdrain
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_windows_amd64.zip
+    sha256: 491d58fcbfdce30d9ac4412f617adca0b8a7a2cd49fc1714311262eb1723c4fa
+    bin: kubectl-slowdrain
+  caveats: |
+    Usage:
+      $ kubectl slowdrain <node-name> --delay 30
+
+    For additional options:
+      $ kubectl slowdrain --help
+      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.2/doc/USAGE.md

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -23,14 +23,14 @@ spec:
         os: darwin
         arch: amd64
     uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_amd64.tar.gz
-    sha256: b08945fbd7c7d77d8fa2328c2201eef043988425ac6d909a6fcc540b27c1f720
+    sha256: 7857b0df0ba13c3a080cb5d79b31703dcaa017edf0f74d8b3a1b0ff377a8d9e5
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
     uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_arm64.tar.gz
-    sha256: 7857b0df0ba13c3a080cb5d79b31703dcaa017edf0f74d8b3a1b0ff377a8d9e5
+    sha256: b08945fbd7c7d77d8fa2328c2201eef043988425ac6d909a6fcc540b27c1f720
     bin: kubectl-slowdrain
   - selector:
       matchLabels:

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -38,7 +38,7 @@ spec:
         arch: amd64
     uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_windows_amd64.zip
     sha256: 491d58fcbfdce30d9ac4412f617adca0b8a7a2cd49fc1714311262eb1723c4fa
-    bin: kubectl-slowdrain
+    bin: kubectl-slowdrain.exe
   caveats: |
     Usage:
       $ kubectl slowdrain <node-name> --delay 30

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: slowdrain
 spec:
-  version: v0.1.4
+  version: v0.1.5
   homepage: https://github.com/cturiel/kubectl-slowdrain
   shortDescription: Drains a Kubernetes node deleting application pods one by one with a delay
   description: |
@@ -15,29 +15,29 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_linux_amd64.tar.gz
-    sha256: 8191d07c0e5e1c6caf050ba93f346dbad7901928b8d73b11958123ed76e85fc5
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_linux_amd64.tar.gz
+    sha256: e96b3e92a7db3a317f4ec936b7a79b19aa4a7b01fc240d5dc0d640d481f7672e
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_darwin_amd64.tar.gz
-    sha256: b944cf2a1e7dc24a13d70f37f8c90f299cf31d962cbe888a9bf93f02491fc63f
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_darwin_amd64.tar.gz
+    sha256: 46497b4432da5c05f28f73cae01bb7403d002546fabceffef8b453c7022f19aa
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_darwin_arm64.tar.gz
-    sha256: 372764b03a5240edbafc2d08636085bc4fe8b7bb8077e1c26f1dda1bd333dcd6
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_darwin_arm64.tar.gz
+    sha256: c89359a8c16c5f43d5fcd6dbed5a21fb4202409e979e43f2822d556af3b80bfc
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_windows_amd64.zip
-    sha256: c4a761ea2d70f51650b7f14f299114aba776b4ac7874ec2cefcd0f572e5ee498
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_windows_amd64.zip
+    sha256: 75ab886c4a0b5ef8ba2248c08e173356e75a4d28ba8c357fb6b21e9bc386f0ce
     bin: kubectl-slowdrain.exe
   caveats: |
     Usage:
@@ -45,4 +45,4 @@ spec:
 
     For additional options:
       $ kubectl slowdrain --help
-      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.4/doc/USAGE.md
+      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.5/doc/USAGE.md

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: slowdrain
 spec:
-  version: v0.1.3
+  version: v0.1.4
   homepage: https://github.com/cturiel/kubectl-slowdrain
   shortDescription: Drains a Kubernetes node deleting application pods one by one with a delay
   description: |
@@ -15,29 +15,29 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_linux_amd64.tar.gz
-    sha256: cccaaaf50cca8dcf0dff56f5cc1a0da3e1de9ecab2eb58ab42b5cca0781091bd
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_linux_amd64.tar.gz
+    sha256: 8191d07c0e5e1c6caf050ba93f346dbad7901928b8d73b11958123ed76e85fc5
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_darwin_amd64.tar.gz
-    sha256: 689bc4b6dda70165b21911cb897f23c2e1e87533bbd92508c49d97372d317149
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_darwin_amd64.tar.gz
+    sha256: b944cf2a1e7dc24a13d70f37f8c90f299cf31d962cbe888a9bf93f02491fc63f
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_darwin_arm64.tar.gz
-    sha256: a997ee8babdd84a11d39bfe22c9787864e29bbab89eb8019186438e44187605c
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_darwin_arm64.tar.gz
+    sha256: 372764b03a5240edbafc2d08636085bc4fe8b7bb8077e1c26f1dda1bd333dcd6
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_windows_amd64.zip
-    sha256: ebfd04f57b62ceb717d0a825f2129bbbac0ab4b76d875f0502c2387dedd226f4
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.4/kubectl-slowdrain_v0.1.4_windows_amd64.zip
+    sha256: c4a761ea2d70f51650b7f14f299114aba776b4ac7874ec2cefcd0f572e5ee498
     bin: kubectl-slowdrain.exe
   caveats: |
     Usage:
@@ -45,4 +45,4 @@ spec:
 
     For additional options:
       $ kubectl slowdrain --help
-      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.3/doc/USAGE.md
+      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.4/doc/USAGE.md

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -22,14 +22,14 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_arm64.tar.gz
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_amd64.tar.gz
     sha256: b08945fbd7c7d77d8fa2328c2201eef043988425ac6d909a6fcc540b27c1f720
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_amd64.tar.gz
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_arm64.tar.gz
     sha256: 7857b0df0ba13c3a080cb5d79b31703dcaa017edf0f74d8b3a1b0ff377a8d9e5
     bin: kubectl-slowdrain
   - selector:

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -3,9 +3,9 @@ kind: Plugin
 metadata:
   name: slowdrain
 spec:
-  version: v0.1.5
+  version: v0.1.6
   homepage: https://github.com/cturiel/kubectl-slowdrain
-  shortDescription: Drains a Kubernetes node deleting application pods one by one with a delay
+  shortDescription: Drains a node, deleting app pods one by one with delay
   description: |
     This plugin drains a Kubernetes node by removing application pods one by one
     with a configurable delay between each deletion. This is useful to avoid
@@ -15,34 +15,27 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_linux_amd64.tar.gz
-    sha256: e96b3e92a7db3a317f4ec936b7a79b19aa4a7b01fc240d5dc0d640d481f7672e
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.6/kubectl-slowdrain_v0.1.6_linux_amd64.tar.gz
+    sha256: e8664b949cac9e16f3f8787a0742e945055952e52e9b591223a9e74ac20ebf28
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_darwin_amd64.tar.gz
-    sha256: 46497b4432da5c05f28f73cae01bb7403d002546fabceffef8b453c7022f19aa
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.6/kubectl-slowdrain_v0.1.6_darwin_amd64.tar.gz
+    sha256: c745b1905c2b200045b431697a01b6e574cf3cf184da694644ccb2399836f7dd
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_darwin_arm64.tar.gz
-    sha256: c89359a8c16c5f43d5fcd6dbed5a21fb4202409e979e43f2822d556af3b80bfc
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.6/kubectl-slowdrain_v0.1.6_darwin_arm64.tar.gz
+    sha256: d3eff94ae70df63ad907cc405887d03fbb01ed9180643f852de67a5374b6840e
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.5/kubectl-slowdrain_v0.1.5_windows_amd64.zip
-    sha256: 75ab886c4a0b5ef8ba2248c08e173356e75a4d28ba8c357fb6b21e9bc386f0ce
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.6/kubectl-slowdrain_v0.1.6_windows_amd64.zip
+    sha256: 27ac4d770d2136f5dffeac887d2b9586d2f73d66641047f10c3e63c881a126d7
     bin: kubectl-slowdrain.exe
-  caveats: |
-    Usage:
-      $ kubectl slowdrain <node-name> --delay 30
-
-    For additional options:
-      $ kubectl slowdrain --help
-      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.5/doc/USAGE.md

--- a/plugins/slowdrain.yaml
+++ b/plugins/slowdrain.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: slowdrain
 spec:
-  version: v0.1.2
+  version: v0.1.3
   homepage: https://github.com/cturiel/kubectl-slowdrain
   shortDescription: Drains a Kubernetes node deleting application pods one by one with a delay
   description: |
@@ -15,29 +15,29 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_linux_amd64.tar.gz
-    sha256: 0598c9b021705405295cbc810be253234abb3ac90e5d034738471022590cf950
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_linux_amd64.tar.gz
+    sha256: cccaaaf50cca8dcf0dff56f5cc1a0da3e1de9ecab2eb58ab42b5cca0781091bd
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_amd64.tar.gz
-    sha256: 7857b0df0ba13c3a080cb5d79b31703dcaa017edf0f74d8b3a1b0ff377a8d9e5
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_darwin_amd64.tar.gz
+    sha256: 689bc4b6dda70165b21911cb897f23c2e1e87533bbd92508c49d97372d317149
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_darwin_arm64.tar.gz
-    sha256: b08945fbd7c7d77d8fa2328c2201eef043988425ac6d909a6fcc540b27c1f720
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_darwin_arm64.tar.gz
+    sha256: a997ee8babdd84a11d39bfe22c9787864e29bbab89eb8019186438e44187605c
     bin: kubectl-slowdrain
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.2/kubectl-slowdrain_v0.1.2_windows_amd64.zip
-    sha256: 491d58fcbfdce30d9ac4412f617adca0b8a7a2cd49fc1714311262eb1723c4fa
+    uri: https://github.com/cturiel/kubectl-slowdrain/releases/download/v0.1.3/kubectl-slowdrain_v0.1.3_windows_amd64.zip
+    sha256: ebfd04f57b62ceb717d0a825f2129bbbac0ab4b76d875f0502c2387dedd226f4
     bin: kubectl-slowdrain.exe
   caveats: |
     Usage:
@@ -45,4 +45,4 @@ spec:
 
     For additional options:
       $ kubectl slowdrain --help
-      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.2/doc/USAGE.md
+      or https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.3/doc/USAGE.md


### PR DESCRIPTION
**Title:** Add `kubectl-slowdrain` plugin  

**Description:**  
This PR adds `kubectl-slowdrain`, a plugin that allows controlled draining of Kubernetes nodes by deleting application pods **one by one** with a **configurable delay** between deletions.  

### **Why this plugin?**  
- Helps reduce downtime when draining nodes with a large number of pods.  
- Avoids overwhelming the cluster by gradually removing pods.  
- Useful in scenarios where **Pod Disruption Budgets (PDBs) are misconfigured** or too restrictive.  

### **Key Features:**  
✅ Configurable delay between pod deletions.  
✅ Works without relying on the Eviction API.  
✅ Supports Linux, macOS (AMD64 & ARM64), and Windows.  

### **Usage Example:**  
```sh
kubectl slowdrain <node-name> --delay 30
```
For more details, check the [usage guide](https://github.com/cturiel/kubectl-slowdrain/blob/v0.1.5/doc/USAGE.md). 

Let me know if there's anything that needs adjustment!

