### PR TITLE
feat: add safe-rename plugin v0.2.0

### DIFF
--- a/plugins/safe-rename.yaml
+++ b/plugins/safe-rename.yaml
@@ -1,0 +1,93 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: safe-rename
+spec:
+  version: v0.2.0
+  homepage: https://github.com/akashbhujbalwebsite/kubectl-safe-rename
+  shortDescription: Safely rename ConfigMaps and Secrets
+  description: |
+    kubectl safe-rename renames ConfigMaps and Secrets. These resources are
+    stateless data stores whose names carry no runtime identity — Kubernetes
+    imposes no live binding on their names at the API level. Other resources
+    such as Pods, Deployments, Services, ServiceAccounts, and PVCs are
+    intentionally not supported: their names are tied to DNS, pod identity,
+    or runtime bindings where a create+delete cycle would break running
+    workloads.
+
+    Features:
+      - Pre-flight permission check (get+create+delete) before touching anything
+      - Dependency scanner: shows which Pods and Deployments reference
+        the resource before rename, so you know what to update
+      - --dry-run mode: preview the rename plan without making changes
+      - Automatic partial-failure recovery: if interrupted after CREATE but
+        before DELETE, re-running detects this and completes the delete
+      - Confirmation prompt (bypass with -y for scripts/CI)
+      - Clear error messages if permissions are missing
+
+    Unlike running export+apply+delete manually, kubectl rename checks
+    all required permissions upfront, warns about references, and
+    recovers automatically from interrupted renames.
+  caveats: |
+    Only ConfigMaps and Secrets are supported in v0.1.
+    References are scanned within the specified namespace only.
+    The rename is not atomic — there is a brief window where both
+    the old and new resource exist simultaneously. Re-running the
+    command detects this and completes the rename automatically.
+    Resources referencing the renamed ConfigMap/Secret (Pods, Deployments)
+    are detected but not automatically updated — update them manually.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-safe-rename/releases/download/v0.2.0/kubectl-safe-rename_linux_amd64.tar.gz
+      sha256: "4f621fc020498683b0e1016c7af230f7106f3352174c55791fb7a6199eaccab1"
+      bin: kubectl-safe-rename
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-safe-rename/releases/download/v0.2.0/kubectl-safe-rename_linux_arm64.tar.gz
+      sha256: "9395d7b860f24aac626ac0dc9ac562bf44e61eb974dd746e3bb90f395c842780"
+      bin: kubectl-safe-rename
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-safe-rename/releases/download/v0.2.0/kubectl-safe-rename_darwin_amd64.tar.gz
+      sha256: "b2d677678cbed20ff464f59e31879a1c292f0d9c28d0968fe4acd97d1290f38a"
+      bin: kubectl-safe-rename
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-safe-rename/releases/download/v0.2.0/kubectl-safe-rename_darwin_arm64.tar.gz
+      sha256: "a2faf20591b9c042336810fbd4c97146cb24b75519c5fa2f414bad61019870b2"
+      bin: kubectl-safe-rename
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-safe-rename/releases/download/v0.2.0/kubectl-safe-rename_windows_amd64.zip
+      sha256: "e457f47db0cdb50848ecdb7ca59a20568f6b6a242c5569e21b2aabe0c0613302"
+      bin: kubectl-safe-rename.exe
+      files:
+        - from: "*"
+          to: "."

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   version: v0.1.0
   homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
-  shortDescription: Show your identity and RBAC permissions in the cluster
+  shortDescription: Show who you are and what you can do
   description: |
     kubectl whoami-enhanced shows who you are and what you can do
     in a Kubernetes cluster in one command.

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: whoami-enhanced
 spec:
-  version: v0.1.0
+  version: v0.1.1
   homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
   shortDescription: Show who you are and what you can do
   description: |
@@ -29,8 +29,8 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_amd64.tar.gz
-      sha256: "853c11df1633f1b6a3a3d8dc6ff99a7dde3eaa037ba449f2f2577c78c7e44276"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_linux_amd64.tar.gz
+      sha256: "8c3e1efe2278d4f76fd3d5f6ac0f2ed9a4f8c8fadee453e4412ad45f9254781b"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -40,8 +40,8 @@ spec:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_arm64.tar.gz
-      sha256: "74cf864803151fd7557f0d8bfa00c395d78db0dafa79242c410acc09057a0144"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_linux_arm64.tar.gz
+      sha256: "f8618433b2bbe9fae67963f0cb369629b1b5f0528c4d5dea0a3e084f4b0b0879"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -51,8 +51,8 @@ spec:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_amd64.tar.gz
-      sha256: "3866f32821e0eff407c417a914584170037af4b1c07eee5a4e9bcf4170eaff27"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_darwin_amd64.tar.gz
+      sha256: "f1d1e8e27c53b4dca51a57d9ff826daf53d67760786ae1791971f6368e268663"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -62,8 +62,8 @@ spec:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_arm64.tar.gz
-      sha256: "85866b3d0918922e7a36fa9c9bc954582e78aee0c9e9889c874aa56bf3656e94"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_darwin_arm64.tar.gz
+      sha256: "cd7e84168106fe6297e109609ab3cdf038b2cae66c4ad4ba67fffcb1e4a62ddf"
       bin: kubectl-whoami-enhanced
       files:
         - from: "*"
@@ -73,8 +73,8 @@ spec:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_windows_amd64.zip
-      sha256: "f880ca644eb6a81a6a1d7c8ece40ffe22b71ea8133f1c957c9e5f6227d70dd8f"
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.1/kubectl-whoami-enhanced_windows_amd64.zip
+      sha256: "1b8f98ab80cc207f8724740ade9756ef101b527dc4fc417094a8349dfef26f5d"
       bin: kubectl-whoami-enhanced.exe
       files:
         - from: "*"

--- a/plugins/whoami-enhanced.yaml
+++ b/plugins/whoami-enhanced.yaml
@@ -1,0 +1,81 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: whoami-enhanced
+spec:
+  version: v0.1.0
+  homepage: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced
+  shortDescription: Show your identity and RBAC permissions in the cluster
+  description: |
+    kubectl whoami-enhanced shows who you are and what you can do
+    in a Kubernetes cluster in one command.
+
+    It displays:
+      - Current context, user, and groups
+      - Token expiry time (parsed from JWT)
+      - Permission matrix (get/list/delete/exec/create) per resource
+      - REASON column: which Role/RoleBinding grants each permission
+      - Supports --all-namespaces and --output-json flags
+
+    Useful for debugging RBAC issues without needing to ask
+    the cluster admin "why can't I delete this pod?"
+  caveats: |
+    Groups are only shown with token-based auth (OIDC/ServiceAccount).
+    Certificate-based auth will show a note instead of groups.
+    The REASON column requires list access to rolebindings/clusterrolebindings;
+    falls back gracefully if that access is not available.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_amd64.tar.gz
+      sha256: "853c11df1633f1b6a3a3d8dc6ff99a7dde3eaa037ba449f2f2577c78c7e44276"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_linux_arm64.tar.gz
+      sha256: "74cf864803151fd7557f0d8bfa00c395d78db0dafa79242c410acc09057a0144"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_amd64.tar.gz
+      sha256: "3866f32821e0eff407c417a914584170037af4b1c07eee5a4e9bcf4170eaff27"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_darwin_arm64.tar.gz
+      sha256: "85866b3d0918922e7a36fa9c9bc954582e78aee0c9e9889c874aa56bf3656e94"
+      bin: kubectl-whoami-enhanced
+      files:
+        - from: "*"
+          to: "."
+
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/akashbhujbalwebsite/kubectl-whoami-enhanced/releases/download/v0.1.0/kubectl-whoami-enhanced_windows_amd64.zip
+      sha256: "f880ca644eb6a81a6a1d7c8ece40ffe22b71ea8133f1c957c9e5f6227d70dd8f"
+      bin: kubectl-whoami-enhanced.exe
+      files:
+        - from: "*"
+          to: "."


### PR DESCRIPTION
## New Plugin: `kubectl safe-rename`

### What it does

`kubectl safe-rename` renames Kubernetes ConfigMaps and Secrets — the only resources where renaming is safe. These resources are stateless data stores whose names carry no runtime identity; Kubernetes imposes no live binding on their names at the API level.

Other resources (Pods, Deployments, Services, ServiceAccounts, PVCs) are intentionally not supported — their names are tied to DNS, pod identity, or runtime bindings where a create+delete cycle would break running workloads.

### Why it is useful

Kubernetes has no built-in way to rename a ConfigMap or Secret. Users currently have to manually `kubectl get`, edit the YAML, `kubectl apply`, then `kubectl delete` — with no safety checks, no dependency scan, and no recovery if interrupted halfway.

### Features

- **Pre-flight permission check** — verifies get+create+delete before touching anything
- **Dependency scanner** — shows which Pods and Deployments reference the resource
- **`--dry-run` mode** — preview the full rename plan without making changes
- **Partial-failure recovery** — re-running detects an interrupted rename and completes it
- **Confirmation prompt** — bypass with `-y` for scripts/CI

### Usage

```bash
kubectl safe-rename configmap old-name new-name -n my-namespace
kubectl safe-rename secret old-secret new-secret -n my-namespace
kubectl safe-rename configmap old-name new-name -n my-namespace --dry-run
```

### Note on previous submission

This supersedes PR #5934 (`kubectl rename`) which was closed. The plugin has been renamed to `safe-rename` to make the intentional resource scope explicit.

Homepage: https://github.com/akashbhujbalwebsite/kubectl-safe-rename