### PR TITLE
Update attune to v0.1.5

### DIFF
--- a/plugins/attune.yaml
+++ b/plugins/attune.yaml
@@ -3,21 +3,22 @@ kind: Plugin
 metadata:
   name: attune
 spec:
-  version: v0.1.4
+  version: v0.1.5
   homepage: https://github.com/attune-io/attune
   shortDescription: Inspect and explain Attune pod right-sizing policies
   description: |
-    The kubectl-attune plugin provides visibility into Attune, a Kubernetes
-    operator for safe, in-place pod resource right-sizing.
+    Shows policy status, savings estimates, per-container recommendations,
+    recommendation reasoning, and resize history for Attune policies.
 
-    Available commands:
-      - explain: Show effective policy values for a workload, including
-        inherited defaults and per-container overrides
-      - status: Display active recommendations and current resize state
-        for targeted pods
-      - history: View the resize history for a workload, including
-        timestamps, old/new values, and outcomes
-      - version: Print the plugin version
+    Subcommands:
+      status            Show policy status, workload counts, and conditions
+      savings           Show estimated CPU/memory savings per policy
+      recommendations   Show per-container sizing recommendations
+      explain           Show recommendation reasoning for one policy
+      preview           Preview per-pod resource changes before promoting type
+      history           Show resize history (including eviction fallbacks)
+      diff              Show resource change diffs from recommendations
+      wizard            Interactive policy creation and type promotion
   caveats: |
     Requires the Attune operator to be installed in the cluster.
   platforms:
@@ -25,34 +26,35 @@ spec:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/attune-io/attune/releases/download/v0.1.4/kubectl-attune_darwin_amd64.tar.gz
-    sha256: 5dc12abc8d2d360915e317cdae6562e0f8375a1183d94ed02bd950f077c2e623
+    uri: https://github.com/attune-io/attune/releases/download/v0.1.5/kubectl-attune_darwin_amd64.tar.gz
+    sha256: 271dcaa1263a0aa26de12ee302fa05ec36a9512133b8bccd54f445c5c3b29872
     bin: kubectl-attune
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/attune-io/attune/releases/download/v0.1.4/kubectl-attune_darwin_arm64.tar.gz
-    sha256: 21d0322ee524d8d7eafe44d06ef9d482d4c271e224961fc47651f80004333610
+    uri: https://github.com/attune-io/attune/releases/download/v0.1.5/kubectl-attune_darwin_arm64.tar.gz
+    sha256: 9082b3e43ad29019b43afff4d822bfdd6aa77ed77d455c95e5d21b614042bbbe
     bin: kubectl-attune
   - selector:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/attune-io/attune/releases/download/v0.1.4/kubectl-attune_linux_amd64.tar.gz
-    sha256: 29f1449bd12569f9896cc37013ff1f81c5cfeb8fb562a8932b7c2b832900d188
+    uri: https://github.com/attune-io/attune/releases/download/v0.1.5/kubectl-attune_linux_amd64.tar.gz
+    sha256: fcb34c6e4fc779621de9441f218cd04b3e9f44b87d612d4781609cf5660cff3b
     bin: kubectl-attune
   - selector:
       matchLabels:
         os: linux
         arch: arm
-    uri: https://github.com/attune-io/attune/releases/download/v0.1.4/kubectl-attune_linux_arm.tar.gz
-    sha256: 28db7b4e523555e70a7867d36110139a071973131c4e958d440e21432f75d4fb
+    uri: https://github.com/attune-io/attune/releases/download/v0.1.5/kubectl-attune_linux_arm.tar.gz
+    sha256: 67379846d23cc1799322ab3794c44a3e6c71786f0e63b4d92aa2bf73a46708c5
     bin: kubectl-attune
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/attune-io/attune/releases/download/v0.1.4/kubectl-attune_linux_arm64.tar.gz
-    sha256: 3c2408fc6afe5c9f6fba63f3044460e069df5454224a1dd858ff4476d2d3f32c
+    uri: https://github.com/attune-io/attune/releases/download/v0.1.5/kubectl-attune_linux_arm64.tar.gz
+    sha256: c807f12464de1d96e8893f184576e2937bd8c2da5c9898fc628dccdab9c0a3e2
     bin: kubectl-attune
+


### PR DESCRIPTION
Update attune kubectl plugin to v0.1.5.

Changes:
- Added new subcommands: preview, diff, wizard, savings
- Added ppc64le and s390x platform support
- Updated description to reflect all available subcommands

The krew-release-bot failed during the v0.1.5 release due to a template variable issue (now fixed in attune-io/attune@3a26c65). This manual update brings the krew index in sync.