### PR TITLE
feat: update k8i to v0.1.2

### DIFF
--- a/plugins/k8i.yaml
+++ b/plugins/k8i.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: k8i
 spec:
-  version: v0.1.1
+  version: v0.1.2
   homepage: https://github.com/ViktorUJ/kubectl-k8i
   shortDescription: Display Kubernetes node resources with color-coded load indicators
   description: |
@@ -38,41 +38,41 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_linux_amd64.tar.gz
-      sha256: "9cc50c4ffc4b3790f24bc1fe2273f5786a8ff2f6ad205e2e75796640934861e9"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_linux_amd64.tar.gz
+      sha256: "431a97a1ed1b50831e88e7e13982880bbdc69db716d1d2061db12490e5091ad0"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_linux_arm64.tar.gz
-      sha256: "ae7706bc8007977bad7a96a580e153dd9353a65b2ad29ede0ff63bf0aae3e509"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_linux_arm64.tar.gz
+      sha256: "13223d4111ed156b31d0e0a8ac27838125f6801320ded24d51201d89a0ba3987"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_darwin_amd64.tar.gz
-      sha256: "ed5ebd02602077e714931076ac3633c906f3537c0fe913fd510bd60cb7adcc8d"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_darwin_amd64.tar.gz
+      sha256: "e6d35483b7b6b876dc87b289e3a8a64f5f43659eb2abd3e93acb5d6924e9d21e"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_darwin_arm64.tar.gz
-      sha256: "7c3105576d2082b46afb5f59ea9a62d18b1d584e0c7980b7d19917357f1fe37e"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_darwin_arm64.tar.gz
+      sha256: "63e8f508e9cc3e189114f3bd3b108f8e742238469d59451ebc6672e20fc2f766"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_windows_amd64.zip
-      sha256: "b1435ee680c6955df3078c4e119fab0f1a07cb3793ae0a30492b352c69172c91"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_windows_amd64.zip
+      sha256: "b2aaede181d893b45bcc02f4d19f167bc9580ef9e07fa7015d4ccbcc9e7d30e2"
       bin: kubectl-k8i.exe
     - selector:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.1/kubectl-k8i_windows_arm64.zip
-      sha256: "b62138bd914f5d74c5af705574df00648bb59978cc7b8d5e511e025f7fe0e131"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_windows_arm64.zip
+      sha256: "d8a58e0f0e3cbe3e4510a56eebaed0e40cc44774adbd61e45ed4cfdfae78f045"
       bin: kubectl-k8i.exe


### PR DESCRIPTION
Update k8i plugin from v0.1.1 to v0.1.2.

## Changes in v0.1.2

New workload-based node filtering flags:
- `--deployment namespace/name` — show only nodes running pods of a deployment
- `--statefulset namespace/name` — show only nodes running pods of a statefulset
- `--daemonset namespace/name` — show only nodes running pods of a daemonset
- `--namespace name` — show only nodes running pods from a namespace
- `--autoscaler value` — show only nodes managed by a specific autoscaler (karpenter, cluster-autoscaler, spotio, x)

New `analyze` subcommand:
- Shows all workloads (Deployments, StatefulSets, DaemonSets, Pods) running on selected nodes
- Select nodes by `--node`, `--labels`, `--taints`, or `--autoscaler`
- Displays aggregated CPU/memory requests, limits, and usage per workload
- Supports `--exclude-namespace` to reduce noise
- Output formats: table, JSON, YAML

Security: updated golang.org/x/crypto and golang.org/x/net to latest versions.

## Release
https://github.com/ViktorUJ/kubectl-k8i/releases/tag/v0.1.2