### PR TITLE
Add kubectl-timeline plugin

### DIFF
--- a/plugins/timeline.yaml
+++ b/plugins/timeline.yaml
@@ -5,16 +5,18 @@ metadata:
 spec:
   version: v0.2.0
   homepage: https://github.com/Bisman-Singh/kubectl-timeline
-  shortDescription: Reconstruct incident timelines from live cluster state
+  shortDescription: Incident timeline from live cluster state
   description: |
-    Agentless incident timeline reconstruction. Point it at any cluster
-    you can reach and get back a chronological, deduplicated, severity-ranked
-    account of what broke and in what order, with root-cause chain analysis.
+    Agentless incident timeline reconstruction from live
+    Kubernetes cluster state. Point it at any cluster and get
+    a chronological, deduplicated, severity-ranked account of
+    what broke and in what order, with root-cause analysis.
 
-    14 correlation patterns, cascade grouping, cross-namespace correlation,
-    chronic detection, and confidence-bucketed root cause analysis.
-    Reads events, pod status, rollout history, node conditions, HPA,
-    Karpenter, and Helm signals. Installs nothing in the cluster.
+    Features 14 correlation patterns, cascade grouping,
+    cross-namespace correlation, chronic issue detection, and
+    confidence-bucketed root cause chains. Reads events, pod
+    status, rollout history, node conditions, HPA, Karpenter,
+    and Helm signals. Installs nothing in the cluster.
   platforms:
     - selector:
         matchLabels:

--- a/plugins/timeline.yaml
+++ b/plugins/timeline.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: timeline
 spec:
-  version: v0.2.0
+  version: v0.2.1
   homepage: https://github.com/Bisman-Singh/kubectl-timeline
   shortDescription: Incident timeline from live cluster state
   description: |
@@ -22,41 +22,41 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_linux_amd64.tar.gz
-      sha256: f83443c5e5d3812924665161e959f5791eabef5c36cb017ab02d34107c6e0bd2
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.1/kubectl-timeline_0.2.1_linux_amd64.tar.gz
+      sha256: 12c3a1b70a3b5705a56df829dd3ba27b1ad53e7b2e0207998122fde04cb32faa
       bin: kubectl-timeline
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_linux_arm64.tar.gz
-      sha256: d722f221e18307e1b74f47622df8366eb3a62e682df528067783f70303e8255e
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.1/kubectl-timeline_0.2.1_linux_arm64.tar.gz
+      sha256: 9f98d49afee11c579a72864cd893b7a700fcaa9811eb3796618bd195abfc1d5f
       bin: kubectl-timeline
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_darwin_amd64.tar.gz
-      sha256: d82edc40664b69d50eb6295e19357f7cd30bf47cabff59072d2b1355057acea5
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.1/kubectl-timeline_0.2.1_darwin_amd64.tar.gz
+      sha256: 976b50ccbb69640b63881729f4e27c2ef382f878c43f6a810d434c7a42e89a46
       bin: kubectl-timeline
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_darwin_arm64.tar.gz
-      sha256: 376afd32dd8325fd100c940951d603a20cdfa1f9ba21298162583c0805524e9d
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.1/kubectl-timeline_0.2.1_darwin_arm64.tar.gz
+      sha256: 3d37a2540c1845d94e2bfcba743df6649d374630056a73638f91f39859e485b3
       bin: kubectl-timeline
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_windows_amd64.zip
-      sha256: ebdf7646d8b3d8b5a2f74adde86c47c114ef654d6f9be661a0c926e1675d915b
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.1/kubectl-timeline_0.2.1_windows_amd64.zip
+      sha256: 0bc72d300b3e0a8843af98531050d5af876d827c7b3a0b8b7300dbc437b864c8
       bin: kubectl-timeline.exe
     - selector:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_windows_arm64.zip
-      sha256: 208ee0ea26b5e20f0f692474efaec40f325f552fbaa95ab97eb5babff60e2bb0
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.1/kubectl-timeline_0.2.1_windows_arm64.zip
+      sha256: 5d3d40c02b36a6e01528d7b4692c9e2a6c66a4efc312c664c886677d4d3d7ba4
       bin: kubectl-timeline.exe

--- a/plugins/timeline.yaml
+++ b/plugins/timeline.yaml
@@ -1,0 +1,60 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: timeline
+spec:
+  version: v0.2.0
+  homepage: https://github.com/Bisman-Singh/kubectl-timeline
+  shortDescription: Reconstruct incident timelines from live cluster state
+  description: |
+    Agentless incident timeline reconstruction. Point it at any cluster
+    you can reach and get back a chronological, deduplicated, severity-ranked
+    account of what broke and in what order, with root-cause chain analysis.
+
+    14 correlation patterns, cascade grouping, cross-namespace correlation,
+    chronic detection, and confidence-bucketed root cause analysis.
+    Reads events, pod status, rollout history, node conditions, HPA,
+    Karpenter, and Helm signals. Installs nothing in the cluster.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_linux_amd64.tar.gz
+      sha256: f83443c5e5d3812924665161e959f5791eabef5c36cb017ab02d34107c6e0bd2
+      bin: kubectl-timeline
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_linux_arm64.tar.gz
+      sha256: d722f221e18307e1b74f47622df8366eb3a62e682df528067783f70303e8255e
+      bin: kubectl-timeline
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_darwin_amd64.tar.gz
+      sha256: d82edc40664b69d50eb6295e19357f7cd30bf47cabff59072d2b1355057acea5
+      bin: kubectl-timeline
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_darwin_arm64.tar.gz
+      sha256: 376afd32dd8325fd100c940951d603a20cdfa1f9ba21298162583c0805524e9d
+      bin: kubectl-timeline
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_windows_amd64.zip
+      sha256: ebdf7646d8b3d8b5a2f74adde86c47c114ef654d6f9be661a0c926e1675d915b
+      bin: kubectl-timeline.exe
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/Bisman-Singh/kubectl-timeline/releases/download/v0.2.0/kubectl-timeline_0.2.0_windows_arm64.zip
+      sha256: 208ee0ea26b5e20f0f692474efaec40f325f552fbaa95ab97eb5babff60e2bb0
+      bin: kubectl-timeline.exe


### PR DESCRIPTION
## New plugin: timeline

Agentless incident timeline reconstruction from live Kubernetes cluster state.

**Repository:** https://github.com/Bisman-Singh/kubectl-timeline
**Release:** https://github.com/Bisman-Singh/kubectl-timeline/releases/tag/v0.2.0
**License:** Apache-2.0

### What it does

Point it at any cluster and get a chronological, deduplicated, severity-ranked account of what broke and in what order, with root-cause chain analysis. Reads the API once, installs nothing in the cluster.

- 14 correlation patterns (deploy-induced, OOM cascade, image pull, probe failure, node pressure, scheduling, config/secret, disruption, Helm deploy, crash loop, drain blocked, HPA metrics, cross-namespace, scaling)
- Cascade grouping with upstream failure identification
- Confidence buckets (high/medium/low)
- Chronic issue detection
- 3 output formats (table, JSON, markdown)
- Karpenter and Helm correlation (degrades silently when absent)

### Pre-submission checklist

- [x] Reviewed the plugin naming guide
- [x] Read the plugin development best practices
- [x] Source code is publicly available
- [x] Apache-2.0 license adopted and included in plugin archive
- [x] Tagged a git release with semantic version (v0.2.0)
- [x] Tested plugin installation locally with Install one or multiple kubectl plugins.

Examples:
  To install one or multiple plugins from the default index, run:
    kubectl krew install NAME [NAME...]

  To install plugins from a newline-delimited file, run:
    kubectl krew install < file.txt

  To install one or multiple plugins from a custom index, run:
    kubectl krew install INDEX/NAME [INDEX/NAME...]

  (For developers) To provide a custom plugin manifest, use the --manifest or
  --manifest-url arguments. Similarly, instead of downloading files from a URL,
  you can specify a local --archive file:
    kubectl krew install --manifest=FILE [--archive=FILE]

Remarks:
  If a plugin is already installed, it will be skipped.
  Failure to install a plugin will not stop the installation of other plugins.

Usage:
  kubectl krew install [flags]

Flags:
      --archive string        (Development-only) force all downloads to use the specified file
  -h, --help                  help for install
      --manifest string       (Development-only) specify local plugin manifest file
      --manifest-url string   (Development-only) specify plugin manifest file from url
      --no-update-index       (Experimental) do not update local copy of plugin index before installing

Global Flags:
  -v, --v Level   number for the log level verbosity
