### PR TITLE
Add gpu-top v0.1.0

### DIFF
--- a/plugins/gpu-top.yaml
+++ b/plugins/gpu-top.yaml
@@ -1,17 +1,3 @@
-# Krew plugin manifest for `kubectl gpu-top`.
-#
-# To publish to the centralized krew-index:
-#   1. Cut a GitHub release at https://github.com/jia-gao/kube-gpu-top/releases
-#      with tarballs named kubectl-gpu-top_<version>_<os>_<arch>.tar.gz
-#      containing the kubectl-gpu-top binary and the LICENSE file.
-#   2. Replace <VERSION> and every REPLACE_WITH_SHA256 placeholder below.
-#      `sha256sum <tarball>` will give you each value.
-#   3. Fork https://github.com/kubernetes-sigs/krew-index and open a PR
-#      adding this file to plugins/gpu-top.yaml.
-#
-# Until the PR lands, users can install directly from a local copy:
-#   kubectl krew install --manifest=./plugins/gpu-top.yaml \
-#     --archive=./dist/kubectl-gpu-top_<version>_<os>_<arch>.tar.gz
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:

--- a/plugins/gpu-top.yaml
+++ b/plugins/gpu-top.yaml
@@ -1,0 +1,88 @@
+# Krew plugin manifest for `kubectl gpu-top`.
+#
+# To publish to the centralized krew-index:
+#   1. Cut a GitHub release at https://github.com/jia-gao/kube-gpu-top/releases
+#      with tarballs named kubectl-gpu-top_<version>_<os>_<arch>.tar.gz
+#      containing the kubectl-gpu-top binary and the LICENSE file.
+#   2. Replace <VERSION> and every REPLACE_WITH_SHA256 placeholder below.
+#      `sha256sum <tarball>` will give you each value.
+#   3. Fork https://github.com/kubernetes-sigs/krew-index and open a PR
+#      adding this file to plugins/gpu-top.yaml.
+#
+# Until the PR lands, users can install directly from a local copy:
+#   kubectl krew install --manifest=./plugins/gpu-top.yaml \
+#     --archive=./dist/kubectl-gpu-top_<version>_<os>_<arch>.tar.gz
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gpu-top
+spec:
+  version: v0.1.0
+  homepage: https://github.com/jia-gao/kube-gpu-top
+  shortDescription: Show GPU utilization per pod across a cluster
+  description: |
+    kube-gpu-top is the missing `kubectl top` for GPUs. It shows per-pod
+    GPU utilization, memory, temperature, and power across every node in
+    your cluster, and can detect wasted GPUs and estimate their cost.
+
+    Requires the kube-gpu-agent DaemonSet to be running in the cluster.
+    See: https://github.com/jia-gao/kube-gpu-top#quick-start
+
+    Common commands:
+      kubectl gpu-top                     # table of all GPUs with pod attribution
+      kubectl gpu-top top -n ml-team      # filter by namespace
+      kubectl gpu-top waste               # detect idle GPUs and estimate cost
+  caveats: |
+    This plugin requires the kube-gpu-agent DaemonSet to be running in
+    the cluster. Install it with:
+
+      kubectl apply -f https://raw.githubusercontent.com/jia-gao/kube-gpu-top/main/deploy/daemonset.yaml
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/jia-gao/kube-gpu-top/releases/download/v0.1.0/kubectl-gpu-top_v0.1.0_linux_amd64.tar.gz
+      sha256: 9b7d12b69483ee8814d346f77e7bdd3b084f85f45e4de792d467ef2cef3e66c5
+      bin: kubectl-gpu-top
+      files:
+        - from: kubectl-gpu-top
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/jia-gao/kube-gpu-top/releases/download/v0.1.0/kubectl-gpu-top_v0.1.0_linux_arm64.tar.gz
+      sha256: 1d91bde1d83cdcc8a2a35dbff1d371871c6f8c82ff2e9a363002e8f64e498a1b
+      bin: kubectl-gpu-top
+      files:
+        - from: kubectl-gpu-top
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/jia-gao/kube-gpu-top/releases/download/v0.1.0/kubectl-gpu-top_v0.1.0_darwin_amd64.tar.gz
+      sha256: ab6463b03c1830d6533d7af9b6a7b67b6f6d9c582b9fe87874b7bad9da2c43d0
+      bin: kubectl-gpu-top
+      files:
+        - from: kubectl-gpu-top
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/jia-gao/kube-gpu-top/releases/download/v0.1.0/kubectl-gpu-top_v0.1.0_darwin_arm64.tar.gz
+      sha256: b9f4355d0f4649f389b065aa522e1f1c3e0faa37a844a882fe581b84b7f843a1
+      bin: kubectl-gpu-top
+      files:
+        - from: kubectl-gpu-top
+          to: .
+        - from: LICENSE
+          to: .


### PR DESCRIPTION
## New plugin: gpu-top

**What it does:** Shows per-pod GPU utilization across a Kubernetes cluster and flags wasted GPUs with cost estimates. Backed by a lightweight DaemonSet agent that joins NVML metrics with the kubelet Pod Resources API.

**Commands:**
- `kubectl gpu-top` — table of all GPUs with pod attribution
- `kubectl gpu-top waste` — detect idle and compute-idle GPUs with monthly cost estimates

**Homepage:** https://github.com/jia-gao/kube-gpu-top
**Release:** https://github.com/jia-gao/kube-gpu-top/releases/tag/v0.1.0
**License:** Apache-2.0

**Platforms:** linux/amd64, linux/arm64, darwin/amd64, darwin/arm64

**Checklist:**
- [x] Plugin manifest follows the [naming guide](https://krew.sigs.k8s.io/docs/developer-guide/develop/naming/)
- [x] Plugin binary is available for download at the URL in the manifest
- [x] sha256 checksums match the release artifacts
- [x] LICENSE file is included in the archive