### PR TITLE
Add hubble-collector plugin

### DIFF
--- a/plugins/hubble-collector.yaml
+++ b/plugins/hubble-collector.yaml
@@ -17,7 +17,7 @@ spec:
           os: linux
           arch: amd64
       uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-linux-amd64.tar.gz
-      sha256: "3a7f4a4678e151e9172f5e1b47979071f5ced8043669a46d3abadc2a65203d59"
+      sha256: "4d0fed5436094e4178b682f5b91e8d48d833cee8a9202b55c97ea10105bcb202"
       bin: kubectl-hubble-collector
 
     - selector:
@@ -25,7 +25,7 @@ spec:
           os: darwin
           arch: amd64
       uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-darwin-amd64.tar.gz
-      sha256: "9824c76aef8b7779e335f18f99e6095a20d16fc3ae1dae78fbe2c596fe0a3a76"
+      sha256: "b5a773ddfe86372550a6f42f6990b96e0e9df1e8c64546f7212dfa303b9016c3"
       bin: kubectl-hubble-collector
 
     - selector:
@@ -33,7 +33,7 @@ spec:
           os: darwin
           arch: arm64
       uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-darwin-arm64.tar.gz
-      sha256: "b4845539f57ae239469c36216c8ae07702a5077902e3a20e532aa48bfab84b0d"
+      sha256: "e0247271ee67a963f1ccabc3eec91fd5b7314469fb2d0773cb32521f2a54955c"
       bin: kubectl-hubble-collector
 
     - selector:
@@ -41,5 +41,5 @@ spec:
           os: windows
           arch: amd64
       uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-windows-amd64.tar.gz
-      sha256: "23a70463aaa6adc1dadea8ac5457985e45fc9cdde79fb0796d98f634e6059c4d"
+      sha256: "cd5197b834995c9b9002b0e32c8f843e198e329cd264ca3b3c2e6220b20f710d"
       bin: kubectl-hubble-collector.exe

--- a/plugins/hubble-collector.yaml
+++ b/plugins/hubble-collector.yaml
@@ -1,0 +1,45 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: hubble-collector
+spec:
+  version: v1.0.0
+  homepage: https://github.com/instinctd/network-policy-generator
+  shortDescription: Collect Hubble network flows and generate CiliumNetworkPolicy
+  description: |
+    Connects to Hubble and collects real network flows between pods,
+    then automatically generates CiliumNetworkPolicy with egress/ingress
+    rules based on observed traffic. Supports filtering by namespace,
+    label, verdict, and follow mode.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-linux-amd64.tar.gz
+      sha256: "3a7f4a4678e151e9172f5e1b47979071f5ced8043669a46d3abadc2a65203d59"
+      bin: kubectl-hubble-collector
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-darwin-amd64.tar.gz
+      sha256: "9824c76aef8b7779e335f18f99e6095a20d16fc3ae1dae78fbe2c596fe0a3a76"
+      bin: kubectl-hubble-collector
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-darwin-arm64.tar.gz
+      sha256: "b4845539f57ae239469c36216c8ae07702a5077902e3a20e532aa48bfab84b0d"
+      bin: kubectl-hubble-collector
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/instinctd/network-policy-generator/releases/download/v1.0.0/kubectl-hubble-collector-windows-amd64.tar.gz
+      sha256: "23a70463aaa6adc1dadea8ac5457985e45fc9cdde79fb0796d98f634e6059c4d"
+      bin: kubectl-hubble-collector.exe


### PR DESCRIPTION
## New plugin: hubble-collector

Collects Hubble network flows and automatically generates CiliumNetworkPolicy based on real traffic.

### Features
- Automatic egress/ingress rule generation from real traffic
- Pod CIDR / Service CIDR aware IP classification
- Label filtering (removes unstable Kubernetes/Cilium labels)
- LoadBalancer and Ingress Controller support
- Auto DNS rules

### Plugin info
- **Homepage**: https://github.com/instinctd/network-policy-generator
- **Version**: v1.0.0
- **Platforms**: linux/amd64, darwin/amd64, darwin/arm64, windows/amd64

### Testing
```bash
kubectl krew install hubble-collector
kubectl hubble-collector -n production -o flows.json --cilium true
```