### PR TITLE
Add gpugo plugin

### DIFF
--- a/plugins/gpugo.yaml
+++ b/plugins/gpugo.yaml
@@ -1,0 +1,89 @@
+# Krew plugin manifest for gpugo.
+#
+# This is the file to submit to kubernetes-sigs/krew-index as
+#   plugins/gpugo.yaml
+# in your PR. Kept here in the source repo as the canonical reference so
+# future releases just need the version + checksums updated and a fresh PR.
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: gpugo
+spec:
+  version: v0.1.1
+  homepage: https://github.com/Tal-Naeh/kubectl-gpugo
+  shortDescription: Top-like TUI for per-pod GPU usage on Kubernetes
+  description: |
+    A zero-cluster-footprint, top-like TUI for per-pod GPU usage on
+    Kubernetes. Auto-discovers existing dcgm-exporter (and optionally
+    cadvisor-gpu-gpu-enricher) pods and scrapes them through the
+    kube-apiserver pod-proxy subresource — no DaemonSet to install,
+    no port-forwards on your machine, no firewall changes.
+
+    Handles MIG: per-slice rows are grouped by physical GPU and labeled
+    with the slice ID (e.g. "0:8" = GPU 0, MIG slice 8). When workloads
+    bypass the NVIDIA device plugin via NVIDIA_VISIBLE_DEVICES=all,
+    falls back to per-(node, GPU) attribution and lists candidate pods.
+
+    The TUI is scrollable, sorted by physical GPU, and refreshes every
+    20 seconds.
+  caveats: |
+    Requires:
+      - dcgm-exporter (or another exporter emitting DCGM_FI_DEV_* /
+        gpu_process_memory_bytes) running in the target cluster.
+      - The user's RBAC must allow "list pods" cluster-wide and
+        "get pods/proxy" in the exporter's namespace.
+
+    Will not work with Lens / freelens local-proxy kubeconfigs — their
+    proxy does not pass pod-proxy subresource requests through. Use a
+    direct kubeconfig.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/Tal-Naeh/kubectl-gpugo/releases/download/v0.1.1/kubectl-gpugo_0.1.1_darwin_amd64.tar.gz
+    sha256: c7c8a0fa45f22d3b40dca8a647cfd0736ad403acb9d59e3d580b133b76ac896b
+    bin: kubectl-gpugo
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/Tal-Naeh/kubectl-gpugo/releases/download/v0.1.1/kubectl-gpugo_0.1.1_darwin_arm64.tar.gz
+    sha256: f89f73bb61b59b0417f69c083ab386e91f1c80b4a71dffaaead7800401ce22bf
+    bin: kubectl-gpugo
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/Tal-Naeh/kubectl-gpugo/releases/download/v0.1.1/kubectl-gpugo_0.1.1_linux_amd64.tar.gz
+    sha256: e6d8a050a579741bc70fa7a806efcb1144fef21bc9b517a99b2ce626da7bcb07
+    bin: kubectl-gpugo
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/Tal-Naeh/kubectl-gpugo/releases/download/v0.1.1/kubectl-gpugo_0.1.1_linux_arm64.tar.gz
+    sha256: 33d1218af85aab2139c14c7ca5ba65ae913bd81898aeb58f090d5921c2d3896d
+    bin: kubectl-gpugo
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/Tal-Naeh/kubectl-gpugo/releases/download/v0.1.1/kubectl-gpugo_0.1.1_windows_amd64.zip
+    sha256: bdd0bad7e8b323d633393715a70efee696c91b3cdfd4db31a2d09f2e20089c8b
+    bin: kubectl-gpugo.exe
+    files:
+    - from: "*"
+      to: "."


### PR DESCRIPTION
## Plugin description

**`gpugo`** — a zero-cluster-footprint, `top`-like TUI for per-pod GPU usage on Kubernetes.

It auto-discovers existing `dcgm-exporter` (and optionally `cadvisor-gpu-gpu-enricher`) pods in the cluster and scrapes them through the kube-apiserver pod-proxy subresource. No DaemonSet to install, no port-forwards on the user's machine, no firewall changes.

Highlights:
- MIG-aware: per-slice rows are grouped by physical GPU with explicit slice labels (e.g. `0:8` = GPU 0, MIG slice 8).
- Three attribution paths chosen automatically: per-process via enricher, per-pod via DCGM `--kubernetes` labels, or per-(node, GPU) fallback with hint pods.
- Scrollable TUI, pinned column header, 20s refresh, proportional power attribution when GPUs are shared.

## Links

- Source: https://github.com/Tal-Naeh/kubectl-gpugo
- Release used in this manifest: https://github.com/Tal-Naeh/kubectl-gpugo/releases/tag/v0.1.1
- License: MIT

## Maintainership

I'm the author and maintainer of the plugin.

## Checklist

- [x] Built with GoReleaser; archives + checksums attached to the GitHub release.
- [x] Supports `darwin/amd64`, `darwin/arm64`, `linux/amd64`, `linux/arm64`, `windows/amd64`.
- [x] `LICENSE` is included in every archive.
- [x] Manifest follows the `krew.googlecontainertools.github.com/v1alpha2` schema.