### PR TITLE
Add aperf plugin

### DIFF
--- a/plugins/aperf.yaml
+++ b/plugins/aperf.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: aperf
+spec:
+  version: v1.2.2
+  homepage: https://github.com/aws/aperf
+  shortDescription: Performance monitoring and debugging for Kubernetes
+  description: |
+    APerf is a CLI tool for performance monitoring and debugging. It records
+    a wide range of performance-related system metrics over a sampling period,
+    such as CPU utilization, memory availability, and PMU counters, and writes
+    them into an archive on disk. APerf processes collected archives, performs
+    analysis, and generates an interactive HTML report with analytical findings
+    and data visualizations.
+  caveats: |
+    Usage:
+      kubectl aperf --node=NODE_NAME [options]
+
+    The plugin deploys a privileged pod on the target node to collect
+    performance data. Requires permissions to create pods in the target
+    namespace.
+
+    For more information, visit: https://github.com/aws/aperf
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values: ["darwin", "linux"]
+    uri: https://github.com/aws/aperf/releases/download/v1.2.2/kubectl-aperf-v1.2.2.tar.gz
+    sha256: 1262849aba55ddbe3a3aab4641a18d7379c79b40ff17af0894758e93f32290a8
+    files:
+    - from: kubectl-aperf-v1.2.2/kubectl-aperf
+      to: .
+    bin: kubectl-aperf

--- a/plugins/aperf.yaml
+++ b/plugins/aperf.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v1.2.2
   homepage: https://github.com/aws/aperf
-  shortDescription: Performance monitoring and debugging for Kubernetes
+  shortDescription: Record and analyze performance metrics on nodes
   description: |
     APerf is a CLI tool for performance monitoring and debugging. It records
     a wide range of performance-related system metrics over a sampling period,

--- a/plugins/aperf.yaml
+++ b/plugins/aperf.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: aperf
 spec:
-  version: v1.2.2
+  version: v1.2.3
   homepage: https://github.com/aws/aperf
   shortDescription: Record and analyze performance metrics on nodes
   description: |
@@ -28,8 +28,8 @@ spec:
       - key: os
         operator: In
         values: ["darwin", "linux"]
-    uri: https://github.com/aws/aperf/releases/download/v1.2.2/kubectl-aperf-v1.2.2.tar.gz
-    sha256: 1262849aba55ddbe3a3aab4641a18d7379c79b40ff17af0894758e93f32290a8
+    uri: https://github.com/aws/aperf/releases/download/v1.2.3/kubectl-aperf-v1.2.3.tar.gz
+    sha256: 0309151fe469a13fb82c7f05a0c603483998c5ff47efa1a7d9f27879f288840b
     files:
     - from: "*/kubectl-aperf"
       to: .

--- a/plugins/aperf.yaml
+++ b/plugins/aperf.yaml
@@ -31,6 +31,8 @@ spec:
     uri: https://github.com/aws/aperf/releases/download/v1.2.2/kubectl-aperf-v1.2.2.tar.gz
     sha256: 1262849aba55ddbe3a3aab4641a18d7379c79b40ff17af0894758e93f32290a8
     files:
-    - from: "*"
+    - from: "*/kubectl-aperf"
+      to: .
+    - from: "*/LICENSE"
       to: .
     bin: kubectl-aperf

--- a/plugins/aperf.yaml
+++ b/plugins/aperf.yaml
@@ -31,6 +31,6 @@ spec:
     uri: https://github.com/aws/aperf/releases/download/v1.2.2/kubectl-aperf-v1.2.2.tar.gz
     sha256: 1262849aba55ddbe3a3aab4641a18d7379c79b40ff17af0894758e93f32290a8
     files:
-    - from: kubectl-aperf-v1.2.2/kubectl-aperf
+    - from: "*"
       to: .
     bin: kubectl-aperf


### PR DESCRIPTION
APerf is a performance monitoring and debugging tool for Linux systems. It collects system metrics (CPU, memory, disk, PMU counters, etc.) and generates interactive HTML reports with automated analysis.

The kubectl plugin deploys a privileged pod on a target node, runs aperf, and copies the report back locally.

Homepage: https://github.com/aws/aperf