### PR TITLE
Add kubectl health plugin

### DIFF
--- a/plugins/health.yaml
+++ b/plugins/health.yaml
@@ -1,0 +1,55 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: health
+spec:
+  homepage: https://github.com/iNecas/kube-health
+  shortDescription: An easy way to determine the health of Kubernetes resources
+  version: v0.3.1
+  description: |
+    kube-health is a kubectl plugin to evaluate the health of Kubernetes
+    resources. It aims at unifying and making it easier to understand the health
+    of individual objects without requiring to know all the nuances of different
+    kinds.
+
+    It provides:
+      - unified reporting on health and progressing of kubernetes objects
+      - decomposing the health of high-level objets to lower-level components
+      - waiting for reconciliation
+      - ability to combine with `kubectl apply` and other commands
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/iNecas/kube-health/releases/download/v0.3.1/kube-health_Darwin_x86_64.tar.gz
+      sha256: cd0fd07db64947ba6d932809a1af38d66ded52f24e46756a04de35a18ed24ac7
+      bin: kube-health
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/iNecas/kube-health/releases/download/v0.3.1/kube-health_Darwin_arm64.tar.gz
+      sha256: f00302a7e7641700ed94b7f2e60a4077d9dc304a681839fc5d6a3c99db3b9505
+      bin: kube-health
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/iNecas/kube-health/releases/download/v0.3.1/kube-health_Linux_x86_64.tar.gz
+      sha256: 1c8b07bf11c945719b11716d4b98c1c50f0069203d03d4fac5e46bbe237e07bb
+      bin: kube-health
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/iNecas/kube-health/releases/download/v0.3.1/kube-health_Linux_arm64.tar.gz
+      sha256: 4e57ee271636edea6735e8836cdcfa5a578e317a5b3c4f4c101e0c2fbb4e2db1
+      bin: kube-health
+    - selector:
+        matchLabels:
+          os: linux
+          arch: 386
+      uri: https://github.com/iNecas/kube-health/releases/download/v0.3.1/kube-health_Linux_i386.tar.gz
+      sha256: 206002d6942db284c0950ee2bf1638aa7f9d87698b45a87787116c2d4afd38e6
+      bin: kube-health

--- a/plugins/health.yaml
+++ b/plugins/health.yaml
@@ -4,7 +4,7 @@ metadata:
   name: health
 spec:
   homepage: https://github.com/iNecas/kube-health
-  shortDescription: An easy way to determine the health of Kubernetes resources
+  shortDescription: Determine the health of Kubernetes resources
   version: v0.3.1
   description: |
     kube-health is a kubectl plugin to evaluate the health of Kubernetes


### PR DESCRIPTION
Project link: https://github.com/inecas/kube-health

**Description**
kube-health is a kubectl plugin to evaluate the health of Kubernetes resources. It aims at unifying and making it easier to understand the health of individual objects without requiring to know all the nuances of different kinds.

**Features available:**
- unified reporting on health and progressing of kubernetes objects
- decomposing the health of high-level objets to lower-level components
- waiting for reconciliation
- ability to combine with `kubectl apply` and other commands

![screenshot](https://raw.githubusercontent.com/iNecas/kube-health/refs/heads/main/docs/screenshot.svg)

![demo](https://raw.githubusercontent.com/iNecas/kube-health/refs/heads/main/docs/demo.svg)


