### PR TITLE
add kubectl-sgmap plugin

### DIFF
--- a/plugins/sgmap.yaml
+++ b/plugins/sgmap.yaml
@@ -26,7 +26,7 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Darwin_amd64.tar.gz
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Darwin_x86_64.tar.gz
       sha256: fea8adfa9f9ad8c264c055c02cafe3e894c0dc86f4816975eb29c0a6d223862e
       files:
         - from: "kubectl-sgmap"
@@ -38,7 +38,7 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Linux_amd64.tar.gz
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Linux_x86_64.tar.gz
       sha256: c8c793dbf244c2c90f46464263a37625192271cc2695b4a77f93b7c77143677e
       files:
         - from: "kubectl-sgmap"

--- a/plugins/sgmap.yaml
+++ b/plugins/sgmap.yaml
@@ -1,0 +1,60 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: sgmap
+spec:
+  version: "v0.14.0"
+  homepage: https://github.com/naka-gawa/kubectl-sgmap
+  shortDescription: "A kubectl plugin to visualize security group per pod."
+  description: |
+    A kubectl plugin to visualize security group per pod.
+    This plugin provides a command to generate a security group map for pods in a Kubernetes cluster.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Darwin_arm64.tar.gz
+      sha256: a50ad4c35b15539bec98c4ac737bea9ddfd7a81c7393ae385f05aaf617d626d3
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Darwin_amd64.tar.gz
+      sha256: fea8adfa9f9ad8c264c055c02cafe3e894c0dc86f4816975eb29c0a6d223862e
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Linux_amd64.tar.gz
+      sha256: c8c793dbf244c2c90f46464263a37625192271cc2695b4a77f93b7c77143677e
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/naka-gawa/kubectl-sgmap/releases/download/v0.14.0/kubectl-sgmap_Linux_arm64.tar.gz
+      sha256: a1ce98a1d0ac0296fe7c6ae031e5d761b7f8809584491f46150a557ee4ae1313
+      files:
+        - from: "kubectl-sgmap"
+          to: "."
+        - from: "LICENSE"
+          to: "."
+      bin: "./kubectl-sgmap"

--- a/plugins/sgmap.yaml
+++ b/plugins/sgmap.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: "v0.14.0"
   homepage: https://github.com/naka-gawa/kubectl-sgmap
-  shortDescription: "A kubectl plugin to visualize security group per pod."
+  shortDescription: "Visualize security group per pod."
   description: |
     A kubectl plugin to visualize security group per pod.
     This plugin provides a command to generate a security group map for pods in a Kubernetes cluster.


### PR DESCRIPTION
I'd like to add kubectl plugin `kubectl-sgmap` to the krew-index.
It's a tool that helps you visualize the relationship between Pods and AWS Security Groups right within your terminal.
This makes it easier to understand which security groups are connected to which resources.

Installation Verification
You can test the installation with the following command:

```
❯❯❯ kubectl krew install --manifest=sgmap.yaml
Installing plugin: sgmap
Installed plugin: sgmap
\
 | Use this plugin:
 |      kubectl sgmap
 | Documentation:
 |      https://github.com/naka-gawa/kubectl-sgmap
/

```