### PR TITLE
Add triage plugin

### DIFF
--- a/plugins/triage.yaml
+++ b/plugins/triage.yaml
@@ -3,62 +3,56 @@ kind: Plugin
 metadata:
   name: triage
 spec:
-  version: "v0.1.1"
-  platforms:
-  - selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-    uri: https://github.com/Lc-Lin/kubectl-triage/releases/download/v0.1.1/kubectl-triage_linux_amd64.tar.gz
-    sha256: "d212e7202a4db0df9fe611057067fe8388412f2efb271ae2bd185e24c1fa665b"
-    files:
-    - from: "kubectl-triage"
-      to: "."
-    - from: LICENSE
-      to: "."
-    bin: "kubectl-triage"
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-    uri: https://github.com/Lc-Lin/kubectl-triage/releases/download/v0.1.1/kubectl-triage_darwin_amd64.tar.gz
-    sha256: "baabb936ec8051cd06910c3fa1678d4f8641cc717397e120b0f765023d548b9f"
-    files:
-    - from: "kubectl-triage"
-      to: "."
-    - from: LICENSE
-      to: "."
-    bin: "kubectl-triage"
-  - selector:
-      matchLabels:
-        os: windows
-        arch: amd64
-    uri: https://github.com/Lc-Lin/kubectl-triage/releases/download/v0.1.1/kubectl-triage_windows_amd64.zip
-    sha256: "112553a86b6398337ba27b41397f75a5d5cd1dde7961b6b18ea472a3938484e7"
-    files:
-    - from: "kubectl-triage.exe"
-      to: "."
-    - from: LICENSE
-      to: "."
-    bin: "kubectl-triage.exe"
-  shortDescription: Fast diagnostics for failed pods
-  homepage: https://github.com/Lc-Lin/kubectl-triage
+  version: "{{ .TagName }}"
+  homepage: https://github.com/khvedela/triage
+  shortDescription: "Diagnose broken Kubernetes workloads"
   description: |
-    kubectl-triage provides 5-second diagnostic snapshots for failed
-    Kubernetes pods.
+    triage cross-references pod status, events, owner references, services,
+    endpoints, PVCs, and RBAC in one pass, returning ranked findings with
+    evidence, confidence levels, and exact next commands.
 
-    It intelligently aggregates the critical information you need:
-    - Pod status and container states
-    - Critical events (Warning/Error only, filtering out noise)
-    - Previous crash logs (if container restarted)
-    - Current container logs
-
-    Only failed/restarted containers are shown by default, keeping output
-    focused.
-
-    Key features:
-    - Smart health detection (catches "flapping" pods)
-    - Intelligent container filtering (RestartCount > 0)
-    - Signal-over-noise event filtering
-    - Parallel log collection for speed
-    - Beautiful color-coded output
+    Usage:
+      kubectl triage pod <name> [-n namespace]
+      kubectl triage deployment <name> [-n namespace]
+      kubectl triage namespace <ns>
+      kubectl triage cluster
+  caveats: |
+    triage requires read access to pods, events, deployments, replicasets,
+    services, endpoints, configmaps, secrets, persistentvolumeclaims, and nodes.
+    Run `kubectl triage rules list` to see all available diagnostic rules.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_amd64.tar.gz
+      sha256: "{{ .linux_amd64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_arm64.tar.gz
+      sha256: "{{ .linux_arm64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_amd64.tar.gz
+      sha256: "{{ .darwin_amd64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_arm64.tar.gz
+      sha256: "{{ .darwin_arm64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_windows_amd64.zip
+      sha256: "{{ .windows_amd64_sha256 }}"
+      bin: triage.exe

--- a/plugins/triage.yaml
+++ b/plugins/triage.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: triage
 spec:
-  version: "{{ .TagName }}"
+  version: "v0.1.1"
   homepage: https://github.com/khvedela/triage
   shortDescription: "Diagnose broken Kubernetes workloads"
   description: |
@@ -25,34 +25,34 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_amd64.tar.gz
-      sha256: "{{ .linux_amd64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_linux_amd64.tar.gz
+      sha256: "20f0ee65eec649c0f69a8d3a04e9bc405c0b08d9a792c270cb6843d9a07d7ff8"
       bin: triage
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_arm64.tar.gz
-      sha256: "{{ .linux_arm64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_linux_arm64.tar.gz
+      sha256: "4ba9c0db7df4eb38e98af3ece4acdb877aaa349595e75215241f8c10cb3b397d"
       bin: triage
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_amd64.tar.gz
-      sha256: "{{ .darwin_amd64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_darwin_amd64.tar.gz
+      sha256: "58210bc4fdeea79bb515b52339adfb808f5e1dbf04032f3d38154e8e9328fa6d"
       bin: triage
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_arm64.tar.gz
-      sha256: "{{ .darwin_arm64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_darwin_arm64.tar.gz
+      sha256: "99e18f242de248e8297be5deeb43ca10866e99d6765b99f633655ecc2bf990cd"
       bin: triage
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_windows_amd64.zip
-      sha256: "{{ .windows_amd64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_windows_amd64.zip
+      sha256: "037517f1b8bfed6816004fc9c97ff8fb981139afe92e860c3803abefb5175154"
       bin: triage.exe


### PR DESCRIPTION
## Summary

This adds the triage plugin, a kubectl-native diagnostic CLI that turns broken Kubernetes workload symptoms into ranked root-cause findings, evidence, and exact next commands to run.

triage cross-references pod status, events, owner references, services, endpoints, PVCs, and RBAC in one pass—solving the common workflow of running `kubectl describe`, `kubectl get events`, `kubectl logs`, etc. in sequence.

## Plugin Details

- **Repository:** https://github.com/khvedela/triage
- **Version:** v0.1.1
- **License:** Apache 2.0
- **Platforms:** Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)

## Testing

- [x] Manifest is valid YAML
- [x] All SHA256 checksums verified
- [x] Local installation tested: `kubectl krew install --manifest=plugins/triage.yaml --archive=dist/triage_darwin_arm64.tar.gz`
- [x] Plugin executes: `kubectl triage --version`
- [x] LICENSE included in all release archives