### PR TITLE
Replace example

### DIFF
--- a/plugins/example.yaml
+++ b/plugins/example.yaml
@@ -3,9 +3,9 @@ kind: Plugin
 metadata:
   name: example
 spec:
-  homepage: https://github.com/seredot/kubectl-example
+  homepage: https://github.com/talos-labs/kubectl-example
   shortDescription: Prints out example manifest YAMLs
-  version: v1.1.0
+  version: v0.0.1
   description: |
     Prints out a example manifest YAML for a given resource type. 
     The plugin works similar to a dry run output but for arbitrary resources.
@@ -15,8 +15,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Darwin_arm64.tar.gz
-      sha256: "639a45faecc828ca29a71d85a7dcb85e89395f1c40651d449e78cfd4786077a7"
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Darwin_arm64.tar.gz
+      sha256: "543acec9db1871289c51ad72cb644ad3b85f29da643eb42d32b9e8cda9cdcb4e"
       bin: "./kubectl-example"
       files:
         - from: kubectl-example
@@ -27,20 +27,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Darwin_x86_64.tar.gz
-      sha256: "eaab1517d6a4f9064584b31fdd013883922cd0a86b3e8dbdf745132aa9090671"
-      bin: "./kubectl-example"
-      files:
-        - from: kubectl-example
-          to: .
-        - from: LICENSE
-          to: .
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Linux_armv6.tar.gz
-      sha256: "4040b9ff76958e8b7ebfd1a94fe73ac4031a4e1567105374d2cab2f318ea8993"
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Darwin_x86_64.tar.gz
+      sha256: "c41ffb994a34a4cbdb3ccad13168df5b36131787603a4780a5e268c977ed3ef1"
       bin: "./kubectl-example"
       files:
         - from: kubectl-example
@@ -51,8 +39,20 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Linux_arm64.tar.gz
-      sha256: "e4d18043e0dfac74c175eb8eacfba91e37a510293ffe56af1041c0f5cc192d3e"
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Linux_arm64.tar.gz
+      sha256: "a0ee1becf3518e8fdcb80f23a45cf84de25729e912ec495c429a4c7078bea0f8"
+      bin: "./kubectl-example"
+      files:
+        - from: kubectl-example
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: i386
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Linux_i386.tar.gz
+      sha256: "f145f5a0ce32e3f6a0f29841dfadc79c1c3c25a5f54d4153b0c2b4cfb9593f98"
       bin: "./kubectl-example"
       files:
         - from: kubectl-example
@@ -63,8 +63,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Linux_x86_64.tar.gz
-      sha256: "c5ef88e5046d3a813f838c1aa20f5412ef25694d26d950f403cac4b9a80df6cb"
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Linux_x86_64.tar.gz
+      sha256: "8954ab9a146f968cf599cd97940bb98b31bfe46cdf071c32bfffc2bebd87d8e2"
       bin: "./kubectl-example"
       files:
         - from: kubectl-example
@@ -75,8 +75,20 @@ spec:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Windows_arm64.tar.gz
-      sha256: "b716ef9bf424bbe9964b3f17836196cca37a22e152156939a729911712c03675"
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Windows_arm64.tar.gz
+      sha256: "4192614377957f644a9808303c2d04c159c5c704b7a6d5f83d344d08d9230c11"
+      bin: "./kubectl-example.exe"
+      files:
+        - from: kubectl-example.exe
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: windows
+          arch: i386
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Windows_i386.tar.gz
+      sha256: "4ba8d12678694d760afe839cecd50f79bb3a6cef531473a50a0f7a2966c7297b"
       bin: "./kubectl-example.exe"
       files:
         - from: kubectl-example.exe
@@ -87,8 +99,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/seredot/kubectl-example/releases/download/v1.1.0/kubectl-example_1.1.0_Windows_x86_64.tar.gz
-      sha256: "cad6c00a402be39eaea4e6796ab381481e25f5b7631c1e2810df4eaeacab70f7"
+      uri: https://github.com/talos-labs/kubectl-example/releases/download/v0.0.1/kubectl-example_v0.0.1_Windows_x86_64.tar.gz
+      sha256: "7147719b7c76647d4264f39d770cbebf0cc7d67d9c10ebf95e316762bbf9fb27"
       bin: "./kubectl-example.exe"
       files:
         - from: kubectl-example.exe


### PR DESCRIPTION
Since the original (https://github.com/seredot/kubectl-example) plugin isn't updated anymore, we forked it and add one improvement.

Therefore I suggest that the index gets updated to use our plugin.

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
