### PR TITLE
add kubectl resource-backup plugin

### DIFF
--- a/plugins/backup.yaml
+++ b/plugins/backup.yaml
@@ -1,0 +1,64 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: backup
+spec:
+  version: v0.1.0
+  homepage: https://github.com/zak905/kubectl-backup
+  shortDescription: kubectl plugin for backing up resources (like CRDs) to local disk
+  description: |
+    kubectl plugin that backs up Kubernetes objects (including CRDs) to the local file system. 
+    Before saving any resource, the plugin does some additional processing to remove:
+    - the status stanza if the object has any.
+    - the server generated fields from the object metadata. 
+    - any field with a null value.
+    The plugin aims to make the saved objects look like the original creation request.
+  caveats: |
+    the plugin does not remove the fields that has a default value (unlike the neat plugin) 
+    because it's not possible to make a distinction between a value set by a creation/update 
+    request and a value set by a controller or a mutating admission webhook.
+    See "kubectl backup --help"
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_darwin_amd64.tar.gz
+    sha256: 9576d0e7a4aa659ed98b74aafd3d26ad81ed4e6a0d939113cea395748c8306fe
+    bin: kubectl-backup
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_darwin_arm64.tar.gz
+    sha256: fb8ffd99584f4c531a6f1e16d27c7b9845e5899c620d71734dcc50913af3b37d
+    bin: kubectl-backup
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_linux_amd64.tar.gz
+    sha256: 8681e2dc6b09d3b73a8c803fa28178061b11734e21c94aa0be4323d9d73f8b22
+    bin: kubectl-backup
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_linux_arm64.tar.gz
+    sha256: cc1133f5e113ac45c88679798b7dc027f2f713d9fc483177d0dc28016fcf2f64
+    bin: kubectl-backup
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_windows_amd64.tar.gz
+    sha256: a78eb8828db416a6c987c5389c41460e8ba9318b5653fa6938f86c32dccdcdac
+    bin: kubectl-backup.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_windows_arm64.tar.gz
+    sha256: c7dac8668760570c83ea4a456cb3bceb72bf30afd4fa7c2f1cf7986d22cb35bf
+    bin: kubectl-backup.exe
+

--- a/plugins/backup.yaml
+++ b/plugins/backup.yaml
@@ -5,19 +5,19 @@ metadata:
 spec:
   version: v0.1.0
   homepage: https://github.com/zak905/kubectl-backup
-  shortDescription: kubectl plugin for backing up resources (like CRDs) to local disk
+  shortDescription: back up K8 resources (like CRDs) to local disk
   description: |
-    kubectl plugin that backs up Kubernetes objects (including CRDs) to the local file system. 
-    Before saving any resource, the plugin does some additional processing to remove:
+    Backs up Kubernetes objects (including CRDs) to the local file system. 
+    Before saving any resource, some additional processing is done to remove:
     - the status stanza if the object has any.
     - the server generated fields from the object metadata. 
     - any field with a null value.
-    The plugin aims to make the saved objects look like the original creation request.
+    The aims is to make the saved objects look like the original creation request.
   caveats: |
-    the plugin does not remove the fields that has a default value (unlike the neat plugin) 
-    because it's not possible to make a distinction between a value set by a creation/update 
-    request and a value set by a controller or a mutating admission webhook.
-    See "kubectl backup --help"
+    The fields that has a default value are not removed (unlike the neat plugin)  
+    because it's not possible to make a distinction between a value set 
+    by a creation/update request and a value set by a controller 
+    or a mutating admission webhook.
   platforms:
   - selector:
       matchLabels:

--- a/plugins/resource-backup.yaml
+++ b/plugins/resource-backup.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.1.0
   homepage: https://github.com/zak905/kubectl-resource-backup
-  shortDescription: back up K8 resources (like CRDs) to local disk
+  shortDescription: Save Kubernetes resources to disk
   description: |
     Backs up Kubernetes objects (including CRDs) to the local file system. 
     Before saving any resource, some additional processing is done to remove:

--- a/plugins/resource-backup.yaml
+++ b/plugins/resource-backup.yaml
@@ -1,10 +1,10 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: backup
+  name: resource-backup
 spec:
   version: v0.1.0
-  homepage: https://github.com/zak905/kubectl-backup
+  homepage: https://github.com/zak905/kubectl-resource-backup
   shortDescription: back up K8 resources (like CRDs) to local disk
   description: |
     Backs up Kubernetes objects (including CRDs) to the local file system. 
@@ -23,42 +23,42 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_darwin_amd64.tar.gz
+    uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_darwin_amd64.tar.gz
     sha256: 9576d0e7a4aa659ed98b74aafd3d26ad81ed4e6a0d939113cea395748c8306fe
-    bin: kubectl-backup
+    bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_darwin_arm64.tar.gz
+    uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_darwin_arm64.tar.gz
     sha256: fb8ffd99584f4c531a6f1e16d27c7b9845e5899c620d71734dcc50913af3b37d
-    bin: kubectl-backup
+    bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_linux_amd64.tar.gz
+    uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_linux_amd64.tar.gz
     sha256: 8681e2dc6b09d3b73a8c803fa28178061b11734e21c94aa0be4323d9d73f8b22
-    bin: kubectl-backup
+    bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_linux_arm64.tar.gz
+    uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_linux_arm64.tar.gz
     sha256: cc1133f5e113ac45c88679798b7dc027f2f713d9fc483177d0dc28016fcf2f64
-    bin: kubectl-backup
+    bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_windows_amd64.tar.gz
+    uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_windows_amd64.tar.gz
     sha256: a78eb8828db416a6c987c5389c41460e8ba9318b5653fa6938f86c32dccdcdac
-    bin: kubectl-backup.exe
+    bin: kubectl-resource-backup.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/zak905/kubectl-backup/releases/download/v0.1.0/kubectl-backup_windows_arm64.tar.gz
+    uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_windows_arm64.tar.gz
     sha256: c7dac8668760570c83ea4a456cb3bceb72bf30afd4fa7c2f1cf7986d22cb35bf
-    bin: kubectl-backup.exe
+    bin: kubectl-resource-backup.exe
 

--- a/plugins/resource-backup.yaml
+++ b/plugins/resource-backup.yaml
@@ -24,41 +24,41 @@ spec:
         os: darwin
         arch: amd64
     uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_darwin_amd64.tar.gz
-    sha256: 9576d0e7a4aa659ed98b74aafd3d26ad81ed4e6a0d939113cea395748c8306fe
+    sha256: 0d0d872aa1d5fabd693cb1b46d70d3507885af3b6cb3b8ead28784ba6e358bc6
     bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
     uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_darwin_arm64.tar.gz
-    sha256: fb8ffd99584f4c531a6f1e16d27c7b9845e5899c620d71734dcc50913af3b37d
+    sha256: 6ed2239980b539937ed4780bbdcf62cc2bfe70cd20f0b89359987168d53e9c76
     bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: linux
         arch: amd64
     uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_linux_amd64.tar.gz
-    sha256: 8681e2dc6b09d3b73a8c803fa28178061b11734e21c94aa0be4323d9d73f8b22
+    sha256: 134406671af6379a9d68bd22d33fcb9f4f3fbcd0a49d6ba46fc4d4eb48a5c347
     bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: linux
         arch: arm64
     uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_linux_arm64.tar.gz
-    sha256: cc1133f5e113ac45c88679798b7dc027f2f713d9fc483177d0dc28016fcf2f64
+    sha256: abb83f480e7e16590a15c3918118df8d9579d71bbafc48ade0e143d883ab7ea1
     bin: kubectl-resource-backup
   - selector:
       matchLabels:
         os: windows
         arch: amd64
     uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_windows_amd64.tar.gz
-    sha256: a78eb8828db416a6c987c5389c41460e8ba9318b5653fa6938f86c32dccdcdac
+    sha256: b9747ee18d7d357933b434f06e94a3f9385334dc548ada3b62e9a4a23870c500
     bin: kubectl-resource-backup.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
     uri: https://github.com/zak905/kubectl-resource-backup/releases/download/v0.1.0/kubectl-resource-backup_windows_arm64.tar.gz
-    sha256: c7dac8668760570c83ea4a456cb3bceb72bf30afd4fa7c2f1cf7986d22cb35bf
+    sha256: 97e62b11b691c1951d55fc1f5cc53f06abb19bf078fed003fa6999bad0f51449
     bin: kubectl-resource-backup.exe
 


### PR DESCRIPTION
kubectl plugin that backs up Kubernetes objects (including CRDs) to the local file system (like Velero). Before saving any resource, the plugin does some additional processing to remove:
* the status stanza if the object has any.
* the server generated fields from the object metadata.
* any field with a null value.

The plugin aims to make the saved objects look like the original creation request.

Usage example: `kubectl resource-backup [<flags>] <resource>` where resource can be any resource kind (single name, lower case). 

The saved object files are named as follow: NAME_TYPE_NAMESPACE.yaml. For example, deployment1_deployment_ns.yaml

if the resource is not namespaced the namespace is omitted.

More details can be found on project README: https://github.com/zak905/kubectl-backup
