### PR TITLE
Bump kubectl-preq to v0.1.12

### DIFF
--- a/plugins/preq.yaml
+++ b/plugins/preq.yaml
@@ -106,7 +106,7 @@ spec:
       uri: https://github.com/prequel-dev/preq/releases/download/v0.1.12/kubectl-preq_windows-amd64.tar.gz
       files:
         - from: kubectl-preq_windows-amd64.exe
-          to: kubectl-preq.exe
+          to: kubectl-preq
         - from: kubectl-preq_windows-amd64.sig
           to: kubectl-preq.sig
         - from: LICENSE

--- a/plugins/preq.yaml
+++ b/plugins/preq.yaml
@@ -43,7 +43,7 @@ metadata:
     # artifacthub.io/recommendations:
     # artifacthub.io/screenshots:
 spec:
-  version: v0.1.9
+  version: v0.1.12
   homepage: https://github.com/prequel-dev/preq
   shortDescription: "Use common reliability enumerations (CREs) to detect problems" 
   description: |
@@ -59,9 +59,9 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      sha256: e169ecc5aae11d2106f23ec28294d56a87871b36e76e862af1a5992127617171
+      sha256: 11ba5c6ec178193e35b2971c4975cce767ae995f61e73478fa11b92c346abcff
       bin: kubectl-preq
-      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_linux-amd64.tar.gz
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.12/kubectl-preq_linux-amd64.tar.gz
       files:
         - from: kubectl-preq_linux-amd64
           to: kubectl-preq
@@ -73,9 +73,9 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      sha256: 2b133ce54e85878103f7e827e38eadd8f52aff98c6b11d2c5810b0784b08f04a
+      sha256: 97ef70d4de7ea5c4002075928f74e6c28819ea4217deedcaa54624df5ee667f5
       bin: kubectl-preq
-      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_linux-arm64.tar.gz
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.12/kubectl-preq_linux-arm64.tar.gz
       files:
         - from: kubectl-preq_linux-arm64
           to: kubectl-preq
@@ -87,9 +87,9 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      sha256: e2137d5ddbb7978190796a16e21911a5f2571b75631474d084f46282447cf09c
+      sha256: 623a3273eeeda445cfc0ac0c32422a4945f9b913d0a54cc5bda97b02d3c14359
       bin: kubectl-preq
-      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_darwin-arm64.tar.gz
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.12/kubectl-preq_darwin-arm64.tar.gz
       files:
         - from: kubectl-preq_darwin-arm64
           to: kubectl-preq
@@ -101,12 +101,12 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      sha256: 446178f487e8c95ef033e38a81f1a9050997cb73730ec3e909502461c608a5d8
+      sha256: 1d02450e8a89d3e93256550eed20b8c6f4b9ce29c4b754a010824e395f5c75ea
       bin: kubectl-preq
-      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.9/kubectl-preq_windows-amd64.tar.gz
+      uri: https://github.com/prequel-dev/preq/releases/download/v0.1.12/kubectl-preq_windows-amd64.tar.gz
       files:
         - from: kubectl-preq_windows-amd64.exe
-          to: kubectl-preq
+          to: kubectl-preq.exe
         - from: kubectl-preq_windows-amd64.sig
           to: kubectl-preq.sig
         - from: LICENSE


### PR DESCRIPTION
- Bump reversion to v0.1.12
- https://github.com/prequel-dev/preq/releases/tag/v0.1.12