### PR TITLE
Add diff-watch plugin

### DIFF
--- a/plugins/diff-watch.yaml
+++ b/plugins/diff-watch.yaml
@@ -1,0 +1,51 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: diff-watch
+spec:
+  version: v0.1.0
+  homepage: https://github.com/databus23/kubectl-diff-watch
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/databus23/kubectl-diff-watch/releases/download/v0.1.0/kubectl-diff-watch_darwin_amd64.tar.gz
+    sha256: 4daca85e96fcb480deaa28830903b54451c72ad08967bfa9fc56fe37892e0f48
+    bin: kubectl-diff-watch
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/databus23/kubectl-diff-watch/releases/download/v0.1.0/kubectl-diff-watch_darwin_arm64.tar.gz
+    sha256: cf62dc21cae34be6a9799c45eadfd485d17dd6ba60d63bc100243e6c300574a7
+    bin: kubectl-diff-watch
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/databus23/kubectl-diff-watch/releases/download/v0.1.0/kubectl-diff-watch_linux_amd64.tar.gz
+    sha256: 20b91de225d19c43cda1002b19d75ac63c5643de2b116cee09935bd83693e21b
+    bin: kubectl-diff-watch
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/databus23/kubectl-diff-watch/releases/download/v0.1.0/kubectl-diff-watch_linux_arm64.tar.gz
+    sha256: b144ab836a818de5802bd1b2ce83f6a74c984522a15155ce74677364075e1c78
+    bin: kubectl-diff-watch
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/databus23/kubectl-diff-watch/releases/download/v0.1.0/kubectl-diff-watch_windows_amd64.zip
+    sha256: 04881dd7270bda0ab0213ed850b956869c1660d5dbc005fcd88e7a1cfade1d19
+    bin: kubectl-diff-watch.exe
+  shortDescription: Watch resources and show diffs when they change
+  description: |
+    Watches Kubernetes resources in real-time and displays colored diffs
+    whenever a resource changes. Useful for observing how controllers,
+    operators, or manual edits modify resources over time.
+
+    Supports colored unified diff (default), structural diff via dyff,
+    and plain text output formats.


### PR DESCRIPTION
## New Plugin Submission: diff-watch

**Plugin name:** diff-watch  
**Plugin description:** Watch Kubernetes resources and show colored diffs when they change  
**Repository:** https://github.com/databus23/kubectl-diff-watch  
**Plugin version:** v0.1.0

### What does this plugin do?

`kubectl diff-watch` watches Kubernetes resources in real-time and displays colored diffs whenever a resource changes. This is useful for observing how controllers, operators, or manual edits modify resources over time.

### Features
- Pure Go implementation — no shell-outs to `kubectl`, `diff`, or other tools
- Colored unified diff output (default)
- Structural diff via dyff (`--output dyff`)
- Noise reduction: strips managedFields, resourceVersion, generation by default
- Informer-based watch with automatic reconnection
- Supports `--namespace`, `--context`, `-l` (label selector), `--all-namespaces`
- Watch multiple resource types simultaneously
- Timestamps showing when each change occurred
- No runtime dependencies — works on Windows natively

### Comparison with existing `watch-diff` plugin

There is an existing [`watch-diff`](https://github.com/alexmt/kubectl-watch-diff) plugin in the index. While the high-level concept is similar, the implementations and capabilities differ substantially:

| | **diff-watch** | **watch-diff** |
|--|----------------|----------------|
| Architecture | Pure Go, Kubernetes informers | Shells out to `kubectl get -w` + system `diff` |
| Resource scope | Label/field selectors, multiple types, `--all-namespaces` | Single named resource only |
| Namespace/context | `--namespace`, `--context` flags | Not supported |
| Noise reduction | Strips managedFields, resourceVersion, generation | None |
| Diff behavior | Incremental (v0→v1, v1→v2, v2→v3) | [Diffs against initial version](https://github.com/alexmt/kubectl-watch-diff/issues/3) (v0→v1, v0→v2, v0→v3) |
| Output | Colored, timestamps, configurable context, dyff support | Plain `diff -u` |
| Runtime deps | None — works on Windows natively | Requires `kubectl` and `diff` in PATH |

Given these fundamental architectural differences, contributing improvements upstream would essentially require a complete rewrite of `watch-diff`.

### Checklist
- [x] Plugin naming guide reviewed
- [x] Plugin development best practices followed
- [x] Source code is open source (Apache 2.0)
- [x] LICENSE file included in archive
- [x] Tagged git release with semantic version (v0.1.0)
- [x] Tested plugin installation locally with `kubectl krew install --manifest`
- [x] Tested plugin installation from remote URI with SHA256 validation

### Platforms supported
- darwin/amd64
- darwin/arm64
- linux/amd64
- linux/arm64
- windows/amd64