### PR TITLE
Add kxdiff plugin

### DIFF
--- a/plugins/kxdiff.yaml
+++ b/plugins/kxdiff.yaml
@@ -1,0 +1,67 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: kxdiff
+spec:
+  version: v1.0.0
+  homepage: https://github.com/fevzisahinler/kxdiff
+  shortDescription: Read-only diff between two Kubernetes environments
+  description: |
+    kxdiff compares two live Kubernetes environments — a context and a namespace
+    on each side — and reports what differs, as text, JSON or markdown.
+
+    It discovers every resource type the cluster serves (built-ins, CRDs and
+    custom resources), filters out server-managed noise (resourceVersion, uid,
+    managedFields, status, controller-owned objects, high-churn types), masks
+    Secret values, and matches list items by name so reordering is not a false
+    diff.
+
+    It is strictly read-only: only get and list verbs are used; nothing is ever
+    created, changed or deleted, and your current context is never switched.
+  caveats: |
+    Compare two environments with:
+
+      kubectl kxdiff --from <context>[/<namespace>] --to <context>[/<namespace>]
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/fevzisahinler/kxdiff/releases/download/v1.0.0/kxdiff_darwin_amd64.tar.gz
+      sha256: 1b3b06500965dcc2c4775ee146326f33e609cead8c4a700065e7760af1914afc
+      bin: kubectl-kxdiff
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/fevzisahinler/kxdiff/releases/download/v1.0.0/kxdiff_darwin_arm64.tar.gz
+      sha256: 270f74bcb8d5a5900f079be93f82ab6f3a8719f4ed224066fcc4c308acb3164a
+      bin: kubectl-kxdiff
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/fevzisahinler/kxdiff/releases/download/v1.0.0/kxdiff_linux_amd64.tar.gz
+      sha256: ec375fe47baca2b0cc0d562a9d9a45605e32982d088f40b0e7cd2699cd5bd35b
+      bin: kubectl-kxdiff
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/fevzisahinler/kxdiff/releases/download/v1.0.0/kxdiff_linux_arm64.tar.gz
+      sha256: 3bbade5a22ff69036c70515119c7ff96ac06264e2ee6903918b073a90b02957a
+      bin: kubectl-kxdiff
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/fevzisahinler/kxdiff/releases/download/v1.0.0/kxdiff_windows_amd64.zip
+      sha256: a9142b29fe6f208fe6f1717ea2e19fe6bff2ce504324f1bf76759b0527921e16
+      bin: kubectl-kxdiff.exe
+    - selector:
+        matchLabels:
+          os: windows
+          arch: arm64
+      uri: https://github.com/fevzisahinler/kxdiff/releases/download/v1.0.0/kxdiff_windows_arm64.zip
+      sha256: ef6f8a15659e8cdc6c559ddc330525f329604b3f82cb8d8a08b4b18c0ed64fa0
+      bin: kubectl-kxdiff.exe


### PR DESCRIPTION
Adds kxdiff — a read-only diff between two Kubernetes environments (context + namespace), as a kubectl plugin.

Homepage: https://github.com/fevzisahinler/kxdiff
Release: v1.0.0

Validated locally with `kubectl krew install --manifest=plugins/kxdiff.yaml` — installs and runs as `kubectl kxdiff`.