### PR TITLE
Update atlas to v1.5.0

### DIFF
--- a/plugins/atlas.yaml
+++ b/plugins/atlas.yaml
@@ -12,7 +12,7 @@ kind: Plugin
 metadata:
   name: atlas
 spec:
-  version: v1.4.0
+  version: v1.5.0
   homepage: https://github.com/lithastra/kubeatlas
   shortDescription: Visualize Kubernetes resource dependencies
   description: |
@@ -45,31 +45,31 @@ spec:
   platforms:
     - selector:
         matchLabels: { os: linux, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_linux_amd64.tar.gz
-      sha256: "4968767c96681d6e27965ed27ddac39f2ceb9e7102cd90b4b6e0153c6d77f740"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_linux_amd64.tar.gz
+      sha256: "28223c407d8691419d02350e8df0a0278e82664416d8232750d4d1292b5382ea"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: linux, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_linux_arm64.tar.gz
-      sha256: "7b691b26afd4a31b9039f3666458b3e1d1da71009551dbfc916c5a3d2ef27f91"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_linux_arm64.tar.gz
+      sha256: "0fe4b2b356f6601e1c4a7aa75505ac8f963be3f5ad69935e4bca4f6b14ecb230"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_darwin_amd64.tar.gz
-      sha256: "2e688175cb56034b99a2d25c9cbb2db81e691eec406177c1df219d7035fa6fdb"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_darwin_amd64.tar.gz
+      sha256: "c12cc96922de521b2fb832a20b58e01ac3148bcb4fb47e59fd2a11515a91b75f"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_darwin_arm64.tar.gz
-      sha256: "b06708cf1b649c6cb036aea2a4da2db8985c65234130aa8c40d1f1ff7d074d3f"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_darwin_arm64.tar.gz
+      sha256: "19e6e10052f6120af2349b05f3c690058b5c616c74cba55c33403e3c1a0e7e0e"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: windows, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_windows_amd64.tar.gz
-      sha256: "632274c656069a865c5e8276f19a7e0279f7d759125816b3cbd13c31bcc61e64"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_windows_amd64.tar.gz
+      sha256: "7cefae3789a7e3c73d0750c2366aa10ba623885893f27caf0933d35f7190474f"
       bin: kubectl-atlas.exe
     - selector:
         matchLabels: { os: windows, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.4.0/kubectl-atlas_1.4.0_windows_arm64.tar.gz
-      sha256: "324e7d60323e024a75e62cc75b6d4beb2181ccd3d3fbb73fde0b2c574d6d8a80"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_windows_arm64.tar.gz
+      sha256: "65b2c71e4af678fcc8a2c8aeea1e3a66f293187794f19bcb2da8d434a643a7a6"
       bin: kubectl-atlas.exe


### PR DESCRIPTION
Bumps the `atlas` plugin (`kubectl-atlas`) from **v1.4.0** to **v1.5.0**.

- Version: `v1.4.0` → `v1.5.0`
- Download URIs point to the published GitHub release: https://github.com/lithastra/kubeatlas/releases/tag/v1.5.0
- `sha256` checksums were computed from the published `kubectl-atlas_1.5.0_<platform>.tar.gz` archives (all six platforms: linux/darwin/windows × amd64/arm64).

Only the version, download URIs, and checksums changed; the rest of the manifest is unchanged from the accepted v1.4.0 entry.
