### PR TITLE
feat: update k8i to v0.1.3

### DIFF
--- a/plugins/k8i.yaml
+++ b/plugins/k8i.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: k8i
 spec:
-  version: v0.1.2
+  version: v0.1.3
   homepage: https://github.com/ViktorUJ/kubectl-k8i
   shortDescription: Display Kubernetes node resources with color-coded load indicators
   description: |
@@ -38,41 +38,41 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_linux_amd64.tar.gz
-      sha256: "431a97a1ed1b50831e88e7e13982880bbdc69db716d1d2061db12490e5091ad0"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_linux_amd64.tar.gz
+      sha256: "c9b95a77ee24bbf1a05f3c091745702c13ff2a00a0d9ca55ba3ac4f1a503b33a"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_linux_arm64.tar.gz
-      sha256: "13223d4111ed156b31d0e0a8ac27838125f6801320ded24d51201d89a0ba3987"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_linux_arm64.tar.gz
+      sha256: "a1fa33c98447ccd34ef4f441950f6f78843245471f5f0cf41e5c6e34d07149b5"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_darwin_amd64.tar.gz
-      sha256: "e6d35483b7b6b876dc87b289e3a8a64f5f43659eb2abd3e93acb5d6924e9d21e"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_darwin_amd64.tar.gz
+      sha256: "5ef8d5ebce865f2efdae5aa0a2a393b2c8a9c61af107fc26164da81ccaee7699"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_darwin_arm64.tar.gz
-      sha256: "63e8f508e9cc3e189114f3bd3b108f8e742238469d59451ebc6672e20fc2f766"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_darwin_arm64.tar.gz
+      sha256: "3237b97c2a8420a14613d687d446961754dc78e5c45308f71135df71bcf8c644"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_windows_amd64.zip
-      sha256: "b2aaede181d893b45bcc02f4d19f167bc9580ef9e07fa7015d4ccbcc9e7d30e2"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_windows_amd64.zip
+      sha256: "cf614ea70aafdf1e343cfde9f2780a58bd87b77699a8212c57fda41b99b07ef7"
       bin: kubectl-k8i.exe
     - selector:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.2/kubectl-k8i_windows_arm64.zip
-      sha256: "d8a58e0f0e3cbe3e4510a56eebaed0e40cc44774adbd61e45ed4cfdfae78f045"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_windows_arm64.zip
+      sha256: "a2b4d64aaebedb683cc2f0302822c4aab52184ec9e7e824d8411d35026749944"
       bin: kubectl-k8i.exe


### PR DESCRIPTION
Update k8i plugin from v0.1.2 to v0.1.3.

## Changes in v0.1.3

Performance fix for `analyze` subcommand:
- Replaced per-pod ReplicaSet API calls with a single bulk List request
- Eliminates duplicate ReplicaSet/Deployment entries in output
- Resolves top-level owner correctly (ReplicaSet → Deployment)

Renamed autoscaler value `cas` → `cluster-autoscaler` for clarity.

Security: updated golang.org/x/crypto to v0.52.0, golang.org/x/net to v0.55.0.

## Release
https://github.com/ViktorUJ/kubectl-k8i/releases/tag/v0.1.3