### PR TITLE
Bump ray to v1.4.1

### DIFF
--- a/plugins/ray.yaml
+++ b/plugins/ray.yaml
@@ -3,36 +3,36 @@ kind: Plugin
 metadata:
   name: ray
 spec:
-  version: v1.4.0
+  version: v1.4.1
   homepage: https://github.com/ray-project/kuberay/tree/master/kubectl-plugin
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.0/kubectl-ray_v1.4.0_darwin_amd64.tar.gz
-      sha256: ccb4b2fb8b1852f1915912a028d212e790df04089611eee47fa816aa0b4f5c81
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.1/kubectl-ray_v1.4.1_darwin_amd64.tar.gz
+      sha256: 24f75f28728203e2e38f4719b40a99aeea6b82304246af948d61166b945883f5
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.0/kubectl-ray_v1.4.0_darwin_arm64.tar.gz
-      sha256: 6310215778154ed77a40ab0ff7a26600340ff9e2d71ae485ed505c86c47c3f4a
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.1/kubectl-ray_v1.4.1_darwin_arm64.tar.gz
+      sha256: bacd219e012e70be6c13dbb0127b7be1110139786dd5c49ba385bb8c026b5dd9
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.0/kubectl-ray_v1.4.0_linux_amd64.tar.gz
-      sha256: 078fec1ccb1ee7af6146bb8fbd92c41c31650039545c5e8747e81639d4bae538
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.1/kubectl-ray_v1.4.1_linux_amd64.tar.gz
+      sha256: a5e30d1eb468fe10cb1a781a80e04044fffc673d7426facb81ae5e411899af1d
       bin: kubectl-ray
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.0/kubectl-ray_v1.4.0_linux_arm64.tar.gz
-      sha256: 23b9e8c3e12a263db23cc9732ffe914a2e098bd06aff970d3107b4e4e340eea5
+      uri: https://github.com/ray-project/kuberay/releases/download/v1.4.1/kubectl-ray_v1.4.1_linux_arm64.tar.gz
+      sha256: 7b53b5abfdef68deaaa22bb4ce955ceb0998a461c240831b0ae6a5d5572a4945
       bin: kubectl-ray
   shortDescription: Ray kubectl plugin
   description: |


### PR DESCRIPTION
Following the https://github.com/kubernetes-sigs/krew-index/pull/4694, bump the ray plugin version to a new patch release.