### PR TITLE
add syncpod

### DIFF
--- a/plugins/syncpod.yaml
+++ b/plugins/syncpod.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: syncpod
+spec:
+  version: v1.0.2
+  homepage: https://github.com/hashmap-kz/kubectl-syncpod
+  shortDescription: High-Speed File Transfer to and from PVCs
+  description: |
+    Small utility that mounts PVCs using a temporary helper pod
+    and transfers files via high-performance SFTP, without impacting
+    application containers or requiring in-container tools.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/hashmap-kz/kubectl-syncpod/releases/download/v1.0.2/kubectl-syncpod_v1.0.2_darwin_amd64.tar.gz
+    sha256: 213d59c86b3a10b1580e28cc84e13d2eee5e15f25edc313f525aff61bf08a417
+    bin: kubectl-syncpod
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/hashmap-kz/kubectl-syncpod/releases/download/v1.0.2/kubectl-syncpod_v1.0.2_darwin_arm64.tar.gz
+    sha256: ed7d5386046e70f00fbf57d4f6d762c4217ee21a02a05c46633f977caf889b31
+    bin: kubectl-syncpod
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/hashmap-kz/kubectl-syncpod/releases/download/v1.0.2/kubectl-syncpod_v1.0.2_linux_amd64.tar.gz
+    sha256: 3089a1d9ecab20342cadd66794bb40407fdaab93ed3349c523f50f4d6089cdbf
+    bin: kubectl-syncpod
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/hashmap-kz/kubectl-syncpod/releases/download/v1.0.2/kubectl-syncpod_v1.0.2_linux_arm64.tar.gz
+    sha256: 1992a880a5a77f15d02f8a08032c17b8753fcae5ac47e8b600830cee210dd88b
+    bin: kubectl-syncpod
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/hashmap-kz/kubectl-syncpod/releases/download/v1.0.2/kubectl-syncpod_v1.0.2_windows_amd64.tar.gz
+    sha256: 4647695e33c515e072b611cc64c5d7828f55e851b7b05e5287e3fb6accde0947
+    bin: kubectl-syncpod.exe


### PR DESCRIPTION
Hello! The new plugin page: https://github.com/hashmap-kz/kubectl-syncpod/tree/master

**Motivation**

There are plenty of tools with seemingly similar functionality at first glance.
Some of them mount PVCs locally, others transfer data between PVCs, perform backups, etc.
However, I was surprised to find that none of them can efficiently transfer files to and from a PVC—especially in a fast and concurrent manner.

Of course, there's always the manual approach: running a debug Pod or building a custom image with the necessary tools—but that's a long and cumbersome way to get things done.

Currently, I'm developing a tool for _PostgreSQL WAL archiving_, and I ran into a roadblock when I needed to transfer a large amount of data inside a PVC.

If the volume is hostPath-based, it's relatively straightforward—you can simply copy the required files onto the target node. But with CSI-backed volumes, where the PVC is mounted as a block device, things become more complex.

In my case, I have three primary storage classes: hostPath, Ceph RBD, and NFS.
Most of my PostgreSQL instances use RBD volumes, so without a lot of shell magic, you can’t just "copy something in" directly.

I've tested this tool with `Ceph RBD`, `distroless-based` images, and hostPath PVCs.
It performs much faster than `kubectl cp` or `kubectl exec`. With those, I gave up waiting for even a 100 GiB copy to finish—and that's a relatively small amount of data.

Perhaps someone will find it useful too.
**Best regards!**
