### PR TITLE
Add pod-why-dead plugin for Kubernetes postmortem reports

### DIFF
--- a/plugins/pod-why-dead.yaml
+++ b/plugins/pod-why-dead.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: pod-why-dead
+spec:
+  version: v0.1.0
+  homepage: https://github.com/NotHarshhaa/pod-why-dead
+  shortDescription: "Full death story of any Kubernetes pod"
+  description: |
+    One command to get the full death story of any Kubernetes pod.
+    Gathers exit codes, previous logs, events, node conditions, and
+    resource usage into a structured postmortem report.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/NotHarshhaa/pod-why-dead/releases/download/v0.1.0/pod-why-dead_0.1.0_linux_amd64.tar.gz
+      sha256: "84d9d4427e963f88609ccbfb7889abc0f26105038ff7bd7a9fd8ad6eda79d099"
+      bin: pod-why-dead
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/NotHarshhaa/pod-why-dead/releases/download/v0.1.0/pod-why-dead_0.1.0_linux_arm64.tar.gz
+      sha256: "59970620b82aed05bd08a39c2639e7071123b4695ed401a5be588eda93ac691e"
+      bin: pod-why-dead
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/NotHarshhaa/pod-why-dead/releases/download/v0.1.0/pod-why-dead_0.1.0_darwin_amd64.tar.gz
+      sha256: "598ccaefcb573368a9d42705417b2c1a1d339b1fc2adbdb075c69f310b05c582"
+      bin: pod-why-dead
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/NotHarshhaa/pod-why-dead/releases/download/v0.1.0/pod-why-dead_0.1.0_darwin_arm64.tar.gz
+      sha256: "1d7ca1e715f1d3c6807ec2a6ebdb75ff14d56daabed0d2cb88d25ab1e7090efa"
+      bin: pod-why-dead
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/NotHarshhaa/pod-why-dead/releases/download/v0.1.0/pod-why-dead_0.1.0_windows_amd64.zip
+      sha256: "aa8827977fa8f9ca6d73892220f682bb02e674acedf02ee28930670b7e20c085"
+      bin: pod-why-dead.exe


### PR DESCRIPTION
## Summary

**Plugin Name**: pod-why-dead

**Primary Use Case**: Post-mortem analysis of DEAD Kubernetes pods (not live pod inspection)

## Plugin Details

- **Repository:** https://github.com/NotHarshhaa/pod-why-dead
- **Version:** v0.1.0
- **License:** MIT
- **Platforms:** Linux (amd64, arm64), macOS (amd64, arm64), Windows (amd64)

**Key Differentiators from Existing Plugins**:

### 1. Focus on Dead Pods Only
- Reconstructs full death story after a pod is completely gone
- Accesses previous logs (`kubectl logs --previous`) and historical state
- Existing plugins (pod-inspect, pod-lens, sick-pods) focus on live/not-ready pods

### 2. Comprehensive Death Analysis
- **Exit code deep dive**: Detailed explanations for exit codes (1, 127, 128+signal, etc.)
- **Event timeline**: From scheduling to termination in chronological order
- **Node conditions at death**: MemoryPressure, DiskPressure, PIDPressure at exact time of death
- **Resource reconstruction**: Peak usage vs limits even when pod is dead
- **Restart history**: First death vs 47th restart

### 3. Actionable Recommendations
- Provides concrete next steps based on specific death cause
- Suggests ready-to-run kubectl commands for debugging
- No existing plugin offers automated recommendations

### 4. Multiple Output Formats
- Text (terminal), JSON (for incident logs/automation), Markdown (for incident reports/Notion/Confluence)
- Enables integration with incident management workflows

### 5. One-Command Efficiency
- Replaces 5+ commands: `kubectl describe`, `kubectl logs --previous`, `kubectl get events`, `kubectl describe node`, `kubectl top pod`
- Saves 10-20 minutes per incident

**Target Users**: SREs, DevOps engineers, on-call engineers debugging production incidents

**Unique Value**: The only Krew plugin specifically designed for post-mortem pod death analysis with automated recommendations and incident-ready output formats.

## Testing

* [x] Manifest is valid YAML
* [x] All SHA256 checksums verified against release artifacts
* [x] Release binaries verified from [https://github.com/NotHarshhaa/pod-why-dead/releases/tag/v0.1.0](https://github.com/NotHarshhaa/pod-why-dead/releases/tag/v0.1.0)
* [x] Plugin executes: `pod-why-dead --help`
* [x] LICENSE included in repository