### PR TITLE
atlas: upgrade to v1.3.0

### DIFF
--- a/plugins/atlas.yaml
+++ b/plugins/atlas.yaml
@@ -12,7 +12,7 @@ kind: Plugin
 metadata:
   name: atlas
 spec:
-  version: v1.2.0
+  version: v1.3.0
   homepage: https://github.com/lithastra/kubeatlas
   shortDescription: Visualize Kubernetes resource dependencies
   description: |
@@ -45,31 +45,31 @@ spec:
   platforms:
     - selector:
         matchLabels: { os: linux, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_linux_amd64.tar.gz
-      sha256: "e29ba40c3375722ba9a6676bc5e36402fef6a7e1e85912daf9ad787e76901094"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.0/kubectl-atlas_1.3.0_linux_amd64.tar.gz
+      sha256: "6024e4b1cb37ffa0a87f84e3967216992ce45fa1762739c4054d56f7b7565651"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: linux, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_linux_arm64.tar.gz
-      sha256: "25196773a15b4e8b08961165c1a90da6cd5c6b7abb807da625011a5fe32ba50a"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.0/kubectl-atlas_1.3.0_linux_arm64.tar.gz
+      sha256: "b95dd4370825f26b466c67576873b4ab69f2c0e95fdf330bdb78cee88845d0b6"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_darwin_amd64.tar.gz
-      sha256: "7f655514af08d7da593100dd5bc27a5d21fde705833bff3bb88b1344af50c485"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.0/kubectl-atlas_1.3.0_darwin_amd64.tar.gz
+      sha256: "f532e51643fd4c54a53e95a8d6fb41d59b1b5a9ead30300c19072640b66c6e99"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_darwin_arm64.tar.gz
-      sha256: "70e7094ed657bfda5ea3e391fb780754f730449d0be0522067d6744a4dc424b6"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.0/kubectl-atlas_1.3.0_darwin_arm64.tar.gz
+      sha256: "83d57a0e40336104da401f5d519d31f85af2d4403259a9a22d58ad1ff8e38806"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: windows, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_windows_amd64.tar.gz
-      sha256: "f0cc8ad1dd9f47981e7851a04efa6d2bfcfb9a2cdc50aae24723809d9999041c"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.0/kubectl-atlas_1.3.0_windows_amd64.tar.gz
+      sha256: "779b97e88316aa5ad1b9bf1fc10b76d595c035478dada4d098378a93358e107a"
       bin: kubectl-atlas.exe
     - selector:
         matchLabels: { os: windows, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_windows_arm64.tar.gz
-      sha256: "0779792174c0b1d4eb02cf5739469193ef371c9be4a526c356e5b9e08df44075"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.0/kubectl-atlas_1.3.0_windows_arm64.tar.gz
+      sha256: "196aa448ce6720241ac5b4ff847749015b7eb43bb5c94e700b29b0d3b2546fd4"
       bin: kubectl-atlas.exe


### PR DESCRIPTION
Upgrades the atlas plugin to v1.3.0. SHAs verified locally with kubectl krew install --manifest.