### PR TITLE
bump ray plugin version to v1.3.2

### DIFF
--- a/plugins/ray.yaml
+++ b/plugins/ray.yaml
@@ -3,36 +3,36 @@ kind: Plugin
 metadata:
   name: ray
 spec:
-  version: v1.3.0
+  version: v1.3.2
   homepage: https://github.com/ray-project/kuberay/tree/master/kubectl-plugin
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.0/kubectl-ray_v1.3.0_darwin_amd64.tar.gz
-      sha256: 64c4075be372b4b924bc4725e94713a21c494e2069a26db61611e7fa818b7a75
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.2/kubectl-ray_v1.3.2_darwin_amd64.tar.gz
+      sha256: af647a673a55239bec2ca7d76ca7a9defb3d4a58a7f1e542d96ababb7885e236
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.0/kubectl-ray_v1.3.0_darwin_arm64.tar.gz
-      sha256: 62d4c2460d5a327b5ffe915f4967ca3646dce884e7ee7b859f6e00a48f3c6ffe
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.2/kubectl-ray_v1.3.2_darwin_arm64.tar.gz
+      sha256: cd6e7196f646701dfdd56f6573ed19609d827dcd0c3a502b78c932962a3eb526
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.0/kubectl-ray_v1.3.0_linux_amd64.tar.gz
-      sha256: 7bb219666fb8eb7abde79d10e4e95bc2c8ed06ddc98a08a3f6aacbc8383c9844
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.2/kubectl-ray_v1.3.2_linux_amd64.tar.gz
+      sha256: c9213c36657d12668ef5d8877a4ef8cab7d4fd64117333cab3ab6abc990aab5d
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.0/kubectl-ray_v1.3.0_linux_arm64.tar.gz
-      sha256: 3d93bdd3bad60fa55e14419911df7a0992eacb8051e1e513ea4c78b280eed0c8
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.3.2/kubectl-ray_v1.3.2_linux_arm64.tar.gz
+      sha256: 472b9082f2c614c2be744f2c8b04d4623f831d2f2bd97520b14d2df7212d245b
       bin: kubectl-ray
   shortDescription: Ray kubectl plugin
   description: |


### PR DESCRIPTION
Bump ray plugin version to v1.3.2.

This is based on automated version bump in https://github.com/kubernetes-sigs/krew-index/pull/4527 that is not auto-merging due to changes to formatting.