### PR TITLE
feat: add whoami-enhanced plugin

### DIFF
--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.1.0
   homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
-  shortDescription: Show your identity and RBAC permissions in the cluster
+  shortDescription: Show who you are and what you can do
   description: |
     kubectl whoami-enhanced shows who you are and what you can do
     in a Kubernetes cluster in one command.

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: whoami-enhanced
 spec:
-  version: v0.1.0
+  version: v0.1.1
   homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
   shortDescription: Show who you are and what you can do
   description: |
@@ -29,8 +29,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_amd64.tar.gz
-      sha256: "853c11df1633f1b6a3a3d8dc6ff99a7dde3eaa037ba449f2f2577c78c7e44276"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_linux_amd64.tar.gz
+      sha256: "8c3e1efe2278d4f76fd3d5f6ac0f2ed9a4f8c8fadee453e4412ad45f9254781b"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -40,8 +40,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_arm64.tar.gz
-      sha256: "74cf864803151fd7557f0d8bfa00c395d78db0dafa79242c410acc09057a0144"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_linux_arm64.tar.gz
+      sha256: "f8618433b2bbe9fae67963f0cb369629b1b5f0528c4d5dea0a3e084f4b0b0879"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -51,8 +51,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_amd64.tar.gz
-      sha256: "3866f32821e0eff407c417a914584170037af4b1c07eee5a4e9bcf4170eaff27"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_darwin_amd64.tar.gz
+      sha256: "f1d1e8e27c53b4dca51a57d9ff826daf53d67760786ae1791971f6368e268663"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -62,8 +62,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_arm64.tar.gz
-      sha256: "85866b3d0918922e7a36fa9c9bc954582e78aee0c9e9889c874aa56bf3656e94"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_darwin_arm64.tar.gz
+      sha256: "cd7e84168106fe6297e109609ab3cdf038b2cae66c4ad4ba67fffcb1e4a62ddf"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -73,8 +73,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_windows_amd64.zip
-      sha256: "f880ca644eb6a81a6a1d7c8ece40ffe22b71ea8133f1c957c9e5f6227d70dd8f"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_windows_amd64.zip
+      sha256: "1b8f98ab80cc207f8724740ade9756ef101b527dc4fc417094a8349dfef26f5d"
       bin: kubectl-whoami-enhanced.exe
       files:
         - from: "*"

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -1,0 +1,81 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: whoami-enhanced
+spec:
+  version: v0.1.0
+  homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
+  shortDescription: Show your identity and RBAC permissions in the cluster
+  description: |
+    kubectl whoami-enhanced shows who you are and what you can do
+    in a Kubernetes cluster in one command.
+
+    It displays:
+      - Current context, user, and groups
+      - Token expiry time (parsed from JWT)
+      - Permission matrix (get/list/delete/exec/create) per resource
+      - REASON column: which Role/RoleBinding grants each permission
+      - Supports --all-namespaces and --output-json flags
+
+    Useful for debugging RBAC issues without needing to ask
+    the cluster admin "why can't I delete this pod?"
+  caveats: |
+    Groups are only shown with token-based auth (OIDC/ServiceAccount).
+    Certificate-based auth will show a note instead of groups.
+    The REASON column requires list access to rolebindings/clusterrolebindings;
+    falls back gracefully if that access is not available.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_amd64.tar.gz
+      sha256: "853c11df1633f1b6a3a3d8dc6ff99a7dde3eaa037ba449f2f2577c78c7e44276"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_arm64.tar.gz
+      sha256: "74cf864803151fd7557f0d8bfa00c395d78db0dafa79242c410acc09057a0144"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_amd64.tar.gz
+      sha256: "3866f32821e0eff407c417a914584170037af4b1c07eee5a4e9bcf4170eaff27"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_arm64.tar.gz
+      sha256: "85866b3d0918922e7a36fa9c9bc954582e78aee0c9e9889c874aa56bf3656e94"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_windows_amd64.zip
+      sha256: "f880ca644eb6a81a6a1d7c8ece40ffe22b71ea8133f1c957c9e5f6227d70dd8f"
+      bin: kubectl-whoami-enhanced.exe
+      files:
+        - from: "*"
+          to: "."


### PR DESCRIPTION
## New Plugin: `whoami-enhanced`

### What it does

`kubectl whoami-enhanced` shows **who you are** and **what you can do** in a Kubernetes cluster — identity, token expiry, permission matrix, and the Role/RoleBinding that grants each permission, all in one command.

```
 KUBECTL WHOAMI — Enhanced
───────────────────────────────────────────────────────
 Context:    my-cluster
 User:       jane@example.com
 Groups:     dev-team, system:authenticated
 Namespace:  staging
 Token:      expires in 5h 23m (at 2026-06-25 18:00:00)
───────────────────────────────────────────────────────
 VERB       RESOURCE             ACCESS REASON
 get        pods                 ✓      ClusterRole/view → ClusterRoleBinding/dev-team-view
 list       pods                 ✓      ClusterRole/view → ClusterRoleBinding/dev-team-view
 delete     pods                 ✗      no matching rule found
 get        deployments          ✓      ClusterRole/view → ClusterRoleBinding/dev-team-view
 get        secrets              ✗      no matching rule found
 get        configmaps           ✓      ClusterRole/view → ClusterRoleBinding/dev-team-view
───────────────────────────────────────────────────────
```

### Why it is different from existing tools

| Tool | Identity | Permissions | Token TTL | REASON (which binding?) |
|------|----------|-------------|-----------|-------------------------|
| `kubectl whoami --all` | ✓ | ✗ | ✗ | ✗ |
| `kubectl access-matrix` | ✗ | ✓ | ✗ | ✗ |
| `kubectl auth whoami` | ✓ | ✗ | ✗ | ✗ |
| **kubectl whoami-enhanced** | ✓ | ✓ | ✓ | ✓ |

No existing plugin combines all four in one command.

### Checklist

- [x] Source code is publicly available
- [x] Apache 2.0 license included in repo and bundled in archives
- [x] Semantic version tag (`v0.1.0`)
- [x] Plugin name is kebab-case
- [x] Binaries built for linux/darwin/windows × amd64/arm64
- [x] SHA256 checksums verified
- [x] `files: [{from: "*", to: "."}]` present on all platforms
- [x] Read-only — no writes or mutations to the cluster
