### PR TITLE
Add ctx-diff plugin

### DIFF
--- a/plugins/ctx-diff.yaml
+++ b/plugins/ctx-diff.yaml
@@ -5,16 +5,11 @@ metadata:
 spec:
   version: v0.1.2
   homepage: https://github.com/salvador-arreola/kubectl-ctx-diff
-  shortDescription: Diff k8s resources between two contexts
+  shortDescription: Compare Kubernetes resources across contexts
   description: |
-    Compare Kubernetes environments across kubeconfig contexts.
-    Diffs ConfigMaps, Secrets (keys only), and Deployment resource
-    limits and env vars, with colored table or JSON output.
-
-    Usage:
-      kubectl ctx-diff diff --context-2 prod -n my-namespace
-      kubectl ctx-diff diff --context-2 prod --filter configmaps,secrets
-      kubectl ctx-diff diff --context-2 prod -o json
+    Compares Kubernetes resources between two kubeconfig contexts. Diffs
+    ConfigMaps, Secrets (keys only), and Deployment resource limits and
+    env vars, with colored table or JSON output.
 
   platforms:
     - selector:

--- a/plugins/ctx-diff.yaml
+++ b/plugins/ctx-diff.yaml
@@ -1,0 +1,83 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ctx-diff
+spec:
+  version: v0.1.1
+  homepage: https://github.com/salvador-arreola/kubectl-ctx-diff
+  shortDescription: Diff k8s resources between two contexts
+  description: |
+    Compare Kubernetes environments across kubeconfig contexts.
+    Diffs ConfigMaps, Secrets (keys only), and Deployment resource
+    limits and env vars, with colored table or JSON output.
+
+    Usage:
+      kubectl ctx-diff diff --context-2 prod -n my-namespace
+      kubectl ctx-diff diff --context-2 prod --filter configmaps,secrets
+      kubectl ctx-diff diff --context-2 prod -o json
+
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_linux_amd64.tar.gz
+      sha256: "038dfafc6060ad029872b5d821572989942442d1663754d83dc010ebd8c91c0d"
+      bin: kubectl-ctx-diff
+      files:
+        - from: kubectl-ctx-diff
+          to: .
+        - from: LICENSE
+          to: .
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_linux_arm64.tar.gz
+      sha256: "1134041aa977e401281b6f2bc217117ecbae77f4437b3dddf6a7531ce508eea9"
+      bin: kubectl-ctx-diff
+      files:
+        - from: kubectl-ctx-diff
+          to: .
+        - from: LICENSE
+          to: .
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_darwin_amd64.tar.gz
+      sha256: "445981340959ba29b4b2f785e551730cf21d151f8da925267c63541da2bfcdb2"
+      bin: kubectl-ctx-diff
+      files:
+        - from: kubectl-ctx-diff
+          to: .
+        - from: LICENSE
+          to: .
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_darwin_arm64.tar.gz
+      sha256: "6899421800b784a0f0d7fa63bae7a31df1c512e229db89470a9f21f92353b469"
+      bin: kubectl-ctx-diff
+      files:
+        - from: kubectl-ctx-diff
+          to: .
+        - from: LICENSE
+          to: .
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_windows_amd64.zip
+      sha256: "524e9a5f446beee0350f927c9f9d5cc01a5337f9a7595c55e9998c50f7bfa903"
+      bin: kubectl-ctx-diff.exe
+      files:
+        - from: kubectl-ctx-diff.exe
+          to: .
+        - from: LICENSE
+          to: .

--- a/plugins/ctx-diff.yaml
+++ b/plugins/ctx-diff.yaml
@@ -8,8 +8,8 @@ spec:
   shortDescription: Compare Kubernetes resources across contexts
   description: |
     Compares Kubernetes resources between two kubeconfig contexts. Diffs
-    ConfigMaps, Secrets (keys only), and Deployment resource limits and
-    env vars, with colored table or JSON output.
+    any namespaced resource including CRDs, discovered automatically.
+    Secret values are never exposed. Colored table or JSON output.
 
   platforms:
     - selector:

--- a/plugins/ctx-diff.yaml
+++ b/plugins/ctx-diff.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: ctx-diff
 spec:
-  version: v0.1.1
+  version: v0.1.2
   homepage: https://github.com/salvador-arreola/kubectl-ctx-diff
   shortDescription: Diff k8s resources between two contexts
   description: |
@@ -21,8 +21,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_linux_amd64.tar.gz
-      sha256: "038dfafc6060ad029872b5d821572989942442d1663754d83dc010ebd8c91c0d"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_linux_amd64.tar.gz
+      sha256: "1d44825aaa4dce67d3edcb5cb99204bc30e193991b381c0ae7a32d3697843814"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -34,8 +34,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_linux_arm64.tar.gz
-      sha256: "1134041aa977e401281b6f2bc217117ecbae77f4437b3dddf6a7531ce508eea9"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_linux_arm64.tar.gz
+      sha256: "340f29812138da6fbf93d22f5d0d53d01d0a68c1645b0c6f8a3481cdd33a1ab6"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -47,8 +47,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_darwin_amd64.tar.gz
-      sha256: "445981340959ba29b4b2f785e551730cf21d151f8da925267c63541da2bfcdb2"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_darwin_amd64.tar.gz
+      sha256: "39e201fb1893c2e3855f57645af0897c2c0c7e213b97fbf2d10b28c8db6b4dbc"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -60,8 +60,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_darwin_arm64.tar.gz
-      sha256: "6899421800b784a0f0d7fa63bae7a31df1c512e229db89470a9f21f92353b469"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_darwin_arm64.tar.gz
+      sha256: "849a33be5acfe6b6ead19db3595ace81da620ef7384bfec0d0944e31ac1164dd"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -73,8 +73,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.1/kubectl-ctx-diff_windows_amd64.zip
-      sha256: "524e9a5f446beee0350f927c9f9d5cc01a5337f9a7595c55e9998c50f7bfa903"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_windows_amd64.zip
+      sha256: "711211807f8e7c5175bde942ff448d474e620577222e4f908e127cb02b442718"
       bin: kubectl-ctx-diff.exe
       files:
         - from: kubectl-ctx-diff.exe

--- a/plugins/ctx-diff.yaml
+++ b/plugins/ctx-diff.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: ctx-diff
 spec:
-  version: v0.1.2
+  version: v0.2.3
   homepage: https://github.com/salvador-arreola/kubectl-ctx-diff
   shortDescription: Compare Kubernetes resources across contexts
   description: |
@@ -16,8 +16,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_linux_amd64.tar.gz
-      sha256: "1d44825aaa4dce67d3edcb5cb99204bc30e193991b381c0ae7a32d3697843814"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.2.3/kubectl-ctx-diff_linux_amd64.tar.gz
+      sha256: "a09da89d5770d4c566f1792a339e30c512052919c021cb5dafd18a99eaf174f5"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -29,8 +29,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_linux_arm64.tar.gz
-      sha256: "340f29812138da6fbf93d22f5d0d53d01d0a68c1645b0c6f8a3481cdd33a1ab6"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.2.3/kubectl-ctx-diff_linux_arm64.tar.gz
+      sha256: "311739273955dde9cb1ceb8278fe260190cfa500a6e8e0cb9e76f754e0ce36d9"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -42,8 +42,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_darwin_amd64.tar.gz
-      sha256: "39e201fb1893c2e3855f57645af0897c2c0c7e213b97fbf2d10b28c8db6b4dbc"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.2.3/kubectl-ctx-diff_darwin_amd64.tar.gz
+      sha256: "122c0461168020093098df9e0509072ee16e66e46408930c0e8c56f2bc53063d"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -55,8 +55,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_darwin_arm64.tar.gz
-      sha256: "849a33be5acfe6b6ead19db3595ace81da620ef7384bfec0d0944e31ac1164dd"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.2.3/kubectl-ctx-diff_darwin_arm64.tar.gz
+      sha256: "0f2783118b6d4cf54cefc494586f44b44909b69dc3e4ffa9e42b4bb32ad2b041"
       bin: kubectl-ctx-diff
       files:
         - from: kubectl-ctx-diff
@@ -68,8 +68,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.1.2/kubectl-ctx-diff_windows_amd64.zip
-      sha256: "711211807f8e7c5175bde942ff448d474e620577222e4f908e127cb02b442718"
+      uri: https://github.com/salvador-arreola/kubectl-ctx-diff/releases/download/v0.2.3/kubectl-ctx-diff_windows_amd64.zip
+      sha256: "461a2bbbe4d254ffaec4b99fe470050a1c81a93ef327537ca9f102de34a4d6aa"
       bin: kubectl-ctx-diff.exe
       files:
         - from: kubectl-ctx-diff.exe


### PR DESCRIPTION
## What this plugin does

`ctx-diff` diffs Kubernetes resources side by side between two kubeconfig contexts or namespaces. It compares ConfigMaps, Secrets (key names only, values are never exposed), and Deployment resource limits and env vars.

Useful for catching environment drift between staging and production, or between two namespaces in the same cluster.

## Plugin details

- **Repository:** https://github.com/salvador-arreola/kubectl-ctx-diff
- **Version:** v0.1.2
- **License:** MIT
- **Platforms:** linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64

## Usage

```sh
kubectl ctx-diff diff --context-2 prod -n my-app
kubectl ctx-diff diff --context-2 prod --filter configmaps,secrets
kubectl ctx-diff diff --context-2 prod -o json
kubectl ctx-diff diff --context-2 prod --full   # opens $DIFFTOOL
```

Checklist

- [x] Reviewed the naming guide
- [x] Reviewed best practices
- [x] Source code is publicly available and open source (MIT)
- [x] LICENSE file is included in the release archive
- [x] Plugin versioned with semantic version tag (v0.1.2)
- [x] Tested local installation via kubectl krew install --manifest --archive
- [x] Plugin name does not conflict with any existing plugin

**Note**: This plugin was developed with assistance from Claude (Anthropic AI).