### PR TITLE
bump sql plugin to v0.3.27

### DIFF
--- a/plugins/sql.yaml
+++ b/plugins/sql.yaml
@@ -3,15 +3,15 @@ kind: Plugin
 metadata:
   name: sql
 spec:
-  version: v0.3.25
+  version: v0.3.27
   homepage: https://github.com/yaacov/kubectl-sql
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/yaacov/kubectl-sql/releases/download/v0.3.25/kubectl-sql.tar.gz
-    sha256: 16621bc5766c9b07c5fcf56982886176fba82137a28670c4b67798541475a141
+    uri: https://github.com/yaacov/kubectl-sql/releases/download/v0.3.27/kubectl-sql.tar.gz
+    sha256: ae878e98648e09847c5055926a9988f17fdd30958769dff91426d9808b697769
     bin: kubectl-sql
   shortDescription: Query the cluster via pseudo-SQL
   description: |


### PR DESCRIPTION
bump sql plugin to v0.3.27
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
