### PR TITLE
Inspect is a plugin to visually browse CRDs schemas

### DIFF
--- a/plugins/inspect.yaml
+++ b/plugins/inspect.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: inspect
+spec:
+  version: v1.0.0 # This will be replaced with the actual version during release
+  homepage: https://github.com/irenedo/kubectl-inspect
+  shortDescription: Browse Kubernetes resources interactively with a TUI tree browser
+  description: |
+    An interactive terminal UI for browsing Kubernetes resource and CRD field
+    structures. Instead of typing kubectl explain repeatedly, use the collapsible
+    tree view to explore fields and see full explain output in real-time.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/irenedo/kubectl-inspect/releases/download/v1.0.0/kubectl-inspect_v1.0.0_darwin_amd64.tar.gz
+    sha256: c554bfb8735af89cbe5a0232129d8b2d81beff4a2291dc845a62a8b091e63e93
+    bin: kubectl-inspect
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/irenedo/kubectl-inspect/releases/download/v1.0.0/kubectl-inspect_v1.0.0_darwin_arm64.tar.gz
+    sha256: e412c78e8ba582768e55e5f29d18439b5c630ddd85c93e67eb0dd9a9f26c0d1c
+    bin: kubectl-inspect
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/irenedo/kubectl-inspect/releases/download/v1.0.0/kubectl-inspect_v1.0.0_linux_amd64.tar.gz
+    sha256: 2cb0dc3c94a24f249f4f9cbc50e7147d5b8cad48c4038fbcaedb2516a21ad066
+    bin: kubectl-inspect
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/irenedo/kubectl-inspect/releases/download/v1.0.0/kubectl-inspect_v1.0.0_linux_arm64.tar.gz
+    sha256: 89e1c363609050999bd51081bf8660b31a553a1fea8491bc53d1c53183bba0d9
+    bin: kubectl-inspect
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/irenedo/kubectl-inspect/releases/download/v1.0.0/kubectl-inspect_v1.0.0_windows_amd64.tar.gz
+    sha256: 4636adcc334a6ac0754b55617d11d0ef8cb6aa39a14d4a19bdc78ec93d4c8eda
+    bin: kubectl-inspect.exe


### PR DESCRIPTION
feat: add interactive TUI for browsing Kubernetes resource field structures

Introduce kubectl-inspect, a kubectl plugin that provides a split-pane terminal UI for exploring Kubernetes resource and CRD schemas interactively.

Instead of repeatedly running
for each nested field, users can now navigate a collapsible tree on the left pane while the right pane displays the full  output for the selected field in real time.

Key features:
- Collapsible tree view for any built-in resource or custom CRD
- Live detail pane showing kubectl explain output per selected field
- Support for named types (ObjectMeta, DeploymentSpec, []Container, etc.)
- Copy field path to clipboard with Enter (e.g. spec.template.spec.containers)
- Always fetches fresh data from the API server
- Keyboard-driven navigation (↑/↓, Tab, PgUp/PgDown, q to quit)

Usage: kubectl inspect <resource> [flags]

<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
