### PR TITLE
Add node-debug-shell plugin

### DIFF
--- a/plugins/node-debug-shell.yaml
+++ b/plugins/node-debug-shell.yaml
@@ -1,0 +1,22 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: node-debug-shell
+
+spec:
+  version: v0.2.0
+  homepage: https://github.com/ragatgen/node-debug-shell
+  shortDescription: Interactive node debug shell
+  description: |
+    node-debug-shell provides an interactive workflow for
+    troubleshooting Kubernetes nodes.
+    Select a node, choose a debug image, and launch a
+    kubectl debug session directly from the command line.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/ragatgen/node-debug-shell/releases/download/v0.2.0/kubectl-node-debug-shell_v0.2.0_linux_amd64.tar.gz
+      sha256: 285df1a1d18b94789a0715a1e19e175136c9617117b58bc8a137126d4f412a2e
+      bin: kubectl-node-debug-shell


### PR DESCRIPTION
<!--

This PR adds the `node-debug-shell` kubectl plugin.

The plugin provides an interactive workflow for Kubernetes node troubleshooting by:

- Listing cluster nodes
- Allowing interactive node selection
- Offering multiple debug image options (Wolfi, Netshoot, Azure Linux BusyBox, or a custom image)
- Launching a `kubectl debug` session on the selected node

The plugin has been tested locally using:

```bash
kubectl krew install --manifest=plugins/node-debug-shell.yaml
kubectl node-debug-shell --help
kubectl node-debug-shell --version
kubectl node-debug-shell

-->
