### PR TITLE
feat: update k8i to v0.1.4

### DIFF
--- a/plugins/k8i.yaml
+++ b/plugins/k8i.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: k8i
 spec:
-  version: v0.1.3
+  version: v0.1.4
   homepage: https://github.com/ViktorUJ/kubectl-k8i
   shortDescription: Display Kubernetes node resources with color-coded load indicators
   description: |
@@ -38,41 +38,41 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_linux_amd64.tar.gz
-      sha256: "c9b95a77ee24bbf1a05f3c091745702c13ff2a00a0d9ca55ba3ac4f1a503b33a"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.4/kubectl-k8i_linux_amd64.tar.gz
+      sha256: "bfde2c12c1b55b9bc9914c755c3702f1a36aee8e13d6d08c005921defc22e7e4"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_linux_arm64.tar.gz
-      sha256: "a1fa33c98447ccd34ef4f441950f6f78843245471f5f0cf41e5c6e34d07149b5"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.4/kubectl-k8i_linux_arm64.tar.gz
+      sha256: "ece80283408b45fae42947df55517df5ce76137d50f21f2679527a6826eaa1f7"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_darwin_amd64.tar.gz
-      sha256: "5ef8d5ebce865f2efdae5aa0a2a393b2c8a9c61af107fc26164da81ccaee7699"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.4/kubectl-k8i_darwin_amd64.tar.gz
+      sha256: "c9dd03d9a1883f05cc1ca576fe898ab898198f813317db6cf20e96c27827db40"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_darwin_arm64.tar.gz
-      sha256: "3237b97c2a8420a14613d687d446961754dc78e5c45308f71135df71bcf8c644"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.4/kubectl-k8i_darwin_arm64.tar.gz
+      sha256: "9d5ff19fad6936541b9b3e2a1e408fd0317ba70949dc562553e0f9933d510a69"
       bin: kubectl-k8i
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_windows_amd64.zip
-      sha256: "cf614ea70aafdf1e343cfde9f2780a58bd87b77699a8212c57fda41b99b07ef7"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.4/kubectl-k8i_windows_amd64.zip
+      sha256: "bbfa3b072760066a1b1c8aca9581b71dcd9d6041b4a1a0ad5798cb02b73a1341"
       bin: kubectl-k8i.exe
     - selector:
         matchLabels:
           os: windows
           arch: arm64
-      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.3/kubectl-k8i_windows_arm64.zip
-      sha256: "a2b4d64aaebedb683cc2f0302822c4aab52184ec9e7e824d8411d35026749944"
+      uri: https://github.com/ViktorUJ/kubectl-k8i/releases/download/v0.1.4/kubectl-k8i_windows_arm64.zip
+      sha256: "256023962e4dbb4a3684edbcf2fd8e37e653f14aa3cc72542cc6582d0594a99d"
       bin: kubectl-k8i.exe


### PR DESCRIPTION
Update k8i plugin from v0.1.3 to v0.1.4.

## Changes in v0.1.4

### analyze: overcommit threshold filtering
- `--cpu-overcommit PERCENT` — show only workloads whose CPU limit exceeds request by more than the given percent
- `--mem-overcommit PERCENT` — same for memory
- Both thresholds work together (logical AND) and with all other flags

### analyze: --namespace flag
- `--namespace NAME` — scope output to a single namespace, combines with any node selector

### Other
- Renamed autoscaler value `cas` → `cluster-autoscaler` for clarity
- Grammar fixes in help text
- Updated golang.org/x/crypto and golang.org/x/net to latest secure versions

## Release
https://github.com/ViktorUJ/kubectl-k8i/releases/tag/v0.1.4