### PR TITLE
ci: declare contents: read + actions: write on the validate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
       - master
   pull_request:
 
+# actions/cache@v5 saves the Go module cache on miss.
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     name: Validate plugin manifests


### PR DESCRIPTION
The single CI workflow in this repo runs `validate-krew-manifest` against changed plugin manifests on PR or push to master. It uses `actions/cache@v5` for the Go module cache, which saves on miss and therefore needs `actions: write` in addition to the standard `contents: read` for the checkout.

YAML validated locally with `yaml.safe_load`.