### PR TITLE
Add finalizer-doctor plugin

### DIFF
--- a/plugins/finalizer-doctor.yaml
+++ b/plugins/finalizer-doctor.yaml
@@ -1,0 +1,53 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: finalizer-doctor
+spec:
+  version: v0.1.0
+  homepage: https://github.com/alexremn/finalizer-doctor
+  shortDescription: Safely diagnose & clear stuck finalizers
+  description: 'Pinpoints the finalizer and the dead controller / APIService blocking deletion, cleans
+    truly-orphaned resources first, and clears finalizers only as a gated last resort. Dry-run and explain
+    by default.
+
+    '
+  caveats: 'This is a last resort. Clearing a finalizer is irreversible and can orphan infrastructure.
+    Run without --apply first to see the evidence and verdict.
+
+    '
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_linux_amd64.tar.gz
+    sha256: ad4823224a25ce358ce729fa370f77e709c96a8077466fca4542a052ea916f2c
+    bin: kubectl-finalizer_doctor
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_linux_arm64.tar.gz
+    sha256: ea345fd87497af44ad2f2649a75c3c2695c9040cdba52a33c7e4e45dc9855dfc
+    bin: kubectl-finalizer_doctor
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_darwin_amd64.tar.gz
+    sha256: c47dd4e0a49c4c42f0972601ae8f97f9cb01cdc6c6dd8254b31bcab10d36c5c8
+    bin: kubectl-finalizer_doctor
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_darwin_arm64.tar.gz
+    sha256: 624c7501c1e3ebff5aa08036624393c256b9d04433121cc9c62a699225933594
+    bin: kubectl-finalizer_doctor
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_windows_amd64.tar.gz
+    sha256: bfdd7d508ebf546b149cbe5d452bb92ddb4beb42411632bb150af56e14e07fbd
+    bin: kubectl-finalizer_doctor.exe

--- a/plugins/finalizer-doctor.yaml
+++ b/plugins/finalizer-doctor.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: finalizer-doctor
 spec:
-  version: v0.1.0
+  version: v0.1.1
   homepage: https://github.com/alexremn/finalizer-doctor
   shortDescription: Safely diagnose & clear stuck finalizers
   description: 'Pinpoints the finalizer and the dead controller / APIService blocking deletion, cleans
@@ -20,34 +20,34 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_linux_amd64.tar.gz
-    sha256: ad4823224a25ce358ce729fa370f77e709c96a8077466fca4542a052ea916f2c
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.1/finalizer-doctor_linux_amd64.tar.gz
+    sha256: 400604029eaaf909a235b7e8045262d68344dbc565d58f18cf44f8db799abec3
     bin: kubectl-finalizer_doctor
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_linux_arm64.tar.gz
-    sha256: ea345fd87497af44ad2f2649a75c3c2695c9040cdba52a33c7e4e45dc9855dfc
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.1/finalizer-doctor_linux_arm64.tar.gz
+    sha256: 58d4a74b22e45694dfbc801d8bc141329b84da4adfd6d47cf2a6a9f84fdba5e1
     bin: kubectl-finalizer_doctor
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_darwin_amd64.tar.gz
-    sha256: c47dd4e0a49c4c42f0972601ae8f97f9cb01cdc6c6dd8254b31bcab10d36c5c8
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.1/finalizer-doctor_darwin_amd64.tar.gz
+    sha256: ada71878f4ecfa9436c0844214d0fab1f667a1901e53c00a242d89e2afaa7525
     bin: kubectl-finalizer_doctor
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_darwin_arm64.tar.gz
-    sha256: 624c7501c1e3ebff5aa08036624393c256b9d04433121cc9c62a699225933594
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.1/finalizer-doctor_darwin_arm64.tar.gz
+    sha256: f9deb3a31c697b48f4cd9f99bb5502cc7e5973c2698df0cf175719f05636c20f
     bin: kubectl-finalizer_doctor
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.0/finalizer-doctor_windows_amd64.tar.gz
-    sha256: bfdd7d508ebf546b149cbe5d452bb92ddb4beb42411632bb150af56e14e07fbd
+    uri: https://github.com/alexremn/finalizer-doctor/releases/download/v0.1.1/finalizer-doctor_windows_amd64.tar.gz
+    sha256: 22c8f3318868f455416650371bf058969b89f5df0505a31cae8c906ee2c80aa6
     bin: kubectl-finalizer_doctor.exe


### PR DESCRIPTION
This adds **finalizer-doctor** — a kubectl plugin that safely diagnoses and clears finalizers on resources stuck in `Terminating`.

It pinpoints the blocking finalizer and the dead controller / APIService, cleans truly-orphaned resources first, and clears finalizers only as a gated last resort (dry-run by default, evidence-based verdict, proof-bound apply).

- Repo: https://github.com/alexremn/finalizer-doctor
- Release: https://github.com/alexremn/finalizer-doctor/releases/tag/v0.1.0
- License: Apache-2.0

Both `kubectl finalizer-doctor` and a short `fid` are shipped as binaries; this krew plugin installs `kubectl finalizer-doctor`.