### PR TITLE
Added komodor 

### DIFF
--- a/plugins/komodor.yaml
+++ b/plugins/komodor.yaml
@@ -1,0 +1,39 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: komodor
+spec:
+  version: "v1.0.2"
+  homepage: "https://github.com/amitlin/kubectl-komodor"
+  shortDescription: "Komodor plugin for kubectl"
+  description: |
+    A kubectl plugin to interact with resources in Komodor directly from the command line.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.2/kubectl-komodor-darwin-arm64.tar.gz
+      sha256: e352651d7a0f25b3e0c378327009c988989750768aa276e67dca0ef6b9aa10ef
+      bin: kubectl-komodor
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.2/kubectl-komodor-darwin-amd64.tar.gz
+      sha256: 084f658e651ef6b53e1ba9f8561e6339feeecbfd248ae5d8e9ba7c5c18b533cd
+      bin: kubectl-komodor
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.2/kubectl-komodor-linux-arm64.tar.gz
+      sha256: 6fd1297a6bba47e10f55280891c5b873168839b41d355e085255e24c9024e302
+      bin: kubectl-komodor
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.2/kubectl-komodor-linux-amd64.tar.gz
+      sha256: 33b8c4eaf55dac44434d6b6abcfa043f6dfe2c8de80ad4a93d5f4400cf7dc740
+      bin: kubectl-komodor


### PR DESCRIPTION
A small plugin for interacting with cluster resources in [komodor](https://komodor.com/).

Saves time when having to jump between CLI and Komodor UI in order to troubleshoot and investigate issues.
Planning on adding access to the Komodor AI chat next.
