### PR TITLE
chore: add meshsync snapshot plugin

### DIFF
--- a/plugins/meshsync-snapshot.yaml
+++ b/plugins/meshsync-snapshot.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   version: v0.8.0
   homepage: https://github.com/meshery-extensions/kubectl-meshsync-snapshot
-  shortDescription: Creates a k8s cluster snapshot
+  shortDescription: Creates a k8s cluster snapshot using meshsync library
   description: |
-    This plugin: generate  a snapshot of a cluster resources as a yaml file;
+    Plugin creates cluster snapshot to upload to meshery server for visualisation
   caveats:
   platforms:
   - selector:


### PR DESCRIPTION
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->

Submit new plugin `meshsync-snapshot`.
Original repository: https://github.com/meshery-extensions/kubectl-meshsync-snapshot .

## Description:
`kubectl meshsync-snapshot` is a Krew plugin for capturing an ad hoc snapshot of resource information from a Kubernetes cluster. The collected data is output as a YAML file and can be uploaded to a Meshery server for visualisation.

The plugin is based on the [MeshSync](https://github.com/meshery/meshsync) — software that provides the Meshery server with detailed information about cluster resources.

And [Meshery](https://github.com/meshery/meshery) is the open source, cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud)

----

updated to latest version :white_check_mark: 

<details>
<summary>plugin run</summary>
<img width="1179" height="239" alt="image" src="https://github.com/user-attachments/assets/98a58956-60e5-4f3e-b9e3-07eb49eb9ea3" />
plugin runs and  generates a snaphshot file :white_check_mark: 
</details>

<details>
<summary>plugin help</summary>
<img width="1388" height="374" alt="screen-0027" src="https://github.com/user-attachments/assets/2168425c-581c-4b12-aee0-c8e9657cdacb" />
</details>

