### PR TITLE
Submission of new plugin `imageof`

### DIFF
--- a/plugins/dolphin.yaml
+++ b/plugins/dolphin.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: dolphin
+spec:
+  version: "v0.1.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/HarshPanchal18/kubectl-dolphin/releases/download/v0.1.0/kubectl-dolphin-linux-amd64.tar.gz
+    sha256: "1150644e39162efa183a065ff54436f3d2173c443662cd88b695689563ee9cf7"
+    bin: kubectl-dolphin-linux-amd64
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/HarshPanchal18/kubectl-dolphin/releases/download/v0.1.0/kubectl-dolphin-darwin-amd64.tar.gz
+    sha256: "e15050a0e28a40ec6000e0facbde06127986df800c832e849dbbc09aa21a27bc"
+    bin: kubectl-dolphin-darwin-amd64
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/HarshPanchal18/kubectl-dolphin/releases/download/v0.1.0/kubectl-dolphin-darwin-arm64.tar.gz
+    sha256: "d22dd8673cbfc948a2982368c2d6733b4dcdf4613920a997ac9d06f810215514"
+    bin: kubectl-dolphin-darwin-arm64
+
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/HarshPanchal18/kubectl-dolphin/releases/download/v0.1.0/kubectl-dolphin-windows-amd64.zip
+    sha256: "216516914f38ba6fce8361671de5b0f61139737bac60fadd8b8a6bc7f6d13e1e"
+    bin: kubectl-dolphin-windows-amd64.exe
+
+  shortDescription: "Delete pods of a namespace scheduled on a specific node"
+  description: |
+    kubectl-dolphin is a kubectl plugin to delete pods of a namespace scheduled on a specific node.
+    It helps in draining a node by deleting all the pods of a specific namespace running on that node.
+    It is useful in scenarios where you want to delete all the pods of a specific namespace running on a node
+    without affecting the pods of other namespaces.
+    It also supports batch deletion of pods from a large number of pod along with interval to do not overwhelm api-server.
+    It also supports dry-run mode to preview the pods that will be deleted without actually deleting them.
+  homepage: https://github.com/HarshPanchal18/kubectl-dolphin

--- a/plugins/imageof.yaml
+++ b/plugins/imageof.yaml
@@ -9,7 +9,7 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-linux-amd64.tar.gz
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-linux-amd64.tar.gz
     sha256: "bde1b24d2c2fcc481fea140e21431fcfdd0512d6944181afe573d57c2400f127"
     bin: kubectl-imageof-linux-amd64
 
@@ -17,7 +17,7 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-amd64.tar.gz
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-darwin-amd64.tar.gz
     sha256: "393cf914b2c4196dcb7351d439adfd1be902c30a1eb617c4c05d0c8220c8fae9"
     bin: kubectl-imageof-darwin-amd64
 
@@ -25,7 +25,7 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-arm64.tar.gz
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-darwin-arm64.tar.gz
     sha256: "ad36fa68bc6631a00e72f4002552d6275c86c2129615497070621de5f4d162f5"
     bin: kubectl-imageof-darwin-arm64
 
@@ -33,7 +33,7 @@ spec:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-windows-amd64.zip
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-windows-amd64.zip
     sha256: "20e8dbd6d7edffd17d018000ab2b902ea91304bfbe679dd1d9587c9e6bb4f018"
     bin: kubectl-imageof-windows-amd64.exe
 

--- a/plugins/imageof.yaml
+++ b/plugins/imageof.yaml
@@ -3,38 +3,38 @@ kind: Plugin
 metadata:
   name: imageof
 spec:
-  version: "v0.1.2"
+  version: "v0.1.3"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-linux-amd64.tar.gz
-    sha256: "bde1b24d2c2fcc481fea140e21431fcfdd0512d6944181afe573d57c2400f127"
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.3/kubectl-imageof-linux-amd64.tar.gz
+    sha256: "0b8c13b992f83f9c3cbe9d5d42a66e2ad3a09c8a92553a3a6408fde77c2e219f"
     bin: kubectl-imageof-linux-amd64
 
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-darwin-amd64.tar.gz
-    sha256: "393cf914b2c4196dcb7351d439adfd1be902c30a1eb617c4c05d0c8220c8fae9"
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.3/kubectl-imageof-darwin-amd64.tar.gz
+    sha256: "cc5cca1936075b67f102c773c81642b52cd0e0d5943f97035d069e05db026bcf"
     bin: kubectl-imageof-darwin-amd64
 
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-darwin-arm64.tar.gz
-    sha256: "ad36fa68bc6631a00e72f4002552d6275c86c2129615497070621de5f4d162f5"
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.3/kubectl-imageof-darwin-arm64.tar.gz
+    sha256: "b78a14b2c29a6a5e89fcf6dfbcc7f2b0500a5ee454ad4852a8b46b9eba20933a"
     bin: kubectl-imageof-darwin-arm64
 
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.2/kubectl-imageof-windows-amd64.zip
-    sha256: "20e8dbd6d7edffd17d018000ab2b902ea91304bfbe679dd1d9587c9e6bb4f018"
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.3/kubectl-imageof-windows-amd64.zip
+    sha256: "54ea228cd565cff22bb74dcd3115968e6b7f874391a7f0be07007e733cfa1045"
     bin: kubectl-imageof-windows-amd64.exe
 
   shortDescription: "Get container images of pods quickly"

--- a/plugins/imageof.yaml
+++ b/plugins/imageof.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: imageof
 spec:
-  version: "v0.1.0"
+  version: "v0.1.1"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-linux-amd64.tar.gz
-    sha256: "7fac9743d202035896ead94d822d6066be21f6b8f83e61040e8746e604261ad3"
+    sha256: "1eaafa9e245f66d419ebf5650050b4913d40b362b5e8a322807f06afeac8be60"
     bin: kubectl-imageof-linux-amd64
 
   - selector:
@@ -18,7 +18,7 @@ spec:
         os: darwin
         arch: amd64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-amd64.tar.gz
-    sha256: "cd0517ff6bb9b94b7222d1c82a25983545dc0f7761817129939641e190641194"
+    sha256: "163b7ec6609cad9c3af81fe15a013fcc60a2c9de4ce750adcfb8153e71e08852"
     bin: kubectl-imageof-darwin-amd64
 
   - selector:
@@ -26,7 +26,7 @@ spec:
         os: darwin
         arch: arm64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-arm64.tar.gz
-    sha256: "cd0517ff6bb9b94b7222d1c82a25983545dc0f7761817129939641e190641194"
+    sha256: "f4260d1627b04607b9da77b8360b6f36f1b1ec21cac2e79a87368f8ea2b9ee8a"
     bin: kubectl-imageof-darwin-arm64
 
   - selector:
@@ -34,7 +34,7 @@ spec:
         os: windows
         arch: amd64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-windows-amd64.zip
-    sha256: "4b6e1fad7e030bc8944fc6af03b865ed6eba0a8cd77c8b880dd2798fccffd91e"
+    sha256: "4e432dd3dd925777b39b881aece00989cf5f18664014f62f2a6975daf5904f05"
     bin: kubectl-imageof-windows-amd64.exe
 
   shortDescription: "Get container images of pods quickly"

--- a/plugins/imageof.yaml
+++ b/plugins/imageof.yaml
@@ -1,0 +1,45 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: imageof
+spec:
+  version: "v0.1.0"
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-linux-amd64.tar.gz
+    sha256: "7fac9743d202035896ead94d822d6066be21f6b8f83e61040e8746e604261ad3"
+    bin: kubectl-imageof-linux-amd64
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-amd64.tar.gz
+    sha256: "cd0517ff6bb9b94b7222d1c82a25983545dc0f7761817129939641e190641194"
+    bin: kubectl-imageof-darwin-amd64
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-arm64.tar.gz
+    sha256: "cd0517ff6bb9b94b7222d1c82a25983545dc0f7761817129939641e190641194"
+    bin: kubectl-imageof-darwin-arm64
+
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-windows-amd64.zip
+    sha256: "4b6e1fad7e030bc8944fc6af03b865ed6eba0a8cd77c8b880dd2798fccffd91e"
+    bin: kubectl-imageof-windows-amd64.exe
+
+  shortDescription: "Get container images of pods quickly"
+  description: |
+    kubectl-imageof is a kubectl plugin to print images of containers
+    in a pod or across all pods in a namespace. Useful alternative to
+    `kubectl describe pod | grep Image`.
+  homepage: https://github.com/HarshPanchal18/kubectl-imageof

--- a/plugins/imageof.yaml
+++ b/plugins/imageof.yaml
@@ -3,14 +3,14 @@ kind: Plugin
 metadata:
   name: imageof
 spec:
-  version: "v0.1.1"
+  version: "v0.1.2"
   platforms:
   - selector:
       matchLabels:
         os: linux
         arch: amd64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-linux-amd64.tar.gz
-    sha256: "1eaafa9e245f66d419ebf5650050b4913d40b362b5e8a322807f06afeac8be60"
+    sha256: "bde1b24d2c2fcc481fea140e21431fcfdd0512d6944181afe573d57c2400f127"
     bin: kubectl-imageof-linux-amd64
 
   - selector:
@@ -18,7 +18,7 @@ spec:
         os: darwin
         arch: amd64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-amd64.tar.gz
-    sha256: "163b7ec6609cad9c3af81fe15a013fcc60a2c9de4ce750adcfb8153e71e08852"
+    sha256: "393cf914b2c4196dcb7351d439adfd1be902c30a1eb617c4c05d0c8220c8fae9"
     bin: kubectl-imageof-darwin-amd64
 
   - selector:
@@ -26,7 +26,7 @@ spec:
         os: darwin
         arch: arm64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-darwin-arm64.tar.gz
-    sha256: "f4260d1627b04607b9da77b8360b6f36f1b1ec21cac2e79a87368f8ea2b9ee8a"
+    sha256: "ad36fa68bc6631a00e72f4002552d6275c86c2129615497070621de5f4d162f5"
     bin: kubectl-imageof-darwin-arm64
 
   - selector:
@@ -34,7 +34,7 @@ spec:
         os: windows
         arch: amd64
     uri: https://github.com/HarshPanchal18/kubectl-imageof/releases/download/v0.1.0/kubectl-imageof-windows-amd64.zip
-    sha256: "4e432dd3dd925777b39b881aece00989cf5f18664014f62f2a6975daf5904f05"
+    sha256: "20e8dbd6d7edffd17d018000ab2b902ea91304bfbe679dd1d9587c9e6bb4f018"
     bin: kubectl-imageof-windows-amd64.exe
 
   shortDescription: "Get container images of pods quickly"


### PR DESCRIPTION
Hello,

`kubectl-imageof` is a kubectl plugin to print images of containers in a pod or across all pods in a namespace.

Link to the repo : [HarshPanchal18/kubectl-imageof](https://github.comHarshPanchal18/kubectl-imageof)

Please, be free to do any remark as it's my first plugin to the community.

Thank you :)