### PR TITLE
bump mtv to v0.1.16

### DIFF
--- a/plugins/mtv.yaml
+++ b/plugins/mtv.yaml
@@ -3,15 +3,15 @@ kind: Plugin
 metadata:
   name: mtv
 spec:
-  version: v0.1.15
+  version: v0.1.16
   homepage: https://github.com/yaacov/kubectl-mtv
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/yaacov/kubectl-mtv/releases/download/v0.1.15/kubectl-mtv.tar.gz
-    sha256: fe7b99d3610babfb5f757fea539adc875ef67ee3fe17deec7521c906d9fd559f
+    uri: https://github.com/yaacov/kubectl-mtv/releases/download/v0.1.16/kubectl-mtv.tar.gz
+    sha256: e13df25da18aa30197e02a89d7b8a1fdb1a51e6ba1e438e7febd8ef330a9b0eb
     bin: kubectl-mtv
   shortDescription: Migrate virtualization workloads to KubeVirt
   description: |


### PR DESCRIPTION
bump mtv to v0.1.16
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
