### PR TITLE
Update: upgrade net-forward plugin to version 1.1.3

### DIFF
--- a/plugins/net-forward.yaml
+++ b/plugins/net-forward.yaml
@@ -3,13 +3,13 @@ kind: Plugin
 metadata:
   name: net-forward
 spec:
-  version: "v1.1.0"       
+  version: "v1.1.3"       
   platforms:
   - selector:
       matchExpressions:
       - {key: os, operator: In, values: [darwin, linux]}
-    uri: https://github.com/antitree/krew-net-forward/releases/download/v1.0.3/net-forward_v1.0.3.tar.gz
-    sha256: "645adb05d9ad68ecc91d9034cb80b1e2fe4762864323c12de0f2bc5afe20baa0"
+    uri: https://github.com/antitree/krew-net-forward/releases/download/v1.1.3/net-forward_v1.1.3.tar.gz
+    sha256: "acba6a901974fe6cb258024e5b988fd3b61e6e85200a2e51c7817d51f4ef5954"
     bin: "net-forward"  
   shortDescription: "Proxy to arbitrary TCP services on a cluster network"
   homepage: https://github.com/antitree/krew-net-forward


### PR DESCRIPTION
This is a minor upgrade to the latest version of net-forward. This adds the following few features:

* An optional --image tag which will let you set custom images (thanks to @killerkenobi)
* Support randomized image values