### PR TITLE
Add kubectl doc plugin

### DIFF
--- a/plugins/doc.yaml
+++ b/plugins/doc.yaml
@@ -1,0 +1,93 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: doc
+spec:
+  version: v0.2.6
+  homepage: https://github.com/sttts/kubectl-doc
+  shortDescription: Render Kubernetes API documentation
+  description: |
+    Render Kubernetes OpenAPI v3 schemas as YAML-shaped documentation for
+    terminal, Markdown, HTML, and interactive documentation surfaces.
+
+    kubectl doc can read schemas from a live cluster or from local CRD
+    manifests. It supports YAML, Markdown, Kro SimpleSchema, HTML, browser,
+    and terminal UI output formats.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.6/kubectl-doc-v0.2.6-linux-amd64.tar.gz
+      sha256: 2afc015de978a2a2060f350b1292c1dedee39fbf590c0da7e829f7d36a71cf7d
+      files:
+        - from: kubectl-doc-v0.2.6-linux-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.6-linux-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.6/kubectl-doc-v0.2.6-linux-arm64.tar.gz
+      sha256: 7914795c0c9007e547774c2563a4d43359b118c734c79d7bb1b5ec76e86936f0
+      files:
+        - from: kubectl-doc-v0.2.6-linux-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.6-linux-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.6/kubectl-doc-v0.2.6-darwin-amd64.tar.gz
+      sha256: 69a8bcc8d1a2f92264269bde919dcb263255d903f4f1d9c4d0cd634615e7d7d8
+      files:
+        - from: kubectl-doc-v0.2.6-darwin-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.6-darwin-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.6/kubectl-doc-v0.2.6-darwin-arm64.tar.gz
+      sha256: 8022a521a17897dab669ff0528bdb2d7b078f4e334334d265ec970f312cbd522
+      files:
+        - from: kubectl-doc-v0.2.6-darwin-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.6-darwin-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.6/kubectl-doc-v0.2.6-windows-amd64.zip
+      sha256: 9925e47ecfde767812045142a02d1e1a9503fcbe3fa23a9b6e2480bfcf4c6282
+      files:
+        - from: kubectl-doc-v0.2.6-windows-amd64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.6-windows-amd64/LICENSE
+          to: .
+      bin: kubectl-doc.exe
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.6/kubectl-doc-v0.2.6-windows-arm64.zip
+      sha256: 8363c170c567ead7fe765cb98115a044c13e6625261d7e54add6b17879a1607a
+      files:
+        - from: kubectl-doc-v0.2.6-windows-arm64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.6-windows-arm64/LICENSE
+          to: .
+      bin: kubectl-doc.exe

--- a/plugins/doc.yaml
+++ b/plugins/doc.yaml
@@ -1,0 +1,93 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: doc
+spec:
+  version: v0.2.5
+  homepage: https://github.com/sttts/kubectl-doc
+  shortDescription: Render Kubernetes API documentation
+  description: |
+    Render Kubernetes OpenAPI v3 schemas as YAML-shaped documentation for
+    terminal, Markdown, HTML, and interactive documentation surfaces.
+
+    kubectl doc can read schemas from a live cluster or from local CRD
+    manifests. It supports YAML, Markdown, Kro SimpleSchema, HTML, browser,
+    and terminal UI output formats.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.5/kubectl-doc-v0.2.5-linux-amd64.tar.gz
+      sha256: 7096be2785e20d306e6182f39a42aeaf5ab387253fd50cfc4577768fb5154cd4
+      files:
+        - from: kubectl-doc-v0.2.5-linux-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.5-linux-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.5/kubectl-doc-v0.2.5-linux-arm64.tar.gz
+      sha256: 092ec76ffe34f4e4d4593bb3df32e46562e84582bb5570b62c166e0317014d5b
+      files:
+        - from: kubectl-doc-v0.2.5-linux-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.5-linux-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.5/kubectl-doc-v0.2.5-darwin-amd64.tar.gz
+      sha256: 60df275e4b9169f6ad2e50b5e088fcb226f6f62878a1683e88445ad3e011b5bc
+      files:
+        - from: kubectl-doc-v0.2.5-darwin-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.5-darwin-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.5/kubectl-doc-v0.2.5-darwin-arm64.tar.gz
+      sha256: 076fd9460fa1ec2af7f809216482f22091f3460da23784d9c3df255e22a1f875
+      files:
+        - from: kubectl-doc-v0.2.5-darwin-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.5-darwin-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.5/kubectl-doc-v0.2.5-windows-amd64.zip
+      sha256: 672d43d77c3bd4628e86332b626f1a953e163bb4d0ecab2f9904d84bc330480b
+      files:
+        - from: kubectl-doc-v0.2.5-windows-amd64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.5-windows-amd64/LICENSE
+          to: .
+      bin: kubectl-doc.exe
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.5/kubectl-doc-v0.2.5-windows-arm64.zip
+      sha256: d4c6fcae5d1eba01e66c3ab1db33c8cb0fa4752c746f310df4edaae30e4bc08c
+      files:
+        - from: kubectl-doc-v0.2.5-windows-arm64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.5-windows-arm64/LICENSE
+          to: .
+      bin: kubectl-doc.exe

--- a/plugins/doc.yaml
+++ b/plugins/doc.yaml
@@ -1,0 +1,93 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: doc
+spec:
+  version: v0.2.2
+  homepage: https://github.com/sttts/kubectl-doc
+  shortDescription: Render Kubernetes API documentation
+  description: |
+    Render Kubernetes OpenAPI v3 schemas as YAML-shaped documentation for
+    terminal, Markdown, HTML, and interactive documentation surfaces.
+
+    kubectl doc can read schemas from a live cluster or from local CRD
+    manifests. It supports YAML, Markdown, Kro SimpleSchema, HTML, browser,
+    and terminal UI output formats.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.2/kubectl-doc-v0.2.2-linux-amd64.tar.gz
+      sha256: 308e21eab0b900f2cd5bc46240134100c1323f0eafdce60acefab1996aea0404
+      files:
+        - from: kubectl-doc-v0.2.2-linux-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.2-linux-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.2/kubectl-doc-v0.2.2-linux-arm64.tar.gz
+      sha256: 4cdfd9faf243f6060631a2875cfdd461912192132d8cfc3123e0a3ee696628ac
+      files:
+        - from: kubectl-doc-v0.2.2-linux-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.2-linux-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.2/kubectl-doc-v0.2.2-darwin-amd64.tar.gz
+      sha256: 3f880e049b1d8b7159cc9142c69ae8b931c063309e9f42473275b405a568b026
+      files:
+        - from: kubectl-doc-v0.2.2-darwin-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.2-darwin-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.2/kubectl-doc-v0.2.2-darwin-arm64.tar.gz
+      sha256: 7daaa1afb98f6c213ca6e74768926bfda1ef1bdb451c8d3aac03c07833952dc2
+      files:
+        - from: kubectl-doc-v0.2.2-darwin-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.2-darwin-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.2/kubectl-doc-v0.2.2-windows-amd64.zip
+      sha256: 56adb5ec68cdab741eebced1d26eaa98885d20e7a2b214feaa39c4a8d02ce212
+      files:
+        - from: kubectl-doc-v0.2.2-windows-amd64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.2-windows-amd64/LICENSE
+          to: .
+      bin: kubectl-doc.exe
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.2/kubectl-doc-v0.2.2-windows-arm64.zip
+      sha256: 1551a662689e852a3533f5f45909be0d301ab44d543face410366648bd115886
+      files:
+        - from: kubectl-doc-v0.2.2-windows-arm64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.2-windows-arm64/LICENSE
+          to: .
+      bin: kubectl-doc.exe

--- a/plugins/doc.yaml
+++ b/plugins/doc.yaml
@@ -1,0 +1,93 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: doc
+spec:
+  version: v0.2.4
+  homepage: https://github.com/sttts/kubectl-doc
+  shortDescription: Render Kubernetes API documentation
+  description: |
+    Render Kubernetes OpenAPI v3 schemas as YAML-shaped documentation for
+    terminal, Markdown, HTML, and interactive documentation surfaces.
+
+    kubectl doc can read schemas from a live cluster or from local CRD
+    manifests. It supports YAML, Markdown, Kro SimpleSchema, HTML, browser,
+    and terminal UI output formats.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.4/kubectl-doc-v0.2.4-linux-amd64.tar.gz
+      sha256: 92600c09771d7cb75c60c9ff719817d302c464a82e17e07c827ce245775c66ec
+      files:
+        - from: kubectl-doc-v0.2.4-linux-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.4-linux-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.4/kubectl-doc-v0.2.4-linux-arm64.tar.gz
+      sha256: 0d01833c711342162d521613e41669fab6c6feae92a0ad79ca17fc5fcc62fe9b
+      files:
+        - from: kubectl-doc-v0.2.4-linux-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.4-linux-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.4/kubectl-doc-v0.2.4-darwin-amd64.tar.gz
+      sha256: e78118f4a405eee671bd132456b06be9e6d09931347a6fb3da1bdc308e560c5e
+      files:
+        - from: kubectl-doc-v0.2.4-darwin-amd64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.4-darwin-amd64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.4/kubectl-doc-v0.2.4-darwin-arm64.tar.gz
+      sha256: 51c3e63b80d2795bd79b82344aa3417923c3624aec250e421b2a0d83d62f97c5
+      files:
+        - from: kubectl-doc-v0.2.4-darwin-arm64/kubectl-doc
+          to: .
+        - from: kubectl-doc-v0.2.4-darwin-arm64/LICENSE
+          to: .
+      bin: kubectl-doc
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.4/kubectl-doc-v0.2.4-windows-amd64.zip
+      sha256: 1ff93b20251eb18a416851eb496e239e2f4a265b2939107fc44b2ddd470b4db2
+      files:
+        - from: kubectl-doc-v0.2.4-windows-amd64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.4-windows-amd64/LICENSE
+          to: .
+      bin: kubectl-doc.exe
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/sttts/kubectl-doc/releases/download/v0.2.4/kubectl-doc-v0.2.4-windows-arm64.zip
+      sha256: 44a36715d8ac56fdddc422228008d67dd86165fabc6bdc0fecbafb8c65ca13a2
+      files:
+        - from: kubectl-doc-v0.2.4-windows-arm64/kubectl-doc.exe
+          to: .
+        - from: kubectl-doc-v0.2.4-windows-arm64/LICENSE
+          to: .
+      bin: kubectl-doc.exe


### PR DESCRIPTION
See https://github.com/sttts/kubectl-doc.
<!--

PLUGIN DEVELOPERS: If you are submitting a new plugin

- Make sure you read the Plugin Naming Guide: https://krew.sigs.k8s.io/docs/developer-guide/develop/naming-guide/
- Verify you can install your plugin locally: kubectl krew install --manifest=[...] --archive=[...]

-->
