### PR TITLE
Bump mtv to v0.1.11

### DIFF
--- a/plugins/mtv.yaml
+++ b/plugins/mtv.yaml
@@ -3,15 +3,15 @@ kind: Plugin
 metadata:
   name: mtv
 spec:
-  version: v0.1.10
+  version: v0.1.11
   homepage: https://github.com/yaacov/kubectl-mtv
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/yaacov/kubectl-mtv/releases/download/v0.1.10/kubectl-mtv.tar.gz
-    sha256: 8e9be4c278e9a7883a74f5d6862dddced827e0bf1ed24665b4993ca5d8865d2e
+    uri: https://github.com/yaacov/kubectl-mtv/releases/download/v0.1.11/kubectl-mtv.tar.gz
+    sha256: 9195eb2e05e62e3dcb6e310683103f79479532539711a731a645d0a89bbbe66f
     bin: kubectl-mtv
   shortDescription: Migrate virtualization workloads to KubeVirt
   description: |


### PR DESCRIPTION
Bump mtv to v0.1.11
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
