### PR TITLE
Adds kubectl-preq problem detector

### DIFF
--- a/plugins/preq.yaml
+++ b/plugins/preq.yaml
@@ -106,7 +106,7 @@ spec:
       uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_windows-amd64.tar.gz
       files:
         - from: kubectl-preq_windows-amd64.exe
-          to: kubectl-preq.exe
+          to: kubectl-preq
         - from: kubectl-preq_windows-amd64.sig
           to: kubectl-preq.sig
         - from: LICENSE

--- a/plugins/preq.yaml
+++ b/plugins/preq.yaml
@@ -1,0 +1,113 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: preq
+  annotations:
+    # List of annotations for Artifact Hub
+    # https://artifacthub.io/docs/topics/annotations/krew/
+    artifacthub.io/category: monitoring-logging
+    artifacthub.io/displayName: preq problem detector
+    artifacthub.io/keywords: |
+      - reliability
+      - problem detection
+      - common reliability enumerations
+      - reliability intelligence
+    artifacthub.io/license: Apache-2.0
+    artifacthub.io/links: |
+      - name: homepage
+        url: https://docs.prequel.dev
+      - name: repository
+        url: https://github.com/prequel-dev/preq/
+      - name: support
+        url: https://github.com/prequel-dev/preq/issues
+    artifacthub.io/readme: |
+      `preq` (prounounced "preek") is a free and open community-driven reliability problem detector. Use `preq` to:
+
+      * detect the latest bugs, misconfigurations, anti-patterns, and known issues from a community of practitioners
+      * provide engineers, on-call support, and SRE agents with impact and community recommended mitigations
+      * hunt for new problems in logs
+
+      `preq` is powered by Common Reliability Enumerations (CREs) that are contributed by the community and [Prequel's Reliability Research Team](https://prequel.dev/blog). Reliability intelligence helps teams see a broad range of problems earlier, so they can prioritize, pinpoint, and reduce the risk of outages.
+
+      Visit https://docs.prequel.dev for more information.
+
+      ## Install
+
+      ```bash
+      $ kubectl krew install preq
+      $ kubectl preq <pod> -a -o "CRE Slack notification: "
+      ```
+    # artifacthub.io/changes:
+    # artifacthub.io/maintainers:
+    # artifacthub.io/provider:
+    # artifacthub.io/recommendations:
+    # artifacthub.io/screenshots:
+spec:
+  version: v0.1.9
+  homepage: https://github.com/prequel-dev/preq
+  shortDescription: "Use common reliability enumerations (CREs) to detect problems" 
+  description: |
+    preq (prounounced "preek") is a free and open community-driven reliability problem detector. Use preq to detect
+    the latest bugs, misconfigurations, anti-patterns, and known issues from a community of practitioners. 
+    CREs provide engineers, on-call support, and SRE agents with impact and community recommended mitigations.
+
+    preq is powered by Common Reliability Enumerations (CREs) that are contributed by the problem detection community and Prequel's Reliability Research Team. Reliability intelligence helps teams see a broad range of problems earlier, so they can prioritize, pinpoint, and reduce the risk of outages.
+
+    Visit https://docs.prequel.dev for more information.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      sha256: e169ecc5aae11d2106f23ec28294d56a87871b36e76e862af1a5992127617171
+      bin: kubectl-preq
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_linux-amd64.tar.gz
+      files:
+        - from: kubectl-preq_linux-amd64
+          to: kubectl-preq
+        - from: kubectl-preq_linux-amd64.sig
+          to: kubectl-preq.sig
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      sha256: 2b133ce54e85878103f7e827e38eadd8f52aff98c6b11d2c5810b0784b08f04a
+      bin: kubectl-preq
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_linux-arm64.tar.gz
+      files:
+        - from: kubectl-preq_linux-arm64
+          to: kubectl-preq
+        - from: kubectl-preq_linux-arm64.sig
+          to: kubectl-preq.sig
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      sha256: e2137d5ddbb7978190796a16e21911a5f2571b75631474d084f46282447cf09c
+      bin: kubectl-preq
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_darwin-arm64.tar.gz
+      files:
+        - from: kubectl-preq_darwin-arm64
+          to: kubectl-preq
+        - from: kubectl-preq_darwin-arm64.sig
+          to: kubectl-preq.sig
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      sha256: 446178f487e8c95ef033e38a81f1a9050997cb73730ec3e909502461c608a5d8
+      bin: kubectl-preq
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_windows-amd64.tar.gz
+      files:
+        - from: kubectl-preq_windows-amd64.exe
+          to: kubectl-preq.exe
+        - from: kubectl-preq_windows-amd64.sig
+          to: kubectl-preq.sig
+        - from: LICENSE
+          to: .


### PR DESCRIPTION
Hey, folks! Thanks for all the hard work over the years with Krew. Happy to answer any questions and would love your feedback on this new plugin.

### `kubectl-preq` overview

preq (prounounced "preek") is a free and open (Apache 2.0) community-driven reliability problem detector. 

- detect the latest bugs, misconfigurations, anti-patterns, and known issues from a community of practitioners
- provide engineers, on-call support, and SRE agents with impact and community recommended mitigations
- hunt for new problems in logs

preq is powered by Common Reliability Enumerations (CREs) that are contributed by the problem detection community.

### Build process

We have an internal build process that we use for signing binaries for all platform/architectures with ECDSA. The macOS builds of the Krew plugin are also signed/notarized by an Apple certificate. If accepted, we will update our build process to support https://krew.sigs.k8s.io/docs/developer-guide/release/automating-updates.

### References

* https://docs.prequel.dev/
* https://github.com/prequel-dev/preq
* https://github.com/prequel-dev/cre
* https://github.com/prequel-dev/preq/releases/tag/v0.1.9