### PR TITLE
feat: add kubectl-rename plugin v0.1.0

### DIFF
--- a/plugins/rename.yaml
+++ b/plugins/rename.yaml
@@ -1,0 +1,90 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: rename
+spec:
+  version: v0.1.0
+  homepage: https://github.com/akashbhujbalwebsite/kubectl-rename
+  shortDescription: Safely rename ConfigMaps and Secrets
+  description: |
+    kubectl rename safely renames Kubernetes ConfigMaps and Secrets
+    by creating a copy under the new name and deleting the original.
+
+    Features:
+      - Pre-flight permission check (get+create+delete) before touching anything
+      - Dependency scanner: shows which Pods and Deployments reference
+        the resource before rename, so you know what to update
+      - --dry-run mode: preview the rename plan without making changes
+      - Automatic partial-failure recovery: re-running detects an interrupted
+        rename and completes it safely
+      - Confirmation prompt (bypass with -y for scripts/CI)
+      - Clear error messages if permissions are missing
+  caveats: |
+    Only ConfigMaps and Secrets are supported in v0.1.
+    References are scanned within the specified namespace only.
+    The rename is not atomic — there is a brief window where both
+    the old and new resource exist simultaneously. Re-running the
+    command detects this and completes the rename automatically.
+    Resources referencing the renamed ConfigMap/Secret (Pods, Deployments)
+    are detected but not automatically updated — update them manually.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/akashbhujbalwebsite/kubectl-rename/releases/download/v0.1.0/kubectl-rename_linux_amd64.tar.gz
+    sha256: "7eccfdbb30d2f142b6b1410e3d4e56ed0598657bbcb2a4e76bd68253511ebd3d"
+    bin: kubectl-rename
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/akashbhujbalwebsite/kubectl-rename/releases/download/v0.1.0/kubectl-rename_linux_arm64.tar.gz
+    sha256: "6667c3840817d95b6c3484a0753348dbd91d758ee8188d94d73fa37bcfcff04e"
+    bin: kubectl-rename
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/akashbhujbalwebsite/kubectl-rename/releases/download/v0.1.0/kubectl-rename_darwin_amd64.tar.gz
+    sha256: "d1512122cb43b9bba5a5b987387d02f845b879e7c15046a2604d45951fb712bc"
+    bin: kubectl-rename
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/akashbhujbalwebsite/kubectl-rename/releases/download/v0.1.0/kubectl-rename_darwin_arm64.tar.gz
+    sha256: "6e518954fd43bed6f3fefb854f9d0a079532103a9c92b714c8ee8ff53db29760"
+    bin: kubectl-rename
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/akashbhujbalwebsite/kubectl-rename/releases/download/v0.1.0/kubectl-rename_windows_amd64.zip
+    sha256: "f983872ff979ccdb3d865c2aab8fd46b5ecf9c65041b9546ca66cba24e59b527"
+    bin: kubectl-rename.exe
+    files:
+    - from: "*"
+      to: "."
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/akashbhujbalwebsite/kubectl-rename/releases/download/v0.1.0/kubectl-rename_windows_arm64.zip
+    sha256: "2f84bdda2ffe53206334fe0a3a04498e4a3b2c96e7bc96c5a3473307aff12439"
+    bin: kubectl-rename.exe
+    files:
+    - from: "*"
+      to: "."

--- a/plugins/rename.yaml
+++ b/plugins/rename.yaml
@@ -7,15 +7,16 @@ spec:
   homepage: https://github.com/akashbhujbalwebsite/kubectl-rename
   shortDescription: Safely rename ConfigMaps and Secrets
   description: |
-    kubectl rename safely renames Kubernetes ConfigMaps and Secrets
-    by creating a copy under the new name and deleting the original.
+    Renames Kubernetes ConfigMaps and Secrets by creating a copy under
+    the new name and deleting the original.
 
     Features:
-      - Pre-flight permission check (get+create+delete) before touching anything
+      - Pre-flight permission check (get+create+delete) before making
+        any changes
       - Dependency scanner: shows which Pods and Deployments reference
         the resource before rename, so you know what to update
       - --dry-run mode: preview the rename plan without making changes
-      - Automatic partial-failure recovery: re-running detects an interrupted
+      - Partial-failure recovery: re-running detects an interrupted
         rename and completes it safely
       - Confirmation prompt (bypass with -y for scripts/CI)
       - Clear error messages if permissions are missing
@@ -25,8 +26,9 @@ spec:
     The rename is not atomic — there is a brief window where both
     the old and new resource exist simultaneously. Re-running the
     command detects this and completes the rename automatically.
-    Resources referencing the renamed ConfigMap/Secret (Pods, Deployments)
-    are detected but not automatically updated — update them manually.
+    Resources referencing the renamed ConfigMap/Secret (Pods,
+    Deployments) are detected but not automatically updated — update
+    them manually.
   platforms:
   - selector:
       matchLabels:

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.1.0
   homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
-  shortDescription: Show your identity and RBAC permissions in the cluster
+  shortDescription: Show who you are and what you can do
   description: |
     kubectl whoami-enhanced shows who you are and what you can do
     in a Kubernetes cluster in one command.

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: whoami-enhanced
 spec:
-  version: v0.1.0
+  version: v0.1.1
   homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
   shortDescription: Show who you are and what you can do
   description: |
@@ -29,8 +29,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_amd64.tar.gz
-      sha256: "853c11df1633f1b6a3a3d8dc6ff99a7dde3eaa037ba449f2f2577c78c7e44276"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_linux_amd64.tar.gz
+      sha256: "8c3e1efe2278d4f76fd3d5f6ac0f2ed9a4f8c8fadee453e4412ad45f9254781b"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -40,8 +40,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_arm64.tar.gz
-      sha256: "74cf864803151fd7557f0d8bfa00c395d78db0dafa79242c410acc09057a0144"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_linux_arm64.tar.gz
+      sha256: "f8618433b2bbe9fae67963f0cb369629b1b5f0528c4d5dea0a3e084f4b0b0879"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -51,8 +51,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_amd64.tar.gz
-      sha256: "3866f32821e0eff407c417a914584170037af4b1c07eee5a4e9bcf4170eaff27"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_darwin_amd64.tar.gz
+      sha256: "f1d1e8e27c53b4dca51a57d9ff826daf53d67760786ae1791971f6368e268663"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -62,8 +62,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_arm64.tar.gz
-      sha256: "85866b3d0918922e7a36fa9c9bc954582e78aee0c9e9889c874aa56bf3656e94"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_darwin_arm64.tar.gz
+      sha256: "cd7e84168106fe6297e109609ab3cdf038b2cae66c4ad4ba67fffcb1e4a62ddf"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -73,8 +73,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_windows_amd64.zip
-      sha256: "f880ca644eb6a81a6a1d7c8ece40ffe22b71ea8133f1c957c9e5f6227d70dd8f"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_windows_amd64.zip
+      sha256: "1b8f98ab80cc207f8724740ade9756ef101b527dc4fc417094a8349dfef26f5d"
       bin: kubectl-whoami-enhanced.exe
       files:
         - from: "*"

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -1,0 +1,81 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: whoami-enhanced
+spec:
+  version: v0.1.0
+  homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
+  shortDescription: Show your identity and RBAC permissions in the cluster
+  description: |
+    kubectl whoami-enhanced shows who you are and what you can do
+    in a Kubernetes cluster in one command.
+
+    It displays:
+      - Current context, user, and groups
+      - Token expiry time (parsed from JWT)
+      - Permission matrix (get/list/delete/exec/create) per resource
+      - REASON column: which Role/RoleBinding grants each permission
+      - Supports --all-namespaces and --output-json flags
+
+    Useful for debugging RBAC issues without needing to ask
+    the cluster admin "why can't I delete this pod?"
+  caveats: |
+    Groups are only shown with token-based auth (OIDC/ServiceAccount).
+    Certificate-based auth will show a note instead of groups.
+    The REASON column requires list access to rolebindings/clusterrolebindings;
+    falls back gracefully if that access is not available.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_amd64.tar.gz
+      sha256: "853c11df1633f1b6a3a3d8dc6ff99a7dde3eaa037ba449f2f2577c78c7e44276"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_arm64.tar.gz
+      sha256: "74cf864803151fd7557f0d8bfa00c395d78db0dafa79242c410acc09057a0144"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_amd64.tar.gz
+      sha256: "3866f32821e0eff407c417a914584170037af4b1c07eee5a4e9bcf4170eaff27"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_arm64.tar.gz
+      sha256: "85866b3d0918922e7a36fa9c9bc954582e78aee0c9e9889c874aa56bf3656e94"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_windows_amd64.zip
+      sha256: "f880ca644eb6a81a6a1d7c8ece40ffe22b71ea8133f1c957c9e5f6227d70dd8f"
+      bin: kubectl-whoami-enhanced.exe
+      files:
+        - from: "*"
+          to: "."


### PR DESCRIPTION
## New Plugin: `kubectl rename`

### What does it do?

`kubectl rename` safely renames Kubernetes ConfigMaps and Secrets by creating a copy under the new name and deleting the original.

### Why is it useful?

Kubernetes has no built-in way to rename a ConfigMap or Secret. Users currently have to manually `kubectl get`, edit the YAML, `kubectl apply`, then `kubectl delete` — and risk breaking dependent workloads if they forget to check what references the resource.

This plugin makes that workflow safe:
- **Pre-flight permission check** before touching anything
- **Dependency scanner** — shows which Pods and Deployments reference the resource
- **`--dry-run` mode** — preview the plan without making changes
- **Partial-failure recovery** — re-running detects an interrupted rename and completes it
- **Confirmation prompt** (bypass with `-y` for scripts/CI)

### Usage

```bash
# Rename a ConfigMap
kubectl rename configmap old-name new-name -n my-namespace

# Rename a Secret
kubectl rename secret old-secret new-secret -n my-namespace

# Dry run — preview without changes
kubectl rename configmap old-name new-name --dry-run

# Skip confirmation prompt
kubectl rename configmap old-name new-name -y
```

### Plugin details

| Field | Value |
|-------|-------|
| Repository | https://github.com/akashbhujbalwebsite/kubectl-rename |
| Version | v0.1.0 |
| License | MIT |
| Platforms | linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64, windows/arm64 |

### Checklist
- [x] Plugin manifest added at `plugins/rename.yaml`
- [x] All platform binaries published in GitHub release v0.1.0
- [x] SHA256 checksums verified from `checksums.txt`
- [x] `--dry-run` supported
- [x] README with usage examples in repo
- [x] MIT License