### PR TITLE
Bump mtv to v0.1.10

### DIFF
--- a/plugins/mtv.yaml
+++ b/plugins/mtv.yaml
@@ -3,15 +3,15 @@ kind: Plugin
 metadata:
   name: mtv
 spec:
-  version: v0.1.9
+  version: v0.1.10
   homepage: https://github.com/yaacov/kubectl-mtv
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/yaacov/kubectl-mtv/releases/download/v0.1.9/kubectl-mtv.tar.gz
-    sha256: af0ac10ee5a2c979519a31f110d008fe8c52506c260fc74640e73592cfd7dd81
+    uri: https://github.com/yaacov/kubectl-mtv/releases/download/v0.1.10/kubectl-mtv.tar.gz
+    sha256: 8e9be4c278e9a7883a74f5d6862dddced827e0bf1ed24665b4993ca5d8865d2e
     bin: kubectl-mtv
   shortDescription: Migrate virtualization workloads to KubeVirt
   description: |


### PR DESCRIPTION
Bump mtv to v0.1.10
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
