### PR TITLE
atlas: upgrade to v1.4.0

### DIFF
--- a/plugins/atlas.yaml
+++ b/plugins/atlas.yaml
@@ -12,7 +12,7 @@ kind: Plugin
 metadata:
   name: atlas
 spec:
-  version: v1.3.1
+  version: v1.4.0
   homepage: https://github.com/lithastra/kubeatlas
   shortDescription: Visualize Kubernetes resource dependencies
   description: |
@@ -45,31 +45,31 @@ spec:
   platforms:
     - selector:
         matchLabels: { os: linux, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_linux_amd64.tar.gz
-      sha256: "587cbc92607a346ac90008597498fbf4e7fc036b496ba2ce1c46729fc041d1d2"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_linux_amd64.tar.gz
+      sha256: "4968767c96681d6e27965ed27ddac39f2ceb9e7102cd90b4b6e0153c6d77f740"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: linux, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_linux_arm64.tar.gz
-      sha256: "e5b7993b09a28ea81943e3866b59f9e82071d7e66c51fb79a86fbd8f07fad780"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_linux_arm64.tar.gz
+      sha256: "7b691b26afd4a31b9039f3666458b3e1d1da71009551dbfc916c5a3d2ef27f91"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_darwin_amd64.tar.gz
-      sha256: "43029e6faaf0ff4199426bd5cd956ec7a167ec57bee39b868b91efbae832b26a"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_darwin_amd64.tar.gz
+      sha256: "2e688175cb56034b99a2d25c9cbb2db81e691eec406177c1df219d7035fa6fdb"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_darwin_arm64.tar.gz
-      sha256: "928dbba933c05c2197b760705ae023beee7e542882eb81b62f2e14ff97d6dbf0"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_darwin_arm64.tar.gz
+      sha256: "b06708cf1b649c6cb036aea2a4da2db8985c65234130aa8c40d1f1ff7d074d3f"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: windows, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_windows_amd64.tar.gz
-      sha256: "95129a8261e4ce3d407e0837d0677ed202f0d1db9641e9c5ba6c59e0b553da02"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_windows_amd64.tar.gz
+      sha256: "632274c656069a865c5e8276f19a7e0279f7d759125816b3cbd13c31bcc61e64"
       bin: kubectl-atlas.exe
     - selector:
         matchLabels: { os: windows, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.3.1/kubectl-atlas_1.3.1_windows_arm64.tar.gz
-      sha256: "99d9a97988c342acf2511209198fe93c5d9119b54cd89075867a6ddb9382d398"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_windows_arm64.tar.gz
+      sha256: "324e7d60323e024a75e62cc75b6d4beb2181ccd3d3fbb73fde0b2c574d6d8a80"
       bin: kubectl-atlas.exe


### PR DESCRIPTION
Upgrades the `atlas` plugin to v1.4.0.

The manifest points the six platform archives at the [v1.4.0 release](https://github.com/lithastra/kubeatlas/releases/tag/v1.4.0) and refreshes their sha256 sums. All URIs were verified reachable with matching digests.

v1.4.0 adds an offline diagnostic report, Gatekeeper/Kyverno policy visibility, and opt-in anonymous telemetry. The `kubectl-atlas` plugin itself is unchanged in shape — same three modes (offline SVG, --local-ui, --online).