### PR TITLE
chore: update version of komodor plugin to v1.1.4

### DIFF
--- a/plugins/komodor.yaml
+++ b/plugins/komodor.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: komodor
 spec:
-  version: "v1.0.3"
+  version: "v1.1.4"
   homepage: "https://github.com/amitlin/kubectl-komodor"
   shortDescription: "Interact with cluster resources through Komodor"
   description: |
@@ -13,27 +13,27 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.3/kubectl-komodor-darwin-arm64.tar.gz
-      sha256: de7d3f05033059e3bb18d244934419d5f3dd142eb72e7837462d5d19e72782bf
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-darwin-arm64.tar.gz
+      sha256: cac79f8e42311e3e487386c7f3d3c164796c8ce42a2c97275c43bd281aff8084
       bin: kubectl-komodor
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.3/kubectl-komodor-darwin-amd64.tar.gz
-      sha256: 701d98681aa0d10847471545f17356d3145b007cf2e9adca36429c16567d34ed
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-darwin-amd64.tar.gz
+      sha256: 68d76d77c8548b63c786a87dc340229e5069d10b76de8aca49f0ca2942bb1dfb
       bin: kubectl-komodor
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.3/kubectl-komodor-linux-arm64.tar.gz
-      sha256: 3d12e1c4cef7028771606ddf7d7fafc331e54236b5634f1805b3018931e4fb71
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-linux-arm64.tar.gz
+      sha256: 03aa1ae3eef76ae1cd8deee537c28087e3f8dafd7a3d14a6755949e28754a914
       bin: kubectl-komodor
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.0.3/kubectl-komodor-linux-amd64.tar.gz
-      sha256: 4b9d6b88bc86c14bbbece6f14c302f2b49768ab15e003299ce64aa1eec05d2ee
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-linux-amd64.tar.gz
+      sha256: 8106bb33f100277028c8e475c181c624218a03912fdfae63c58f43c5b880a3da
       bin: kubectl-komodor


### PR DESCRIPTION
feat: added support for root cause anaylsis

I'll add the krew release plugin once I get a bit of free time, as it was giving me some issues with goreleaser