### PR TITLE
Update hpa-status to v0.3.0

### DIFF
--- a/plugins/hpa-status.yaml
+++ b/plugins/hpa-status.yaml
@@ -3,8 +3,8 @@ kind: Plugin
 metadata:
   name: hpa-status
 spec:
-  version: v0.1.0
-  homepage: https://github.com/mattsu2020/kubehpa_cli
+  version: v0.3.0
+  homepage: https://github.com/mattsu2020/kubectl-hpa-status
   shortDescription: Show detailed HPA status and scaling analysis
   description: |
     Displays detailed HorizontalPodAutoscaler status including current and
@@ -18,34 +18,34 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_amd64.tar.gz
-      sha256: e38b251e1742daa2e957363342ea4c5aa6bbb6664f1fa24d7633aeac76ad72a3
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.3.0/kubectl-hpa-status_v0.3.0_darwin_amd64.tar.gz
+      sha256: 20b2a914bbcdf1df6e36ddcdd34f4b8214afdc3a599231be5e5638b703f0f57f
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_darwin_arm64.tar.gz
-      sha256: bdce2f3a9d7fdd875f63a6296abbf606d1f99781d5038dfbfa6558676a13d9d7
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.3.0/kubectl-hpa-status_v0.3.0_darwin_arm64.tar.gz
+      sha256: 95d795c9e73786f7bd8bd32139fc5d0af333a805422477b908cc97c41d61d79b
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_amd64.tar.gz
-      sha256: 6b61d37dd9217cced6e70b66a4f14d1d24e8ba519870bf5b6f09721ac87bb707
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.3.0/kubectl-hpa-status_v0.3.0_linux_amd64.tar.gz
+      sha256: 3c4228ac8c5655a4de4c26627413e7aeb9cd1a137cb7bec5be5b0ef6a47d1902
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_linux_arm64.tar.gz
-      sha256: 654b29e9185785059772a16bff5404275a19d49ae23f10f09727f2dcd0ab2e21
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.3.0/kubectl-hpa-status_v0.3.0_linux_arm64.tar.gz
+      sha256: ea1a3e0ffe2ed396b3d92a5f9645cccbd20066a76abbfdb0d642c486923ebca0
       bin: kubectl-hpa-status
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/mattsu2020/kubehpa_cli/releases/download/v0.1.0/kubectl-hpa-status_v0.1.0_windows_amd64.tar.gz
-      sha256: b95eccfca109333e0d8da45a87f47b617147fa5523f9b4e8b4995f2ad6e5a12f
+      uri: https://github.com/mattsu2020/kubectl-hpa-status/releases/download/v0.3.0/kubectl-hpa-status_v0.3.0_windows_amd64.tar.gz
+      sha256: 9d424a728f1c4fda771c751cc292e5c686583f36675f4eb63e1de4931e5e985c
       bin: kubectl-hpa-status.exe


### PR DESCRIPTION
Updates the hpa-status plugin manifest to v0.3.0.
Changes:
- Bump version from v0.1.0 to v0.3.0
- Update homepage and artifact URLs from mattsu2020/kubehpa_cli to mattsu2020/kubectl-hpa-status
- Refresh SHA256 values from the v0.3.0 release checksums\n\nValidation:
- /private/tmp/validate-krew-manifest -manifest plugins/hpa-status.yaml