### PR TITLE
atlas: upgrade to v1.3.1

### DIFF
--- a/plugins/atlas.yaml
+++ b/plugins/atlas.yaml
@@ -12,7 +12,7 @@ kind: Plugin
 metadata:
   name: atlas
 spec:
-  version: v1.2.0
+  version: v1.3.1
   homepage: https://github.com/lithastra/kubeatlas
   shortDescription: Visualize Kubernetes resource dependencies
   description: |
@@ -45,31 +45,31 @@ spec:
   platforms:
     - selector:
         matchLabels: { os: linux, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_linux_amd64.tar.gz
-      sha256: "e29ba40c3375722ba9a6676bc5e36402fef6a7e1e85912daf9ad787e76901094"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_linux_amd64.tar.gz
+      sha256: "587cbc92607a346ac90008597498fbf4e7fc036b496ba2ce1c46729fc041d1d2"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: linux, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_linux_arm64.tar.gz
-      sha256: "25196773a15b4e8b08961165c1a90da6cd5c6b7abb807da625011a5fe32ba50a"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_linux_arm64.tar.gz
+      sha256: "e5b7993b09a28ea81943e3866b59f9e82071d7e66c51fb79a86fbd8f07fad780"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_darwin_amd64.tar.gz
-      sha256: "7f655514af08d7da593100dd5bc27a5d21fde705833bff3bb88b1344af50c485"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_darwin_amd64.tar.gz
+      sha256: "43029e6faaf0ff4199426bd5cd956ec7a167ec57bee39b868b91efbae832b26a"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_darwin_arm64.tar.gz
-      sha256: "70e7094ed657bfda5ea3e391fb780754f730449d0be0522067d6744a4dc424b6"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_darwin_arm64.tar.gz
+      sha256: "928dbba933c05c2197b760705ae023beee7e542882eb81b62f2e14ff97d6dbf0"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: windows, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_windows_amd64.tar.gz
-      sha256: "f0cc8ad1dd9f47981e7851a04efa6d2bfcfb9a2cdc50aae24723809d9999041c"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_windows_amd64.tar.gz
+      sha256: "95129a8261e4ce3d407e0837d0677ed202f0d1db9641e9c5ba6c59e0b553da02"
       bin: kubectl-atlas.exe
     - selector:
         matchLabels: { os: windows, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.2.0/kubectl-atlas_1.2.0_windows_arm64.tar.gz
-      sha256: "0779792174c0b1d4eb02cf5739469193ef371c9be4a526c356e5b9e08df44075"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_windows_arm64.tar.gz
+      sha256: "99d9a97988c342acf2511209198fe93c5d9119b54cd89075867a6ddb9382d398"
       bin: kubectl-atlas.exe


### PR DESCRIPTION
Upgrades the atlas plugin to v1.3.1. SHAs verified locally from published release assets.

Release notes: https://github.com/lithastra/kubeatlas/releases/tag/v1.3.1