### PR TITLE
Add aks-node-debug plugin

### DIFF
--- a/plugins/aks-debug-node.yaml
+++ b/plugins/aks-debug-node.yaml
@@ -1,0 +1,36 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: aks-debug-node
+spec:
+  version: "v1.0.0"
+  homepage: "https://github.com/ragatgen/kubectl-aks-debug-node"
+  shortDescription: "Debug Azure AKS nodes: collect logs, kubelet info, OS/runtime diagnostics."
+  description: |
+    A kubectl plugin to collect detailed diagnostic information from Azure Kubernetes Service nodes.
+    It gathers kubelet logs, system details, container runtime status, OS information, Node events,
+    and network/service information to help troubleshoot AKS node health and kubelet behavior.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: "https://github.com/ragatgen/kubectl-aks-debug-node/releases/download/v1.0.0/kubectl-aks-debug-node_v1.0.0_linux_amd64.tar.gz"
+      sha256: "24643882e3c65d93f4ab06dbb406aafe75780d4ab1b5c593a094d4836e02db5a"
+      bin: "kubectl-aks-debug-node"
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: "https://github.com/ragatgen/kubectl-aks-debug-node/releases/download/v1.0.0/kubectl-aks-debug-node_v1.0.0_darwin_amd64.tar.gz"
+      sha256: "24643882e3c65d93f4ab06dbb406aafe75780d4ab1b5c593a094d4836e02db5a"
+      bin: "kubectl-aks-debug-node"
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: "https://github.com/ragatgen/kubectl-aks-debug-node/releases/download/v1.0.0/kubectl-aks-debug-node_v1.0.0_darwin_arm64.tar.gz"
+      sha256: "24643882e3c65d93f4ab06dbb406aafe75780d4ab1b5c593a094d4836e02db5a"
+      bin: "kubectl-aks-debug-node"

--- a/plugins/aks-node-debug.yaml
+++ b/plugins/aks-node-debug.yaml
@@ -1,0 +1,24 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: aks-node-debug
+spec:
+  version: v0.1.1
+  homepage: https://github.com/ragatgen/kubectl-aks-node-debug
+  shortDescription: Interactive node debugging for AKS clusters
+  description: |
+    aks-node-debug provides an interactive workflow for node-level
+    troubleshooting.
+
+    The plugin discovers cluster nodes, allows the user to select
+    a node interactively, and launches a kubectl debug session.
+
+    Designed primarily for Azure Kubernetes Service (AKS).
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/ragatgen/kubectl-aks-node-debug/releases/download/v0.1.1/kubectl-aks-node-debug_v0.1.1_linux_amd64.tar.gz
+      sha256: df1807c34a360812c6a251e631972ce22e179393a78cd55de93fc135b4a1f419
+      bin: kubectl-aks-node-debug


### PR DESCRIPTION
<!--

## Plugin Description

Adds `aks-node-debug`, a kubectl plugin that simplifies node-level troubleshooting by providing an interactive workflow for launching `kubectl debug` sessions.

The plugin:

- Lists available cluster nodes
- Allows interactive node selection
- Launches a node debug session using `kubectl debug`
- Is primarily designed for Azure Kubernetes Service (AKS)

## Validation

Successfully tested locally:

```bash
kubectl krew install --manifest=plugins/aks-node-debug.yaml
kubectl aks-node-debug --version
kubectl aks-node-debug --help
kubectl aks-node-debug
''''
-->
