### PR TITLE
Add zane plugin

### DIFF
--- a/plugins/zane.yaml
+++ b/plugins/zane.yaml
@@ -1,13 +1,13 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: zanecli
+  name: zane
 spec:
-  version: v0.1.0
+  version: v0.1.1
   homepage: https://github.com/zarakM/zanecli
   shortDescription: Conversational Kubernetes co-pilot in your terminal
   description: |
-    zanecli is a conversational Kubernetes co-pilot. Launch it to open a chat
+    zane is a conversational Kubernetes co-pilot. Launch it to open a chat
     REPL, ask a question in plain English, and the agent investigates your
     cluster (pods, deployments, events, logs, PVCs, and arbitrary resources)
     through read-only API calls, cites the evidence it found, and proposes
@@ -24,14 +24,14 @@ spec:
 
     Start the co-pilot with:
 
-      kubectl zanecli
+      kubectl zane
   platforms:
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Darwin_x86_64.tar.gz
-      sha256: ca11d0ca35aadddb82ecc14d4e93cf6ae3dd11bdaa294007543e9fb84c8a59a4
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Darwin_x86_64.tar.gz
+      sha256: bceecfbad7df6d5325ebae2a687d0b2c961f08ce5983af3ae4e613b03225303f
       bin: zanecli
       files:
         - from: zanecli
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Darwin_arm64.tar.gz
-      sha256: 46675a38110dfb88e17205ee95f09e36c7080631338a80a76080af1c15ad7e73
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Darwin_arm64.tar.gz
+      sha256: 293f2532365501474bad632cfa791188054011517fc40b1926e63b8513687295
       bin: zanecli
       files:
         - from: zanecli
@@ -54,8 +54,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Linux_x86_64.tar.gz
-      sha256: 2e67e118fbc8e59acebdfef3f4a0ccb12488c71a7d3bdd019e5b71e7798aea04
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Linux_x86_64.tar.gz
+      sha256: b74e82a92b529c0575aa87b2b60a152096d1c8f1a7c4ba878b8b789ebb7a6ebc
       bin: zanecli
       files:
         - from: zanecli
@@ -66,8 +66,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Linux_arm64.tar.gz
-      sha256: 74170027b8f99080ddc8b0ced745478b137da18f8d2a383e412ae4322d517100
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Linux_arm64.tar.gz
+      sha256: bbfefd9a5378fbad17b9633308e72a66b060c6b2f5c999c34fa9609a403cb1f6
       bin: zanecli
       files:
         - from: zanecli
@@ -78,8 +78,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Windows_x86_64.zip
-      sha256: 905bc4fac356679bd4f21ebc09d3bb8f4a236f1501bebb9b947f1570e2517ad5
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Windows_x86_64.zip
+      sha256: 9e66fd2e61616293f94504e206a92ccb2bf0715abab38561a9c9a00453003485
       bin: zanecli.exe
       files:
         - from: zanecli.exe

--- a/plugins/zane.yaml
+++ b/plugins/zane.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: zane
 spec:
-  version: v0.1.3
+  version: v0.1.4
   homepage: https://github.com/zarakM/zane
   shortDescription: Conversational Kubernetes co-pilot in your terminal
   description: |
@@ -30,8 +30,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Darwin_x86_64.tar.gz
-      sha256: d4879fb2eef9fc1bd8918c8c1aad028ff3423b5bbf3e47775f989305492e0265
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.4/zane_0.1.4_Darwin_x86_64.tar.gz
+      sha256: 918e1459cd327bc01168add289251ae7080a1f91020a9144e9d8a69eb2ae94bc
       bin: zane
       files:
         - from: zane
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Darwin_arm64.tar.gz
-      sha256: 683314b33a1ed2a899b964b7756730d81f9fce824ec0b7cbacd3cb8dc657383d
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.4/zane_0.1.4_Darwin_arm64.tar.gz
+      sha256: 3cd3242e8febb284707bc7d709ff6a76d1fae3123d07ec2e4d6354e3f5c2fe93
       bin: zane
       files:
         - from: zane
@@ -54,8 +54,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Linux_x86_64.tar.gz
-      sha256: e3a9951107a643798022bbff3d0064154b17b66c78d4321c892340b9a7fd1aeb
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.4/zane_0.1.4_Linux_x86_64.tar.gz
+      sha256: 85cb0f8bedbc22c5b722a734c2c60f8b595db69a9213527b25affd29ad9eb2aa
       bin: zane
       files:
         - from: zane
@@ -66,8 +66,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Linux_arm64.tar.gz
-      sha256: a70f20240728d7f05407a4de13d321e9d0c7d38474c23fc62218aff341dc981b
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.4/zane_0.1.4_Linux_arm64.tar.gz
+      sha256: 80037de5fa1a2fd11ed813e32e4f0a5ef1cb39eead657ad9386599a431186242
       bin: zane
       files:
         - from: zane
@@ -78,8 +78,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Windows_x86_64.zip
-      sha256: 5b01dcd71078f262ef2b8fd939390b37fd432e03d6392909752c6d80669872a1
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.4/zane_0.1.4_Windows_x86_64.zip
+      sha256: 189bc03386d9952e21d16cd53b6101c67175ce480b1d2311450f400cb67557ac
       bin: zane.exe
       files:
         - from: zane.exe

--- a/plugins/zane.yaml
+++ b/plugins/zane.yaml
@@ -3,8 +3,8 @@ kind: Plugin
 metadata:
   name: zane
 spec:
-  version: v0.1.2
-  homepage: https://github.com/zarakM/zanecli
+  version: v0.1.3
+  homepage: https://github.com/zarakM/zane
   shortDescription: Conversational Kubernetes co-pilot in your terminal
   description: |
     zane is a conversational Kubernetes co-pilot. Launch it to open a chat
@@ -30,8 +30,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Darwin_x86_64.tar.gz
-      sha256: 0ad422296c9056c8d76b3c535d0682375870fea3c2f2dc045451162fd85756bd
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Darwin_x86_64.tar.gz
+      sha256: d4879fb2eef9fc1bd8918c8c1aad028ff3423b5bbf3e47775f989305492e0265
       bin: zane
       files:
         - from: zane
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Darwin_arm64.tar.gz
-      sha256: ecdc7f126f7e1bcb08fc08fd04e37935123c791286fc002d5cdf1f9f7da55c59
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Darwin_arm64.tar.gz
+      sha256: 683314b33a1ed2a899b964b7756730d81f9fce824ec0b7cbacd3cb8dc657383d
       bin: zane
       files:
         - from: zane
@@ -54,8 +54,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Linux_x86_64.tar.gz
-      sha256: bc89b2ed80ef823b2f9178331e58c0e942ebd3a99dc7119d3e9c19d839a304a4
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Linux_x86_64.tar.gz
+      sha256: e3a9951107a643798022bbff3d0064154b17b66c78d4321c892340b9a7fd1aeb
       bin: zane
       files:
         - from: zane
@@ -66,8 +66,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Linux_arm64.tar.gz
-      sha256: cd7487257a53893a56ca220b9cd3628d38446a49d5d875c0beda83cd8fc6f096
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Linux_arm64.tar.gz
+      sha256: a70f20240728d7f05407a4de13d321e9d0c7d38474c23fc62218aff341dc981b
       bin: zane
       files:
         - from: zane
@@ -78,8 +78,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Windows_x86_64.zip
-      sha256: e58e6abea0fac4eb5f035cc0a5ae955abd35049a6193636d58b8bc612a091ca1
+      uri: https://github.com/zarakM/zane/releases/download/v0.1.3/zane_0.1.3_Windows_x86_64.zip
+      sha256: 5b01dcd71078f262ef2b8fd939390b37fd432e03d6392909752c6d80669872a1
       bin: zane.exe
       files:
         - from: zane.exe

--- a/plugins/zane.yaml
+++ b/plugins/zane.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: zane
 spec:
-  version: v0.1.1
+  version: v0.1.2
   homepage: https://github.com/zarakM/zanecli
   shortDescription: Conversational Kubernetes co-pilot in your terminal
   description: |
@@ -30,11 +30,11 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Darwin_x86_64.tar.gz
-      sha256: bceecfbad7df6d5325ebae2a687d0b2c961f08ce5983af3ae4e613b03225303f
-      bin: zanecli
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Darwin_x86_64.tar.gz
+      sha256: 0ad422296c9056c8d76b3c535d0682375870fea3c2f2dc045451162fd85756bd
+      bin: zane
       files:
-        - from: zanecli
+        - from: zane
           to: .
         - from: LICENSE
           to: .
@@ -42,11 +42,11 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Darwin_arm64.tar.gz
-      sha256: 293f2532365501474bad632cfa791188054011517fc40b1926e63b8513687295
-      bin: zanecli
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Darwin_arm64.tar.gz
+      sha256: ecdc7f126f7e1bcb08fc08fd04e37935123c791286fc002d5cdf1f9f7da55c59
+      bin: zane
       files:
-        - from: zanecli
+        - from: zane
           to: .
         - from: LICENSE
           to: .
@@ -54,11 +54,11 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Linux_x86_64.tar.gz
-      sha256: b74e82a92b529c0575aa87b2b60a152096d1c8f1a7c4ba878b8b789ebb7a6ebc
-      bin: zanecli
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Linux_x86_64.tar.gz
+      sha256: bc89b2ed80ef823b2f9178331e58c0e942ebd3a99dc7119d3e9c19d839a304a4
+      bin: zane
       files:
-        - from: zanecli
+        - from: zane
           to: .
         - from: LICENSE
           to: .
@@ -66,11 +66,11 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Linux_arm64.tar.gz
-      sha256: bbfefd9a5378fbad17b9633308e72a66b060c6b2f5c999c34fa9609a403cb1f6
-      bin: zanecli
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Linux_arm64.tar.gz
+      sha256: cd7487257a53893a56ca220b9cd3628d38446a49d5d875c0beda83cd8fc6f096
+      bin: zane
       files:
-        - from: zanecli
+        - from: zane
           to: .
         - from: LICENSE
           to: .
@@ -78,11 +78,11 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.1/zanecli_0.1.1_Windows_x86_64.zip
-      sha256: 9e66fd2e61616293f94504e206a92ccb2bf0715abab38561a9c9a00453003485
-      bin: zanecli.exe
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.2/zane_0.1.2_Windows_x86_64.zip
+      sha256: e58e6abea0fac4eb5f035cc0a5ae955abd35049a6193636d58b8bc612a091ca1
+      bin: zane.exe
       files:
-        - from: zanecli.exe
+        - from: zane.exe
           to: .
         - from: LICENSE
           to: .

--- a/plugins/zanecli.yaml
+++ b/plugins/zanecli.yaml
@@ -1,0 +1,88 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: zanecli
+spec:
+  version: v0.1.0
+  homepage: https://github.com/zarakM/zanecli
+  shortDescription: Conversational Kubernetes co-pilot in your terminal
+  description: |
+    zanecli is a conversational Kubernetes co-pilot. Launch it to open a chat
+    REPL, ask a question in plain English, and the agent investigates your
+    cluster (pods, deployments, events, logs, PVCs, and arbitrary resources)
+    through read-only API calls, cites the evidence it found, and proposes
+    fixes. A tightly-scoped set of writes (restart a deployment, delete a pod)
+    is available, and every cluster mutation is confirmation-gated.
+
+    It talks directly to the Anthropic API (no third-party LLM service) and
+    never stores cluster identifiers in its optional telemetry.
+  caveats: |
+    This plugin requires:
+      * An Anthropic API key, provided via the ANTHROPIC_API_KEY environment
+        variable or entered during the first-run setup wizard.
+      * A valid kubeconfig (KUBECONFIG or ~/.kube/config).
+
+    Start the co-pilot with:
+
+      kubectl zanecli
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Darwin_x86_64.tar.gz
+      sha256: ca11d0ca35aadddb82ecc14d4e93cf6ae3dd11bdaa294007543e9fb84c8a59a4
+      bin: zanecli
+      files:
+        - from: zanecli
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Darwin_arm64.tar.gz
+      sha256: 46675a38110dfb88e17205ee95f09e36c7080631338a80a76080af1c15ad7e73
+      bin: zanecli
+      files:
+        - from: zanecli
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Linux_x86_64.tar.gz
+      sha256: 2e67e118fbc8e59acebdfef3f4a0ccb12488c71a7d3bdd019e5b71e7798aea04
+      bin: zanecli
+      files:
+        - from: zanecli
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Linux_arm64.tar.gz
+      sha256: 74170027b8f99080ddc8b0ced745478b137da18f8d2a383e412ae4322d517100
+      bin: zanecli
+      files:
+        - from: zanecli
+          to: .
+        - from: LICENSE
+          to: .
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/zarakM/zanecli/releases/download/v0.1.0/zanecli_0.1.0_Windows_x86_64.zip
+      sha256: 905bc4fac356679bd4f21ebc09d3bb8f4a236f1501bebb9b947f1570e2517ad5
+      bin: zanecli.exe
+      files:
+        - from: zanecli.exe
+          to: .
+        - from: LICENSE
+          to: .


### PR DESCRIPTION
Adds **zanecli**, a conversational Kubernetes co-pilot.

`kubectl zanecli` opens a chat REPL: you ask a question in plain English, the agent investigates the cluster through read-only API calls (pods, deployments, events, logs, PVCs, and arbitrary resources via the dynamic client), cites the evidence it found, and proposes fixes. A tightly-scoped set of writes (restart a deployment, delete a pod) is available, and every cluster mutation is confirmation-gated. It talks directly to the Anthropic API; optional telemetry never stores cluster identifiers.

- Source: https://github.com/zarakM/zanecli (open source)
- Release with prebuilt binaries: https://github.com/zarakM/zanecli/releases/tag/v0.1.0
- Platforms: darwin/amd64, darwin/arm64, linux/amd64, linux/arm64, windows/amd64
- LICENSE is extracted on install.

Validated locally with `kubectl krew install --manifest=plugins/zanecli.yaml` (checksums verified, LICENSE + binary extracted, `kubectl zanecli` discovered).

Note: this plugin is an interactive chat REPL rather than a one-shot command; happy to discuss if that affects acceptance.