### PR TITLE
Add resource usage plugin

### DIFF
--- a/plugins/resource-usage.yaml
+++ b/plugins/resource-usage.yaml
@@ -1,0 +1,88 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: resource-usage
+spec:
+  version: "v0.1.0"
+  homepage: https://github.com/clglavan/kubectl-resource-usage
+  shortDescription: "Real-time Kubernetes pod resource usage monitor with TUI"
+  description: |
+    A terminal-based user interface (TUI) for monitoring Kubernetes pod resource usage in real-time.
+    
+    Features:
+    - Real-time CPU and memory usage monitoring
+    - Resource requests and limits display
+    - HPA (Horizontal Pod Autoscaler) metrics and status
+    - Recent cluster events monitoring
+    - Multi-namespace support
+    - Configurable refresh intervals
+    - Color-coded alerts for resource thresholds
+    
+    The plugin provides an intuitive dashboard for monitoring pod resources across multiple namespaces,
+    making it easy to identify resource bottlenecks and scaling events.
+  caveats: |
+    This plugin requires:
+    - Access to Kubernetes metrics-server for resource usage data
+    - Appropriate RBAC permissions to read pods, events, and HPA resources
+    - A terminal that supports colors and unicode characters for best experience
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-linux-amd64.tar.gz
+    sha256: "a0c0ed33defc8b8536af1e602a7899d5d7b5ae5eff83e2d417b3e0a019f41cf3"
+    files:
+    - from: kubectl-resource_usage
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-resource_usage
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-linux-arm64.tar.gz
+    sha256: "82326b73405764598f4511659a982137183798a0f0e6f13015300d5dccec6551"
+    files:
+    - from: kubectl-resource_usage
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-resource_usage
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-darwin-amd64.tar.gz
+    sha256: "a71b36226924c47803fb7d13d50277c7492bf17e4ac8d01ba2ac03dc94fa9610"
+    files:
+    - from: kubectl-resource_usage
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-resource_usage
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-darwin-arm64.tar.gz
+    sha256: "e88e252ce16e78df0568dd5ae4654ee1d4bd23f6771a8d08d2c893436d832bf7"
+    files:
+    - from: kubectl-resource_usage
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-resource_usage
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-windows-amd64.tar.gz
+    sha256: "8d239007ef16b2c4d45099ffe87c3dc9d21c5cda573efedf43efab426b41187d"
+    files:
+    - from: kubectl-resource_usage.exe
+      to: .
+    - from: LICENSE
+      to: .
+    bin: kubectl-resource_usage.exe

--- a/plugins/resource-usage.yaml
+++ b/plugins/resource-usage.yaml
@@ -31,7 +31,7 @@ spec:
         os: linux
         arch: amd64
     uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-linux-amd64.tar.gz
-    sha256: "a0c0ed33defc8b8536af1e602a7899d5d7b5ae5eff83e2d417b3e0a019f41cf3"
+    sha256: "a39d4b0e185e804fd418a4330cc8b4e08ee68b1d032f66285648c65eb415d126"
     files:
     - from: kubectl-resource_usage
       to: .
@@ -43,7 +43,7 @@ spec:
         os: linux
         arch: arm64
     uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-linux-arm64.tar.gz
-    sha256: "82326b73405764598f4511659a982137183798a0f0e6f13015300d5dccec6551"
+    sha256: "39d39a2a0a13cefdc2624dfaf81b741d5eaecd2f9a70bad09aabcb77b87a8719"
     files:
     - from: kubectl-resource_usage
       to: .
@@ -55,7 +55,7 @@ spec:
         os: darwin
         arch: amd64
     uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-darwin-amd64.tar.gz
-    sha256: "a71b36226924c47803fb7d13d50277c7492bf17e4ac8d01ba2ac03dc94fa9610"
+    sha256: "16ccd8700c09f88f6d25eaf6fc66dc6c9526427560300d8f4739819e13b80da0"
     files:
     - from: kubectl-resource_usage
       to: .
@@ -67,7 +67,7 @@ spec:
         os: darwin
         arch: arm64
     uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-darwin-arm64.tar.gz
-    sha256: "e88e252ce16e78df0568dd5ae4654ee1d4bd23f6771a8d08d2c893436d832bf7"
+    sha256: "ee7c2b87bebf4c9b6face2ee66d6d6be85d01360e2c67725fdb6fddbfc175f9b"
     files:
     - from: kubectl-resource_usage
       to: .
@@ -79,7 +79,7 @@ spec:
         os: windows
         arch: amd64
     uri: https://github.com/clglavan/kubectl-resource-usage/releases/download/v0.1.0/kubectl-resource-usage-windows-amd64.tar.gz
-    sha256: "8d239007ef16b2c4d45099ffe87c3dc9d21c5cda573efedf43efab426b41187d"
+    sha256: "ff014f88ef306f82815a46354a6f71d51d700a430f45e87ebf5468ab1a8dfb31"
     files:
     - from: kubectl-resource_usage.exe
       to: .


### PR DESCRIPTION
Title: Add kubectl-resource-usage plugin

Description:
This PR adds the kubectl-resource-usage plugin - a TUI for monitoring Kubernetes pod resource usage.

- Plugin provides real-time resource monitoring
- Supports multiple namespaces and HPA metrics
- All platform binaries built and tested
- Follows Krew plugin guidelines

Plugin repository: https://github.com/clglavan/kubectl-resource-usage