### PR TITLE
Add konfuse plugin

### DIFF
--- a/plugins/konfuse.yaml
+++ b/plugins/konfuse.yaml
@@ -1,0 +1,48 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: konfuse
+spec:
+  version: v0.4.1
+  homepage: https://github.com/chameerar/konfuse
+  shortDescription: Merge and manage kubeconfig files
+  description: |
+    konfuse merges kubeconfig files into your existing config in one
+    command, with rename-on-import so context, cluster, and user names
+    never collide, and an automatic timestamped backup before every write.
+
+    It also lists entries, switches the active context, and cleanly deletes
+    a context (removing its orphaned cluster and user), with structured
+    --json output and meaningful exit codes for scripting and CI.
+  caveats: |
+    konfuse writes to ~/.kube/config (or the path given via --kubeconfig) and
+    always creates a timestamped backup before modifying it.
+  platforms:
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/chameerar/konfuse/releases/download/v0.4.1/konfuse-macos-amd64.tar.gz
+      sha256: aae4f2a690af9ce8d13f03d44ac2707baafbac2e06d3ff92c9cfe38b95d506f2
+      bin: konfuse
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/chameerar/konfuse/releases/download/v0.4.1/konfuse-macos-arm64.tar.gz
+      sha256: b065c98355e86db565f187ec6db80f4668809920f8c620491a17ffb5e646b364
+      bin: konfuse
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/chameerar/konfuse/releases/download/v0.4.1/konfuse-linux-amd64.tar.gz
+      sha256: e046061c00346058a2768ee0070783645c2714a04cc26b83557cf19e7b586d49
+      bin: konfuse
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/chameerar/konfuse/releases/download/v0.4.1/konfuse-linux-arm64.tar.gz
+      sha256: 0350fc37c756df19016ff09d9887a4be866cfffce7b39a80c7fc5c9f6636c951
+      bin: konfuse


### PR DESCRIPTION
This PR adds `konfuse`, a single-binary Go CLI for kubeconfig management: merge with rename-on-import, automatic timestamped backup, plus list / switch-context / delete-context.

- Repo: https://github.com/chameerar/konfuse (MIT)
- Release: v0.4.1, with `.tar.gz` archives (binary + LICENSE) for darwin/linux × amd64/arm64
- Validated locally with `kubectl krew install --manifest --archive`; `kubectl konfuse --version` → `konfuse v0.4.1`
- All 4 platform archive SHA256s verified against the manifest

## How konfuse differs from existing plugins

konfuse's niche is **non-interactive, collision-safe kubeconfig merging** — the combination of rename-on-import and automatic backup, which none of the overlapping plugins provide together:

- **konfig** — wraps `kubectl config view` for merge/split/import. Because it flattens without renaming, importing a file whose context/cluster/user names collide with existing ones overwrites them. konfuse renames the incoming context/cluster/user on import (`--rename-context` / `--rename-cluster` / `--rename-user`) so collisions can't clobber existing entries, and rewrites the internal cross-references.
- **config-import** — interactive, fzf-driven merge. konfuse is fully non-interactive and scriptable (flags only, `--json`, meaningful exit codes), aimed at CI and agent use.
- **kc** — interactive CRUD TUI. Same distinction: konfuse is non-interactive/scriptable.
- **ctx** (kubectx) — context switching only, no merge. konfuse's `use` overlaps a little here, but merging is the core feature.

The distinguishing combination is **merge + rename-on-import (collision-safe) + automatic timestamped backup before every write**, with structured `--json` output and exit codes for scripting/CI.

## About the name

The name `konfuse` is intended to read descriptively, not just as a "confuse" pun:

- **conf + fuse** — *fusing* configurations together (the core merge feature)
- **conf + use** — easy *use* of configurations (list, switch, clean up)

The leading `k` is deliberate: it distinguishes the tool from the plain-English word "confuse" while signalling the Kubernetes relation. The short description ("Merge and manage kubeconfig files") carries the plain-language "what it does" alongside the name.

## Checklist
- [x] Read the plugin naming guide and best practices
- [x] Open source with an OSI license (MIT); LICENSE bundled in the archive
- [x] Semver release tag (`v0.4.1`)
- [x] Tested locally with `kubectl krew install --manifest`