### PR TITLE
Add execrec plugin

### DIFF
--- a/plugins/execrec.yaml
+++ b/plugins/execrec.yaml
@@ -5,11 +5,12 @@ metadata:
 spec:
   version: v1.0.0
   homepage: https://github.com/keidarcy/kubectl-execrec
-  shortDescription: A kubectl plugin that wraps `kubectl exec` with session recording capabilities for audit and debugging.
+  shortDescription: Record kubectl exec sessions for audit
   description: |
-    A kubectl plugin that wraps `kubectl exec` with session recording capabilities.
-    All interactive sessions are automatically logged to timestamped files for audit and debugging purposes.
-    You can also upload the log file to storage like S3.
+    A kubectl plugin that wraps kubectl exec with session recording capabilities.
+    All interactive sessions are automatically logged to timestamped files for audit
+    and debugging purposes. Supports optional upload to S3-compatible storage
+    services for centralized log management and compliance requirements.
   platforms:
   - selector:
       matchLabels:


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Hi, `execrec` is a plugin that records `kubectl exec` sessions.It works as a drop-in wrapper for `kubectl exec`, logging all input and output to a local file, with optional upload to storage service for audit and review.

Repo: https://github.com/keidarcy/kubectl-execrec

<img width="1004" height="439" alt="Screenshot 2025-08-10 at 23 54 50" src="https://github.com/user-attachments/assets/0fd812fb-7c6e-4813-adeb-31b9277556a6" />

