### PR TITLE
update komodor v1.1.12

### DIFF
--- a/plugins/komodor.yaml
+++ b/plugins/komodor.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: komodor
 spec:
-  version: "v1.1.4"
+  version: "v1.1.12"
   homepage: "https://github.com/amitlin/kubectl-komodor"
   shortDescription: "Interact with cluster resources through Komodor"
   description: |
@@ -13,27 +13,27 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-darwin-arm64.tar.gz
-      sha256: cac79f8e42311e3e487386c7f3d3c164796c8ce42a2c97275c43bd281aff8084
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.12/kubectl-komodor-darwin-arm64.tar.gz
+      sha256: 2389cebe7610ac71ea668963c39a4d27dbe9e6dd741099c2531fadc2490fdd81
       bin: kubectl-komodor
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-darwin-amd64.tar.gz
-      sha256: 68d76d77c8548b63c786a87dc340229e5069d10b76de8aca49f0ca2942bb1dfb
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.12/kubectl-komodor-darwin-amd64.tar.gz
+      sha256: c6541a8813b70727e9d410953bb4c6c4b69874d2f23a5fe4ecf28e8a43105e66
       bin: kubectl-komodor
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-linux-arm64.tar.gz
-      sha256: 03aa1ae3eef76ae1cd8deee537c28087e3f8dafd7a3d14a6755949e28754a914
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.12/kubectl-komodor-linux-arm64.tar.gz
+      sha256: af094704773da60e7220a2b1de35b4df1a6e385d23e57c6b93375778930e91e8
       bin: kubectl-komodor
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.4/kubectl-komodor-linux-amd64.tar.gz
-      sha256: 8106bb33f100277028c8e475c181c624218a03912fdfae63c58f43c5b880a3da
+      uri: https://github.com/amitlin/kubectl-komodor/releases/download/v1.1.12/kubectl-komodor-linux-amd64.tar.gz
+      sha256: 589b844f58453aabb0548039550c48fceded76d1b17e5f06220dd5f7ddb58f63
       bin: kubectl-komodor


### PR DESCRIPTION
fix: linux binaries were not working on all distros