### PR TITLE
Add hpa-status plugin

### DIFF
--- a/plugins/hpa-status.yaml
+++ b/plugins/hpa-status.yaml
@@ -4,7 +4,7 @@ metadata:
   name: hpa-status
 spec:
   version: v0.1.0
-  homepage: https://github.com/mattsu2020/kubehpa_cli
+  homepage: https://github.com/mattsu2020/kubectl-hpa-status
   shortDescription: Show detailed HPA status and scaling analysis
   description: |
     Displays detailed HorizontalPodAutoscaler status including current and
@@ -18,34 +18,34 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_amd64.tar.gz
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_amd64.tar.gz
       sha256: e38b251e1742daa2e957363342ea4c5aa6bbb6664f1fa24d7633aeac76ad72a3
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_arm64.tar.gz
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_arm64.tar.gz
       sha256: bdce2f3a9d7fdd875f63a6296abbf606d1f99781d5038dfbfa6558676a13d9d7
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_amd64.tar.gz
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_amd64.tar.gz
       sha256: 6b61d37dd9217cced6e70b66a4f14d1d24e8ba519870bf5b6f09721ac87bb707
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_arm64.tar.gz
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_arm64.tar.gz
       sha256: 654b29e9185785059772a16bff5404275a19d49ae23f10f09727f2dcd0ab2e21
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_windows_amd64.tar.gz
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_windows_amd64.tar.gz
       sha256: b95eccfca109333e0d8da45a87f47b617147fa5523f9b4e8b4995f2ad6e5a12f
       bin: kubectl-hpa-status.exe

--- a/plugins/hpa-status.yaml
+++ b/plugins/hpa-status.yaml
@@ -1,0 +1,51 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: hpa-status
+spec:
+  version: v0.1.0
+  homepage: https://github.com/mattsu2020/kubehpa_cli
+  shortDescription: Show detailed HPA status and scaling analysis
+  description: |
+    Displays detailed HorizontalPodAutoscaler status including current and
+    target utilization, replica counts, scaling conditions, metric analysis,
+    and interpretation of scaling decisions.
+    This plugin reads existing HPA status, metrics, conditions, and events
+    to provide human-readable analysis without reimplementing the HPA
+    controller's internal decision logic.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_amd64.tar.gz
+      sha256: e38b251e1742daa2e957363342ea4c5aa6bbb6664f1fa24d7633aeac76ad72a3
+      bin: kubectl-hpa-status
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_arm64.tar.gz
+      sha256: bdce2f3a9d7fdd875f63a6296abbf606d1f99781d5038dfbfa6558676a13d9d7
+      bin: kubectl-hpa-status
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_amd64.tar.gz
+      sha256: 6b61d37dd9217cced6e70b66a4f14d1d24e8ba519870bf5b6f09721ac87bb707
+      bin: kubectl-hpa-status
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_arm64.tar.gz
+      sha256: 654b29e9185785059772a16bff5404275a19d49ae23f10f09727f2dcd0ab2e21
+      bin: kubectl-hpa-status
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_windows_amd64.tar.gz
+      sha256: b95eccfca109333e0d8da45a87f47b617147fa5523f9b4e8b4995f2ad6e5a12f
+      bin: kubectl-hpa-status.exe


### PR DESCRIPTION
Adds the hpa-status kubectl plugin manifest.
This also points the manifest at the renamed upstream repository: https://github.com/mattsu2020/kubectl-hpa-status
