### PR TITLE
Add kubediag plugin

### DIFF
--- a/plugins/kubediag.yaml
+++ b/plugins/kubediag.yaml
@@ -1,0 +1,61 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: kubediag
+spec:
+  version: "v0.2.0"
+  homepage: https://github.com/khvedela/kubediag
+  shortDescription: "Diagnose broken Kubernetes workloads"
+  description: |
+    kubediag cross-references pod status, events, owner references, services,
+    endpoints, PVCs, and RBAC in one pass, returning ranked findings with
+    evidence, confidence levels, and exact next commands.
+
+    Usage:
+      kubectl kubediag pod <name> [-n namespace]
+      kubectl kubediag deployment <name> [-n namespace]
+      kubectl kubediag namespace <ns>
+      kubectl kubediag cluster
+      kubectl kubediag report namespace <ns>
+      kubectl kubediag report cluster
+  caveats: |
+    kubediag requires read access to pods, events, deployments, replicasets,
+    services, endpoints, configmaps, secrets, persistentvolumeclaims, nodes,
+    and resourcequotas. Run `kubectl kubediag rules list` to see all 28
+    available diagnostic rules.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_linux_amd64.tar.gz
+      sha256: "0dbd22e7562632fc6818656fd719f090d2925754a602432b3be629253c74b007"
+      bin: kubediag
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_linux_arm64.tar.gz
+      sha256: "c590a630e86b0958aefa15eab708e17d942e52ce44a7536169fe3653c14f04c7"
+      bin: kubediag
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_darwin_amd64.tar.gz
+      sha256: "7e7e08691654736283ac8e2d4afe53c62be0aa5cc2f715ba2181fa13156a0b9f"
+      bin: kubediag
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_darwin_arm64.tar.gz
+      sha256: "4fb898a5d868d61bcfcafa766b6751d3f9d01d29e117fec98880388733ca095a"
+      bin: kubediag
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_windows_amd64.zip
+      sha256: "5c553b8a9c315988b50f3f92c2fae750ebb06ca23b4f4d979adb23a1af79d0a3"
+      bin: kubediag.exe

--- a/plugins/kubediag.yaml
+++ b/plugins/kubediag.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: kubediag
 spec:
-  version: "v0.2.0"
+  version: "v0.2.1"
   homepage: https://github.com/khvedela/kubediag
   shortDescription: "Diagnose broken Kubernetes workloads"
   description: |
@@ -28,34 +28,34 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_linux_amd64.tar.gz
-      sha256: "0dbd22e7562632fc6818656fd719f090d2925754a602432b3be629253c74b007"
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.1/kubediag_linux_amd64.tar.gz
+      sha256: "4443878e51e0f7944d3038d36aa243fd7bcf027ac5c628447a2a876c512c70bb"
       bin: kubediag
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_linux_arm64.tar.gz
-      sha256: "c590a630e86b0958aefa15eab708e17d942e52ce44a7536169fe3653c14f04c7"
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.1/kubediag_linux_arm64.tar.gz
+      sha256: "b70fe1152e93f8fc891bf3c4052db6e5f78e51a9571f3ebaf4e749f5521fad8b"
       bin: kubediag
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_darwin_amd64.tar.gz
-      sha256: "7e7e08691654736283ac8e2d4afe53c62be0aa5cc2f715ba2181fa13156a0b9f"
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.1/kubediag_darwin_amd64.tar.gz
+      sha256: "0a867a502ae1a6febc330b93a3c52fca58c046865d294af9b331d53d3bd961ea"
       bin: kubediag
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_darwin_arm64.tar.gz
-      sha256: "4fb898a5d868d61bcfcafa766b6751d3f9d01d29e117fec98880388733ca095a"
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.1/kubediag_darwin_arm64.tar.gz
+      sha256: "1e44aebd9cf1ce41188f57e386b1dce69154813218fc51b83653bc976fb3d3c3"
       bin: kubediag
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.0/kubediag_windows_amd64.zip
-      sha256: "5c553b8a9c315988b50f3f92c2fae750ebb06ca23b4f4d979adb23a1af79d0a3"
+      uri: https://github.com/khvedela/kubediag/releases/download/v0.2.1/kubediag_windows_amd64.zip
+      sha256: "2404760180b89e2d73c90ee722d8088106b8f0cd521464e13de0fcd1286c0f2c"
       bin: kubediag.exe

--- a/plugins/triage.yaml
+++ b/plugins/triage.yaml
@@ -3,62 +3,56 @@ kind: Plugin
 metadata:
   name: triage
 spec:
-  version: "v0.1.1"
-  platforms:
-  - selector:
-      matchLabels:
-        os: linux
-        arch: amd64
-    uri: https://github.com/Lc-Lin/kubectl-triage/releases/download/v0.1.1/kubectl-triage_linux_amd64.tar.gz
-    sha256: "d212e7202a4db0df9fe611057067fe8388412f2efb271ae2bd185e24c1fa665b"
-    files:
-    - from: "kubectl-triage"
-      to: "."
-    - from: LICENSE
-      to: "."
-    bin: "kubectl-triage"
-  - selector:
-      matchLabels:
-        os: darwin
-        arch: amd64
-    uri: https://github.com/Lc-Lin/kubectl-triage/releases/download/v0.1.1/kubectl-triage_darwin_amd64.tar.gz
-    sha256: "baabb936ec8051cd06910c3fa1678d4f8641cc717397e120b0f765023d548b9f"
-    files:
-    - from: "kubectl-triage"
-      to: "."
-    - from: LICENSE
-      to: "."
-    bin: "kubectl-triage"
-  - selector:
-      matchLabels:
-        os: windows
-        arch: amd64
-    uri: https://github.com/Lc-Lin/kubectl-triage/releases/download/v0.1.1/kubectl-triage_windows_amd64.zip
-    sha256: "112553a86b6398337ba27b41397f75a5d5cd1dde7961b6b18ea472a3938484e7"
-    files:
-    - from: "kubectl-triage.exe"
-      to: "."
-    - from: LICENSE
-      to: "."
-    bin: "kubectl-triage.exe"
-  shortDescription: Fast diagnostics for failed pods
-  homepage: https://github.com/Lc-Lin/kubectl-triage
+  version: "{{ .TagName }}"
+  homepage: https://github.com/khvedela/triage
+  shortDescription: "Diagnose broken Kubernetes workloads"
   description: |
-    kubectl-triage provides 5-second diagnostic snapshots for failed
-    Kubernetes pods.
+    triage cross-references pod status, events, owner references, services,
+    endpoints, PVCs, and RBAC in one pass, returning ranked findings with
+    evidence, confidence levels, and exact next commands.
 
-    It intelligently aggregates the critical information you need:
-    - Pod status and container states
-    - Critical events (Warning/Error only, filtering out noise)
-    - Previous crash logs (if container restarted)
-    - Current container logs
-
-    Only failed/restarted containers are shown by default, keeping output
-    focused.
-
-    Key features:
-    - Smart health detection (catches "flapping" pods)
-    - Intelligent container filtering (RestartCount > 0)
-    - Signal-over-noise event filtering
-    - Parallel log collection for speed
-    - Beautiful color-coded output
+    Usage:
+      kubectl triage pod <name> [-n namespace]
+      kubectl triage deployment <name> [-n namespace]
+      kubectl triage namespace <ns>
+      kubectl triage cluster
+  caveats: |
+    triage requires read access to pods, events, deployments, replicasets,
+    services, endpoints, configmaps, secrets, persistentvolumeclaims, and nodes.
+    Run `kubectl triage rules list` to see all available diagnostic rules.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_amd64.tar.gz
+      sha256: "{{ .linux_amd64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_arm64.tar.gz
+      sha256: "{{ .linux_arm64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_amd64.tar.gz
+      sha256: "{{ .darwin_amd64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_arm64.tar.gz
+      sha256: "{{ .darwin_arm64_sha256 }}"
+      bin: triage
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_windows_amd64.zip
+      sha256: "{{ .windows_amd64_sha256 }}"
+      bin: triage.exe

--- a/plugins/triage.yaml
+++ b/plugins/triage.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: triage
 spec:
-  version: "{{ .TagName }}"
+  version: "v0.1.1"
   homepage: https://github.com/khvedela/triage
   shortDescription: "Diagnose broken Kubernetes workloads"
   description: |
@@ -25,34 +25,34 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_amd64.tar.gz
-      sha256: "{{ .linux_amd64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_linux_amd64.tar.gz
+      sha256: "20f0ee65eec649c0f69a8d3a04e9bc405c0b08d9a792c270cb6843d9a07d7ff8"
       bin: triage
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_linux_arm64.tar.gz
-      sha256: "{{ .linux_arm64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_linux_arm64.tar.gz
+      sha256: "4ba9c0db7df4eb38e98af3ece4acdb877aaa349595e75215241f8c10cb3b397d"
       bin: triage
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_amd64.tar.gz
-      sha256: "{{ .darwin_amd64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_darwin_amd64.tar.gz
+      sha256: "58210bc4fdeea79bb515b52339adfb808f5e1dbf04032f3d38154e8e9328fa6d"
       bin: triage
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_darwin_arm64.tar.gz
-      sha256: "{{ .darwin_arm64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_darwin_arm64.tar.gz
+      sha256: "99e18f242de248e8297be5deeb43ca10866e99d6765b99f633655ecc2bf990cd"
       bin: triage
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/khvedela/triage/releases/download/{{ .TagName }}/triage_windows_amd64.zip
-      sha256: "{{ .windows_amd64_sha256 }}"
+      uri: https://github.com/khvedela/triage/releases/download/v0.1.1/triage_windows_amd64.zip
+      sha256: "037517f1b8bfed6816004fc9c97ff8fb981139afe92e860c3803abefb5175154"
       bin: triage.exe


### PR DESCRIPTION
## Add kubediag plugin

**kubediag** is a kubectl-native diagnostic CLI that surfaces probable root causes for broken Kubernetes workloads in seconds.

### What it does

kubediag cross-references pod status, events, owner references, services, endpoints, PVCs, and RBAC in one pass, returning ranked findings with evidence and exact next commands to run. It automates the forensic sequence most ops teams do manually:

```bash
kubectl describe pod ...
kubectl get events ...
kubectl logs ...
kubectl get svc,endpoints ...
# ... then Google the error message
