### PR TITLE
new version v0.9.0 of kubetail

### DIFF
--- a/plugins/kubetail.yaml
+++ b/plugins/kubetail.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubetail
 spec:
-  version: "v0.8.2"
+  version: "v0.9.0"
   homepage: https://github.com/kubetail-org/kubetail
   shortDescription: "Logging tool for Kubernetes with real-time web dashboard"
   description: |
@@ -16,41 +16,41 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.8.2/kubetail-darwin-amd64.tar.gz
-    sha256: 25a799fd0f0979af21063afe46bd4335daf3fa570ca6628aad68d758cee5d226
+    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.9.0/kubetail-darwin-amd64.tar.gz
+    sha256: 41ab0c4a4a3ee5d6479c1230c3e9fb63eb4b0d70e66516b63ad665ba79160b3f
     bin: kubetail
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.8.2/kubetail-darwin-arm64.tar.gz
-    sha256: e65918fa8c2f5dfba295306f2c1dda5d6151a8144ee78a15cb42b3f00157c86e
+    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.9.0/kubetail-darwin-arm64.tar.gz
+    sha256: 28f0bdec67694a6c4db285cc57ff23a6059e46f278a100399575d1f982058d0f
     bin: kubetail
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.8.2/kubetail-linux-amd64.tar.gz
-    sha256: 78810fcd420b165e033289d18022f89991b165b384775ed24939a7a603cf045c
+    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.9.0/kubetail-linux-amd64.tar.gz
+    sha256: 206315f3ee92ad57bc450a86dbe9873afa44c25da27f925c1b7e5c826fda63e2
     bin: kubetail
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.8.2/kubetail-linux-arm64.tar.gz
-    sha256: 65ae2f3cc7cd213696d5d53bc7f90c6f994b3a49d237b1e9190119869521660e
+    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.9.0/kubetail-linux-arm64.tar.gz
+    sha256: b0a8ce145d725ba61133403868392bb2275922136e2d5230a7c0aa0e6a4dc4f3
     bin: kubetail
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.8.2/kubetail-windows-amd64.tar.gz
-    sha256: a5460adb71525f150cf84b106c161f8ff302dff63ac9e13c86ece1c2448fc588
+    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.9.0/kubetail-windows-amd64.tar.gz
+    sha256: cac1ab6f539138f2aeed0418048d2eadcf520472b1a7ead76f49ec22834ded9b
     bin: kubetail.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.8.2/kubetail-windows-arm64.tar.gz
-    sha256: 11fb3c091d8a3748e23644e326fbc847d46f54ff1894bcb231428a63c9b66572
+    uri: https://github.com/kubetail-org/kubetail/releases/download/cli%2Fv0.9.0/kubetail-windows-arm64.tar.gz
+    sha256: a6ebde8e6730ba9589784490dc9180917638040635243359bce82b60c15778c9
     bin: kubetail.exe


### PR DESCRIPTION
This upgrades `kubetail` to v0.9.0. Among other improvements, the new version uses `kubectl kubetail` for the command display name as suggested by @ahmetb. It also supports the use of `--context` to switch between kube contexts, as recommended by the docs. We ran into an issue with automated updates but hopefully we can switch over for our next release.
