### PR TITLE
Add lambda-g plugin v1.0.0 — 6D K8s resource imbalance scanner

### DIFF
--- a/plugins/lambda-g.yaml
+++ b/plugins/lambda-g.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: lambda-g
 spec:
-  version: v1.0.0
+  version: v1.0.1
   shortDescription: "6D resource imbalance scanner for Kubernetes clusters"
   description: |
     Scans your Kubernetes cluster for stranded resources across 6 dimensions:
@@ -33,38 +33,38 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-linux-amd64.tar.gz
-    sha256: "ad71067454bafa231a7abe4ef751ff942397868b61aa8b3e3c278e0aa18225a4"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-linux-amd64.tar.gz
+    sha256: "04cfa585bfa4ec4cd154c227d8a45294603da36a74d30d61fc2d986f96df9c0f"
     bin: kubectl-lambda_g
 
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-linux-arm64.tar.gz
-    sha256: "996c38af356bee652b0126fff68c11ad159e0820ade7f0ad6839738de8aa71c0"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-linux-arm64.tar.gz
+    sha256: "a81d1d070cec689bf49677bfc36687e991f823709bda859acd79dd668bcf3b29"
     bin: kubectl-lambda_g
 
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-darwin-amd64.tar.gz
-    sha256: "f890d7e35a0bb97e105e8db718f09c242bc966e78779ea4540dd8c21091bb5c0"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-darwin-amd64.tar.gz
+    sha256: "a42c732341e4455f2a5757ec5841273db70729e582330e64e4c9367cc72977f6"
     bin: kubectl-lambda_g
 
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-darwin-arm64.tar.gz
-    sha256: "a37fd987f303157cc07c943df6f24b373a98b339382e4fdccf618386aff59214"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-darwin-arm64.tar.gz
+    sha256: "60a497793c29f9b4c7ee7bb8e8a4094a7bde346827883239cd7b8d42118ecff2"
     bin: kubectl-lambda_g
 
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-windows-amd64.zip
-    sha256: "faeb0861eed2c1a9d9e787020e23a4d35e08fd704c0530799ee9b68bab03d7ba"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-windows-amd64.zip
+    sha256: "93e95aa73f76530ef1b22b106e1f627db6db9347948beeaed31ad684be52a6fd"
     bin: kubectl-lambda_g.exe

--- a/plugins/lambda-g.yaml
+++ b/plugins/lambda-g.yaml
@@ -1,0 +1,70 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: lambda-g
+spec:
+  version: v1.0.0
+  shortDescription: "6D resource imbalance scanner for Kubernetes clusters"
+  description: |
+    Scans your Kubernetes cluster for stranded resources across 6 dimensions:
+    CPU, RAM, GPU Core, GPU Memory, IOPS, and Network.
+
+    Detects nodes where one resource is maxed while others sit idle — the
+    kind of imbalance that kubectl top misses because it only shows one
+    dimension at a time.
+
+    Most clusters waste 10-20% of compute budget this way.
+    GPU clusters waste even more (VRAM full but compute idle).
+
+    Commands:
+      kubectl lambda-g scan              Scan cluster
+      kubectl lambda-g scan --detailed   Full per-node breakdown
+      kubectl lambda-g scan --gpu        Include GPU metrics
+      kubectl lambda-g scan --json       JSON output
+      kubectl lambda-g watch             Continuous monitoring
+
+  homepage: https://github.com/0x-auth/lambda-g-auditor
+  caveats: |
+    Requires kubectl to be configured with cluster access.
+    Fix detected imbalances automatically with the lambda-g-controller:
+      helm install lambda-g-controller oci://registry-1.docker.io/bitsabhi/lambda-g-controller
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-linux-amd64.tar.gz
+    sha256: "ad71067454bafa231a7abe4ef751ff942397868b61aa8b3e3c278e0aa18225a4"
+    bin: kubectl-lambda_g
+
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-linux-arm64.tar.gz
+    sha256: "996c38af356bee652b0126fff68c11ad159e0820ade7f0ad6839738de8aa71c0"
+    bin: kubectl-lambda_g
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-darwin-amd64.tar.gz
+    sha256: "f890d7e35a0bb97e105e8db718f09c242bc966e78779ea4540dd8c21091bb5c0"
+    bin: kubectl-lambda_g
+
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-darwin-arm64.tar.gz
+    sha256: "a37fd987f303157cc07c943df6f24b373a98b339382e4fdccf618386aff59214"
+    bin: kubectl-lambda_g
+
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.0/kubectl-lambda_g-windows-amd64.zip
+    sha256: "faeb0861eed2c1a9d9e787020e23a4d35e08fd704c0530799ee9b68bab03d7ba"
+    bin: kubectl-lambda_g.exe

--- a/plugins/lambda-g.yaml
+++ b/plugins/lambda-g.yaml
@@ -33,6 +33,9 @@ spec:
     uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-linux-amd64.tar.gz
     sha256: "04cfa585bfa4ec4cd154c227d8a45294603da36a74d30d61fc2d986f96df9c0f"
     bin: kubectl-lambda_g
+    files:
+    - from: kubectl-lambda_g-linux-amd64
+      to: kubectl-lambda_g
 
   - selector:
       matchLabels:
@@ -41,6 +44,9 @@ spec:
     uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-linux-arm64.tar.gz
     sha256: "a81d1d070cec689bf49677bfc36687e991f823709bda859acd79dd668bcf3b29"
     bin: kubectl-lambda_g
+    files:
+    - from: kubectl-lambda_g-linux-arm64
+      to: kubectl-lambda_g
 
   - selector:
       matchLabels:
@@ -49,6 +55,9 @@ spec:
     uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-darwin-amd64.tar.gz
     sha256: "a42c732341e4455f2a5757ec5841273db70729e582330e64e4c9367cc72977f6"
     bin: kubectl-lambda_g
+    files:
+    - from: kubectl-lambda_g-darwin-amd64
+      to: kubectl-lambda_g
 
   - selector:
       matchLabels:
@@ -57,6 +66,9 @@ spec:
     uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-darwin-arm64.tar.gz
     sha256: "60a497793c29f9b4c7ee7bb8e8a4094a7bde346827883239cd7b8d42118ecff2"
     bin: kubectl-lambda_g
+    files:
+    - from: kubectl-lambda_g-darwin-arm64
+      to: kubectl-lambda_g
 
   - selector:
       matchLabels:
@@ -65,3 +77,6 @@ spec:
     uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-windows-amd64.zip
     sha256: "93e95aa73f76530ef1b22b106e1f627db6db9347948beeaed31ad684be52a6fd"
     bin: kubectl-lambda_g.exe
+    files:
+    - from: kubectl-lambda_g-windows-amd64.exe
+      to: kubectl-lambda_g.exe

--- a/plugins/lambda-g.yaml
+++ b/plugins/lambda-g.yaml
@@ -4,24 +4,21 @@ metadata:
   name: lambda-g
 spec:
   version: v1.0.1
-  shortDescription: "6D resource imbalance scanner for Kubernetes clusters"
+  shortDescription: "6D resource imbalance scanner for K8s"
   description: |
-    Scans your Kubernetes cluster for stranded resources across 6 dimensions:
-    CPU, RAM, GPU Core, GPU Memory, IOPS, and Network.
+    Scans your Kubernetes cluster for stranded resources across 6
+    dimensions: CPU, RAM, GPU Core, GPU Memory, IOPS, and Network.
 
-    Detects nodes where one resource is maxed while others sit idle — the
-    kind of imbalance that kubectl top misses because it only shows one
-    dimension at a time.
+    Detects nodes where one resource is saturated while others sit
+    idle — the kind of imbalance that kubectl top misses because it
+    only shows one dimension at a time.
 
-    Most clusters waste 10-20% of compute budget this way.
-    GPU clusters waste even more (VRAM full but compute idle).
+    Most clusters waste 10-20% of compute budget this way. GPU
+    clusters waste even more (VRAM full but compute idle).
 
-    Commands:
-      kubectl lambda-g scan              Scan cluster
-      kubectl lambda-g scan --detailed   Full per-node breakdown
-      kubectl lambda-g scan --gpu        Include GPU metrics
-      kubectl lambda-g scan --json       JSON output
-      kubectl lambda-g watch             Continuous monitoring
+    Use --detailed for per-node breakdown, --gpu to include GPU
+    metrics, --json for machine-readable output, and watch for
+    continuous monitoring.
 
   homepage: https://github.com/0x-auth/lambda-g-auditor
   caveats: |

--- a/plugins/lambda-g.yaml
+++ b/plugins/lambda-g.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: lambda-g
 spec:
-  version: v1.0.1
+  version: v1.0.2
   shortDescription: "6D resource imbalance scanner for K8s"
   description: |
     Scans your Kubernetes cluster for stranded resources across 6
@@ -30,53 +30,63 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-linux-amd64.tar.gz
-    sha256: "04cfa585bfa4ec4cd154c227d8a45294603da36a74d30d61fc2d986f96df9c0f"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.2/kubectl-lambda_g-linux-amd64.tar.gz
+    sha256: "d3a7e81d84da72c3c52865963b42368972661bf5f102bd39ef5f6ab4778229ab"
     bin: kubectl-lambda_g
     files:
     - from: kubectl-lambda_g-linux-amd64
       to: kubectl-lambda_g
+    - from: LICENSE
+      to: LICENSE
 
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-linux-arm64.tar.gz
-    sha256: "a81d1d070cec689bf49677bfc36687e991f823709bda859acd79dd668bcf3b29"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.2/kubectl-lambda_g-linux-arm64.tar.gz
+    sha256: "c425caa8bb76f7d39bb5641ee35cff7a8e1d360ca04f9dd16e3e41c21985ba4e"
     bin: kubectl-lambda_g
     files:
     - from: kubectl-lambda_g-linux-arm64
       to: kubectl-lambda_g
+    - from: LICENSE
+      to: LICENSE
 
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-darwin-amd64.tar.gz
-    sha256: "a42c732341e4455f2a5757ec5841273db70729e582330e64e4c9367cc72977f6"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.2/kubectl-lambda_g-darwin-amd64.tar.gz
+    sha256: "6630a6470c0575952a7f90b19f1376692051651c5ef566a73b314e9e1eb4aa17"
     bin: kubectl-lambda_g
     files:
     - from: kubectl-lambda_g-darwin-amd64
       to: kubectl-lambda_g
+    - from: LICENSE
+      to: LICENSE
 
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-darwin-arm64.tar.gz
-    sha256: "60a497793c29f9b4c7ee7bb8e8a4094a7bde346827883239cd7b8d42118ecff2"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.2/kubectl-lambda_g-darwin-arm64.tar.gz
+    sha256: "ce30ad6e9f421007ef230acedbf6167a9bda021067e705fea2759b1d3716a805"
     bin: kubectl-lambda_g
     files:
     - from: kubectl-lambda_g-darwin-arm64
       to: kubectl-lambda_g
+    - from: LICENSE
+      to: LICENSE
 
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.1/kubectl-lambda_g-windows-amd64.zip
-    sha256: "93e95aa73f76530ef1b22b106e1f627db6db9347948beeaed31ad684be52a6fd"
+    uri: https://github.com/0x-auth/lambda-g-auditor/releases/download/v1.0.2/kubectl-lambda_g-windows-amd64.zip
+    sha256: "e2fe0e430d2fc556b025e4ae49d85b4a9b285627ec28d884d1381e8288254cfd"
     bin: kubectl-lambda_g.exe
     files:
     - from: kubectl-lambda_g-windows-amd64.exe
       to: kubectl-lambda_g.exe
+    - from: LICENSE
+      to: LICENSE


### PR DESCRIPTION
## New Plugin: `kubectl lambda-g`

Scans your Kubernetes cluster for stranded resources across 6 dimensions: **CPU, RAM, GPU Core, GPU Memory, IOPS, Network**.

Detects nodes where one resource is maxed while others sit idle — the kind of cross-dimensional imbalance that `kubectl top` misses.

```bash
kubectl krew install lambda-g
kubectl lambda-g scan
kubectl lambda-g scan --detailed
kubectl lambda-g watch
```

- Self-contained Go binary, no dependencies
- All platforms: linux/darwin/windows × amd64/arm64
- Homepage: https://github.com/0x-auth/lambda-g-auditor
- Open source (MIT)