### PR TITLE
Bump config-cleanup plugin

### DIFF
--- a/plugins/config-cleanup.yaml
+++ b/plugins/config-cleanup.yaml
@@ -3,16 +3,16 @@ kind: Plugin
 metadata:
   name: config-cleanup
 spec:
-  version: "v0.6.0"
+  version: "v0.7.0"
   shortDescription: Automatically clean up your kubeconfig
   description: |
     This plugin will attempt to connect to each apiserver specified by a context entry in your kubeconfig.
     If the connection succeeds then the user, cluster, and context entries are maintained in the result.
     Otherwise, the entries are removed.
-  homepage: https://github.com/B23admin/kubectl-config-cleanup
+  homepage: https://github.com/TorchAIKC/kubectl-config-cleanup
   platforms:
-  - uri: https://github.com/B23admin/kubectl-config-cleanup/releases/download/v0.6.0/kubectl-config-cleanup_0.6.0_linux_amd64.tar.gz
-    sha256: 17dd97598f25b3fe1b1b5582dcf55016a5a870007dcc99e78f7cad65993375f6
+  - uri: https://github.com/TorchAIKC/kubectl-config-cleanup/releases/download/v0.7.0/kubectl-config-cleanup_0.7.0_linux_amd64.tar.gz
+    sha256: 77ef15985f2c3fe746ae2713c1a31e30944413634e06e2ec13e5b8d3dbdd923b
     bin: kubectl-config_cleanup
     files:
     - from: "./kubectl-config_cleanup"
@@ -23,8 +23,8 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-  - uri: https://github.com/B23admin/kubectl-config-cleanup/releases/download/v0.6.0/kubectl-config-cleanup_0.6.0_linux_arm64.tar.gz
-    sha256: baf80bf66e5b07f581ef99169fa9013d860c3d709a46fcb177feb36c416cac07
+  - uri: https://github.com/TorchAIKC/kubectl-config-cleanup/releases/download/v0.7.0/kubectl-config-cleanup_0.7.0_linux_arm64.tar.gz
+    sha256: 5d281f385eabfbc98b8575d85a10d5f99e8db1e293cebfda07a78d7a570f54b5
     bin: kubectl-config_cleanup
     files:
     - from: "./kubectl-config_cleanup"
@@ -35,8 +35,8 @@ spec:
       matchLabels:
         os: linux
         arch: arm64
-  - uri: https://github.com/B23admin/kubectl-config-cleanup/releases/download/v0.6.0/kubectl-config-cleanup_0.6.0_darwin_amd64.tar.gz
-    sha256: eae610b7dd411c7a1cefb1287d5c00c090034288ba536dcf85c99bd4974446df
+  - uri: https://github.com/TorchAIKC/kubectl-config-cleanup/releases/download/v0.7.0/kubectl-config-cleanup_0.7.0_darwin_amd64.tar.gz
+    sha256: 25263348a4e6060d6474419b5cd10e8444fcb9c1344cad0623b40a352070447e
     bin: kubectl-config_cleanup
     files:
     - from: "./kubectl-config_cleanup"
@@ -47,8 +47,8 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-  - uri: https://github.com/B23admin/kubectl-config-cleanup/releases/download/v0.6.0/kubectl-config-cleanup_0.6.0_darwin_arm64.tar.gz
-    sha256: a9ff25426ca58ae917903aea1a13a0d8e8ed6c79cfbc57c378e308f3752eefdc
+  - uri: https://github.com/TorchAIKC/kubectl-config-cleanup/releases/download/v0.7.0/kubectl-config-cleanup_0.7.0_darwin_arm64.tar.gz
+    sha256: e7cbcb3a7d7cb2f082a03bba587d08e1113e45b679cad40b6432bb17b19fa800
     bin: kubectl-config_cleanup
     files:
     - from: "./kubectl-config_cleanup"
@@ -59,8 +59,8 @@ spec:
       matchLabels:
         os: darwin
         arch: arm64
-  - uri: https://github.com/B23admin/kubectl-config-cleanup/releases/download/v0.6.0/kubectl-config-cleanup_0.6.0_windows_amd64.zip
-    sha256: e1b974bdec5d6ce45c5cf1783d1dcc0667a7b7eed46a6a611f305d5f93a6862e
+  - uri: https://github.com/TorchAIKC/kubectl-config-cleanup/releases/download/v0.7.0/kubectl-config-cleanup_0.7.0_windows_amd64.zip
+    sha256: 495a84d2dfe5c57b1b30118db52b0f10037acd9470ca7c02d1694c0891a5f0cf
     bin: kubectl-config_cleanup.exe
     files:
     - from: "./kubectl-config_cleanup.exe"


### PR DESCRIPTION
Bumps the `config-cleanup` plugin version from `0.6.0` -> `0.7.0`

Unfortunately I also had to update the source repo path because the original org was renamed and the repos were migrated. I no longer work for the the original org but I am the author of the plugin and the current maintainer