### PR TITLE
add cnp-viz plugin

### DIFF
--- a/plugins/cnp-viz.yaml
+++ b/plugins/cnp-viz.yaml
@@ -1,0 +1,83 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cnp-viz
+spec:
+  version: "v0.1.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: "https://github.com/mostafahussein/kubectl-cnp-viz/releases/download/v0.1.0/kubectl-cnp-viz_linux_amd64.tar.gz"
+    sha256: d3a90e3eb29b300cdc87bcdd0e094e4a20adab018640c3371aec1becda82f1bb
+    files:
+    - from: "./kubectl-cnp-viz"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "kubectl-cnp-viz"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: "https://github.com/mostafahussein/kubectl-cnp-viz/releases/download/v0.1.0/kubectl-cnp-viz_darwin_amd64.tar.gz"
+    sha256: 4db9cfc3e3cc2a3e270ad5a398e153425e0b7e020eb9f2539354809f59c378f3
+    files:
+    - from: "./kubectl-cnp-viz"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "kubectl-cnp-viz"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: "https://github.com/mostafahussein/kubectl-cnp-viz/releases/download/v0.1.0/kubectl-cnp-viz_windows_amd64.zip"
+    sha256: 492386ccfaf1af8cb38350dd97c602d79cd19ef0b3f7c6369a149af1fbad760d
+    files:
+    - from: "/kubectl-cnp-viz.exe"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "kubectl-cnp-viz.exe"
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: "https://github.com/mostafahussein/kubectl-cnp-viz/releases/download/v0.1.0/kubectl-cnp-viz_linux_arm64.tar.gz"
+    sha256: 21d1830830c8d3fd151cc199ce311ae0ab8e6d65ce943cf50c2580c83cff89a0
+    files:
+    - from: "./kubectl-cnp-viz"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "kubectl-cnp-viz"
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: "https://github.com/mostafahussein/kubectl-cnp-viz/releases/download/v0.1.0/kubectl-cnp-viz_darwin_arm64.tar.gz"
+    sha256: ddb2972322b8f203f13fd6ca270d9b698768afa198675c47ae31aeef31321b8a
+    files:
+    - from: "./kubectl-cnp-viz"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "kubectl-cnp-viz"
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: "https://github.com/mostafahussein/kubectl-cnp-viz/releases/download/v0.1.0/kubectl-cnp-viz_windows_arm64.zip"
+    sha256: e2da8163668ad9cb650c789589aad852f6bf5eaf6876af5994202888e5764a1a
+    files:
+    - from: "./kubectl-cnp-viz.exe"
+      to: "."
+    - from: "LICENSE"
+      to: "."
+    bin: "kubectl-cnp-viz.exe"
+  shortDescription: Visualize Cilium Network Policies without leaving the terminal
+  homepage: https://github.com/mostafahussein/kubectl-cnp-viz
+  description: |
+    Visualize Cilium Network Policies without leaving the terminal


### PR DESCRIPTION
I would like to add my plugin to `krew-index` to make it installable through krew

`cnp-viz` (CiliumNetworkPolicy Visualizer) helps in visualizing CiliumNetworkPolicy without leaving your terminal.
installation verification:

```
❯ kubectl krew install --manifest=deploy/krew/plugin.yaml
Installing plugin: cnp-viz
Installed plugin: cnp-viz
\
 | Use this plugin:
 |      kubectl cnp-viz
 | Documentation:
 |      https://github.com/mostafahussein/kubectl-cnp-viz
/
```