### PR TITLE
feat: update k8i to v0.1.1

### DIFF
--- a/plugins/k8i.yaml
+++ b/plugins/k8i.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: k8i
 spec:
-  version: v0.1.0
+  version: v0.1.1
   homepage: https://github.com/ViktorUJ/kubectl-k8i
   shortDescription: Display Kubernetes node resources with color-coded load indicators
   description: |
@@ -38,41 +38,41 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.0/kubectl-k8i_linux_amd64.tar.gz
-      sha256: "274605c4288db8ec06a83fb72ea7b00a0c26b17884396d7d4fbb3adaed2bc941"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_linux_amd64.tar.gz
+      sha256: "9cc50c4ffc4b3790f24bc1fe2273f5786a8ff2f6ad205e2e75796640934861e9"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.0/kubectl-k8i_linux_arm64.tar.gz
-      sha256: "43b6c62a03de6a501bcde97da54cbf9fdf870165f8a94b4a903eb4635cfac66e"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_linux_arm64.tar.gz
+      sha256: "ae7706bc8007977bad7a96a580e153dd9353a65b2ad29ede0ff63bf0aae3e509"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.0/kubectl-k8i_darwin_amd64.tar.gz
-      sha256: "09a910bb7a177f9ddabd00400342b97eee604b28b0562d2728410c60c2ebe43c"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_darwin_amd64.tar.gz
+      sha256: "ed5ebd02602077e714931076ac3633c906f3537c0fe913fd510bd60cb7adcc8d"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.0/kubectl-k8i_darwin_arm64.tar.gz
-      sha256: "bb32dc757e9b24cf2b0a0e99da92a8e2a8ea0903f11c1da8f5f1c317f8de34f3"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_darwin_arm64.tar.gz
+      sha256: "7c3105576d2082b46afb5f59ea9a62d18b1d584e0c7980b7d19917357f1fe37e"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.0/kubectl-k8i_windows_amd64.zip
-      sha256: "4c2e9d09e520f802b0ae6f2f831b338bc58aa0f5f00beea56f4c1ff05e038c1e"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_windows_amd64.zip
+      sha256: "b1435ee680c6955df3078c4e119fab0f1a07cb3793ae0a30492b352c69172c91"
       bin: kubectl-k8i.exe
     - selector:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.0/kubectl-k8i_windows_arm64.zip
-      sha256: "be548e01c12edf38f393ea9abb36091f1dd54884ac30b7e81a804aa11a912d96"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_windows_arm64.zip
+      sha256: "b62138bd914f5d74c5af705574df00648bb59978cc7b8d5e511e025f7fe0e131"
       bin: kubectl-k8i.exe


### PR DESCRIPTION
Update k8i plugin from v0.1.0 to v0.1.1.

## Changes in v0.1.1

New flags for workload-based node filtering:
- `--deployment namespace/name` — show only nodes running pods of a deployment
- `--statefulset namespace/name` — show only nodes running pods of a statefulset
- `--daemonset namespace/name` — show only nodes running pods of a daemonset
- `--namespace name` — show only nodes running pods from a namespace

All new flags support tab completion.

## Release
https://github.com/ViktorUJ/kubectl-k8i/releases/tag/v0.1.1