### PR TITLE
Update the spy plugin to exclusively support containerd.

### DIFF
--- a/plugins/spy2.yaml
+++ b/plugins/spy2.yaml
@@ -1,7 +1,7 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: spy
+  name: spy2
 spec:
   homepage: github.com/asaf400/kubespy
   shortDescription: pod debugging tool for kubernetes clusters with containerd runtimes

--- a/plugins/spy2.yaml
+++ b/plugins/spy2.yaml
@@ -38,7 +38,7 @@ spec:
         - darwin
         - linux
     uri: https://github.com/asaf400/kubespy/releases/download/v1.0.1/kubespy.tar.gz
-    sha256: sha256:74ec776cbf6a469f8487448d6d7b2aed561f7b834082cf4fc5b0097f54f3db92
+    sha256: 74ec776cbf6a469f8487448d6d7b2aed561f7b834082cf4fc5b0097f54f3db92
     bin: kubespy
     files:
     - from: ./kubespy

--- a/plugins/spy2.yaml
+++ b/plugins/spy2.yaml
@@ -1,0 +1,47 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: spy
+spec:
+  homepage: github.com/asaf400/kubespy
+  shortDescription: pod debugging tool for kubernetes clusters with containerd runtimes
+  version: v1.0.1
+  description: |
+    `kubespy` is a kubectl plugin implemented in bash to debug a running pod.
+    It starts a temporary `spy container` which joins the namespaces of the
+    target container (eg. pid/net/ipc). You can specify the image of `spy
+    container` which should include all the required debugging tools. Thus,
+    the debugging tools need not unnecessarily be bundled with the main
+    application container image.
+
+    `kubespy` is similar to [kubectl-debug](https://github.com/verb/kubectl-debug).
+    In contrast to the latter, kubespy works without the EphemeralContainers
+    feature which is an experimental alpha feature and needs to be activated
+    per pod.
+
+    Meanwhile `kubespy` has its prerequisites - the cluster must use containerd as
+    container runtime and you need to be able to run privileged pods.
+
+    Usage:
+      kubectl spy POD [-c CONTAINER] [-n NAMESPACE] [--spy-image SPY_IMAGE]
+
+  caveats: |
+    This plugin can only work with nodes with a containerd runtime with admin
+    privileges and you need to be able to run privileged pods.
+
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/asaf400/kubespy/releases/download/v1.0.1/kubespy.tar.gz
+    sha256: sha256:74ec776cbf6a469f8487448d6d7b2aed561f7b834082cf4fc5b0097f54f3db92
+    bin: kubespy
+    files:
+    - from: ./kubespy
+      to: kubespy
+    - from: ./LICENSE
+      to: .


### PR DESCRIPTION
I have created a fork of [kubespy](https://github.com/huazhihao/kubespy) | [krew index](https://github.com/kubernetes-sigs/krew-index/blob/master/plugins/spy.yaml) that was vibe coded to support k8s clusters running containerd 📦  (and possibly cri-o ❄️ )

[Fork](https://github.com/asaf400/kubespy)

The existing kubespy is non functional on modern clusters, but I did not want to overwrite it's name..