### PR TITLE
Add xdsnap plugin

### DIFF
--- a/plugins/xdsnap.yaml
+++ b/plugins/xdsnap.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: xdsnap
 spec:
-  version: "v0.2.3"
+  version: "v0.2.5"
   homepage: "https://github.com/markcampv/xdsnap"
   shortDescription: "Capture Envoy xDS snapshots and endpoints from Consul service mesh"
   description: |
@@ -17,19 +17,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_linux_amd64.tar.gz
-      sha256: a78f455d96389c4f91acee6e8de68f2cef2659b00d9bf8c6515c3939b2f84a55
-      bin: kubectl-xdsnap
-      files:
-        - from: kubectl-xdsnap
-          to: .
-
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_linux_arm64.tar.gz
-      sha256: 62bf78749de8b756b5873af4788528cdb44ab93ef201b7fd01f24fcfbdf365f9
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_linux_amd64.tar.gz
+      sha256: 494b02c32e5c01378de3cbdf1ed472313d6a4a4e6fe74dc8b7004b700ef9c8a8
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
@@ -39,8 +28,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_darwin_amd64.tar.gz
-      sha256: 00edae05802007c9958244aa242db1da202afa55ecab8e98aa0a05d1420c782a
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_darwin_amd64.tar.gz
+      sha256: 28d5b7f4a38035ece6e0a796dc4423d6ce52ea9c8ddc6603df00ea9afdd45f28
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
@@ -50,8 +39,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_darwin_arm64.tar.gz
-      sha256: 68787bd1840cee31bb76ce60eec55d060976c76f7acc6da85147bce4aac4e96b
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_darwin_arm64.tar.gz
+      sha256: cde4823c78a84a9dd63c4444a0e85405ca6877500fbcf097ab701e4a3bfa9b59
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
@@ -61,8 +50,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_windows_amd64.tar.gz
-      sha256: a71a7204484498c01c6251a5a763ecc5dca5f8fc569658ea7a2643b7fe35d749
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_windows_amd64.tar.gz
+      sha256: c0d9501a4042b3c188cf58f36ff70848d5e22e6495302efbddb1b5c7fef248a0
       bin: kubectl-xdsnap.exe
       files:
         - from: kubectl-xdsnap.exe

--- a/plugins/xdsnap.yaml
+++ b/plugins/xdsnap.yaml
@@ -1,0 +1,69 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: xdsnap
+spec:
+  version: "v0.2.3"
+  homepage: "https://github.com/markcampv/xdsnap"
+  shortDescription: "Capture Envoy xDS snapshots and endpoints from Consul service mesh"
+  description: |
+    xDSnap helps platform and service mesh operators extract debug-level
+    configuration and endpoint state from Envoy sidecars connected to
+    Consul service mesh. It's helpful for analyzing upstream issues, 
+    traffic configuration, and xDS debug state.
+
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_linux_amd64.tar.gz
+      sha256: a78f455d96389c4f91acee6e8de68f2cef2659b00d9bf8c6515c3939b2f84a55
+      bin: kubectl-xdsnap
+      files:
+        - from: kubectl-xdsnap
+          to: .
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_linux_arm64.tar.gz
+      sha256: 62bf78749de8b756b5873af4788528cdb44ab93ef201b7fd01f24fcfbdf365f9
+      bin: kubectl-xdsnap
+      files:
+        - from: kubectl-xdsnap
+          to: .
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_darwin_amd64.tar.gz
+      sha256: 00edae05802007c9958244aa242db1da202afa55ecab8e98aa0a05d1420c782a
+      bin: kubectl-xdsnap
+      files:
+        - from: kubectl-xdsnap
+          to: .
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_darwin_arm64.tar.gz
+      sha256: 68787bd1840cee31bb76ce60eec55d060976c76f7acc6da85147bce4aac4e96b
+      bin: kubectl-xdsnap
+      files:
+        - from: kubectl-xdsnap
+          to: .
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.3/xdsnap_0.2.3_windows_amd64.tar.gz
+      sha256: a71a7204484498c01c6251a5a763ecc5dca5f8fc569658ea7a2643b7fe35d749
+      bin: kubectl-xdsnap.exe
+      files:
+        - from: kubectl-xdsnap.exe
+          to: .

--- a/plugins/xdsnap.yaml
+++ b/plugins/xdsnap.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: xdsnap
 spec:
-  version: "v0.2.5"
+  version: "v0.2.7"
   homepage: "https://github.com/markcampv/xdsnap"
   shortDescription: "Capture Envoy xDS snapshots and endpoints from Consul service mesh"
   description: |
@@ -17,8 +17,19 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_linux_amd64.tar.gz
-      sha256: 494b02c32e5c01378de3cbdf1ed472313d6a4a4e6fe74dc8b7004b700ef9c8a8
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.7/xdsnap_0.2.7_linux_amd64.tar.gz
+      sha256: 0849c292c4a9c7f46aeabb5f57c78c005677a1f86d8c33c356aff1cede8d543e
+      bin: kubectl-xdsnap
+      files:
+        - from: kubectl-xdsnap
+          to: .
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.7/xdsnap_0.2.7_linux_arm64.tar.gz
+      sha256: fea24874cbef66f80bf86b746c2df2a912d3b1fa0b5fe84e158c320abbe70ff6
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
@@ -28,8 +39,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_darwin_amd64.tar.gz
-      sha256: 28d5b7f4a38035ece6e0a796dc4423d6ce52ea9c8ddc6603df00ea9afdd45f28
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.7/xdsnap_0.2.7_darwin_amd64.tar.gz
+      sha256: 83906ce6e9a6065fc29c28130aae04f554bdd4d77eb27e587cd6b0a72ec9b4b5
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
@@ -39,8 +50,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_darwin_arm64.tar.gz
-      sha256: cde4823c78a84a9dd63c4444a0e85405ca6877500fbcf097ab701e4a3bfa9b59
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.7/xdsnap_0.2.7_darwin_arm64.tar.gz
+      sha256: c1db73c903b47765ee7ac3061e8cb509210ec74b47c3bc1c4f00052f863163e8
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
@@ -50,9 +61,10 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.5/xdsnap_0.2.5_windows_amd64.tar.gz
-      sha256: c0d9501a4042b3c188cf58f36ff70848d5e22e6495302efbddb1b5c7fef248a0
+      uri: https://github.com/markcampv/xdsnap/releases/download/v0.2.7/xdsnap_0.2.7_windows_amd64.tar.gz
+      sha256: 0cddc9eacd7408c435e589df494de757f0e18c0c5baa403ef4659a1da094c666
       bin: kubectl-xdsnap.exe
       files:
         - from: kubectl-xdsnap.exe
           to: .
+

--- a/plugins/xdsnap.yaml
+++ b/plugins/xdsnap.yaml
@@ -23,6 +23,8 @@ spec:
       files:
         - from: kubectl-xdsnap
           to: .
+        - from: LICENSE
+          to: .
 
     - selector:
         matchLabels:
@@ -33,6 +35,8 @@ spec:
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
+          to: .
+        - from: LICENSE
           to: .
 
     - selector:
@@ -45,6 +49,8 @@ spec:
       files:
         - from: kubectl-xdsnap
           to: .
+        - from: LICENSE
+          to: .
 
     - selector:
         matchLabels:
@@ -55,6 +61,8 @@ spec:
       bin: kubectl-xdsnap
       files:
         - from: kubectl-xdsnap
+          to: .
+        - from: LICENSE
           to: .
 
     - selector:
@@ -67,4 +75,5 @@ spec:
       files:
         - from: kubectl-xdsnap.exe
           to: .
-
+        - from: LICENSE
+          to: .

--- a/plugins/xdsnap.yaml
+++ b/plugins/xdsnap.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   version: "v0.2.7"
   homepage: "https://github.com/markcampv/xdsnap"
-  shortDescription: "Capture Envoy xDS snapshots and endpoints from Consul service mesh"
+  shortDescription: "Capture Envoy xDS state from Consul sidecars"
   description: |
     xDSnap helps platform and service mesh operators extract debug-level
-    configuration and endpoint state from Envoy sidecars connected to
-    Consul service mesh. It's helpful for analyzing upstream issues, 
-    traffic configuration, and xDS debug state.
+    configuration and endpoint state from Envoy sidecars connected to Consul.
+    It's helpful for analyzing upstream issues, traffic configuration, and
+    xDS debug state.
 
   platforms:
     - selector:


### PR DESCRIPTION
This PR adds the `xdsnap` plugin, which allows operators of Consul service meshes
to capture xDS snapshot and endpoint state from Envoy sidecars for debugging.

Repo: https://github.com/markcampv/xdsnap  
Binary: `kubectl-xdsnap`  
Latest release: v0.2.7

While xdsnap can technically be run standalone, this plugin is specifically intended for Kubernetes users who need to inspect and capture xDS snapshots or Envoy admin data from pods using kubectl. Integrating with kubectl makes it easier to target pods, use kubectl exec, and operate within existing RBAC permissions. This streamlines service mesh debugging workflows for platform engineers and operators working in Kubernetes-native environments—without needing to context switch from the CLI.

Let me know if you'd like any change

