### PR TITLE
Add new plugin: idx

### DIFF
--- a/plugins/idx.yaml
+++ b/plugins/idx.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: idx
 spec:
-  version: v0.0.7
+  version: v0.0.8
   homepage: https://github.com/jzills/kx
   shortDescription: Select resources by index instead of typing names
   description: |
@@ -18,19 +18,19 @@ spec:
     Index history is stored in ~/.kx/.
   platforms:
   - selector: {matchLabels: {os: linux, arch: amd64}}
-    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_linux_amd64.tar.gz
-    sha256: 9a66ba659cdf1c2ecf864a64bc15c83ea72749bb0428ba303563049cb89bf42a
+    uri: https://github.com/jzills/kx/releases/download/v0.0.8/kx_v0.0.8_linux_amd64.tar.gz
+    sha256: 6fce4b8cd544e6d59cb2cdd65b8da57727779cee7926a89cd33b85b6b0f690ae
     bin: kx/kx
   - selector: {matchLabels: {os: linux, arch: arm64}}
-    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_linux_arm64.tar.gz
-    sha256: 0e586cd21e9e69ecb19cddea8aa985e2f92363c8552a294831d62eb668abca55
+    uri: https://github.com/jzills/kx/releases/download/v0.0.8/kx_v0.0.8_linux_arm64.tar.gz
+    sha256: 44bf7a7fd6201d5026592b6f50dbb1127c1294802c0a13833a83025d14daeebe
     bin: kx/kx
   - selector: {matchLabels: {os: darwin, arch: amd64}}
-    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_darwin_amd64.tar.gz
-    sha256: 760ed7e47adb35ce9e9504b36cc365e0c3fbbb050dbafa5bcbbc4ef7c23be3b1
+    uri: https://github.com/jzills/kx/releases/download/v0.0.8/kx_v0.0.8_darwin_amd64.tar.gz
+    sha256: d5b4b84b69eaebb96a765f824dae05f86fed6fbe0b9057761aa058ee070940b0
     bin: kx/kx
   - selector: {matchLabels: {os: darwin, arch: arm64}}
-    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_darwin_arm64.tar.gz
-    sha256: cebc4661f73cbb197eaa39d5f5c168f0543faf7f227ad7ea996e98a1ac4a226e
+    uri: https://github.com/jzills/kx/releases/download/v0.0.8/kx_v0.0.8_darwin_arm64.tar.gz
+    sha256: e6733d31193ccaae677af0bd9465ef59bfe09ac0f529b1dfc3ee1bbab7fc47b8
     bin: kx/kx
 

--- a/plugins/idx.yaml
+++ b/plugins/idx.yaml
@@ -1,22 +1,21 @@
 apiVersion: krew.googlecontainertools.github.com/v1alpha2
 kind: Plugin
 metadata:
-  name: kx
+  name: idx
 spec:
   version: v0.0.7
   homepage: https://github.com/jzills/kx
   shortDescription: Select resources by index instead of typing names
   description: |
-    kx wraps kubectl with index-based resource selection. List resources
-    once with "kubectl kx get pods" to assign numbered indexes, then
+    idx wraps kubectl with index-based resource selection. List resources
+    once with "kubectl idx get pods" to assign numbered indexes, then
     reference any resource by number in follow-up commands: describe,
     logs, exec, delete, edit, scale, rollout, port-forward, events,
     yaml, tree, and more. A navigable history of listings keeps indexes
     resolving as you move between resource kinds and namespaces.
+    Also distributed as "kx" on PyPI (https://pypi.org/project/kx-cli/).
   caveats: |
-    kx shells out to kubectl and uses your current kubeconfig context.
-    Index history is stored in ~/.kx/. For the short form, add:
-      alias kx="kubectl kx"
+    Index history is stored in ~/.kx/.
   platforms:
   - selector: {matchLabels: {os: linux, arch: amd64}}
     uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_linux_amd64.tar.gz

--- a/plugins/kx.yaml
+++ b/plugins/kx.yaml
@@ -1,0 +1,37 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: kx
+spec:
+  version: v0.0.7
+  homepage: https://github.com/jzills/kx
+  shortDescription: Select resources by index instead of typing names
+  description: |
+    kx wraps kubectl with index-based resource selection. List resources
+    once with "kubectl kx get pods" to assign numbered indexes, then
+    reference any resource by number in follow-up commands: describe,
+    logs, exec, delete, edit, scale, rollout, port-forward, events,
+    yaml, tree, and more. A navigable history of listings keeps indexes
+    resolving as you move between resource kinds and namespaces.
+  caveats: |
+    kx shells out to kubectl and uses your current kubeconfig context.
+    Index history is stored in ~/.kx/. For the short form, add:
+      alias kx="kubectl kx"
+  platforms:
+  - selector: {matchLabels: {os: linux, arch: amd64}}
+    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_linux_amd64.tar.gz
+    sha256: 9a66ba659cdf1c2ecf864a64bc15c83ea72749bb0428ba303563049cb89bf42a
+    bin: kx/kx
+  - selector: {matchLabels: {os: linux, arch: arm64}}
+    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_linux_arm64.tar.gz
+    sha256: 0e586cd21e9e69ecb19cddea8aa985e2f92363c8552a294831d62eb668abca55
+    bin: kx/kx
+  - selector: {matchLabels: {os: darwin, arch: amd64}}
+    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_darwin_amd64.tar.gz
+    sha256: 760ed7e47adb35ce9e9504b36cc365e0c3fbbb050dbafa5bcbbc4ef7c23be3b1
+    bin: kx/kx
+  - selector: {matchLabels: {os: darwin, arch: arm64}}
+    uri: https://github.com/jzills/kx/releases/download/v0.0.7/kx_v0.0.7_darwin_arm64.tar.gz
+    sha256: cebc4661f73cbb197eaa39d5f5c168f0543faf7f227ad7ea996e98a1ac4a226e
+    bin: kx/kx
+


### PR DESCRIPTION
Adds **kx** — a kubectl wrapper with index-based resource selection.

Run `kubectl kx get pods` once to list resources with numbered indexes, then reference any resource by number in follow-up commands (`describe`, `logs`, `exec`, `delete`, `edit`, `scale`, `rollout`, `port-forward`, `events`, `yaml`, `tree`, …). A navigable history of listings keeps indexes resolving across resource kinds and namespaces.

- Homepage: https://github.com/jzills/kx
- Platforms: linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 (self-contained PyInstaller builds; no runtime dependencies beyond kubectl itself)
- Archives are built and checksummed by CI on each release ([release workflow](https://github.com/jzills/kx/blob/main/.github/workflows/release.yml)); future versions will be submitted via krew-release-bot.
- Verified locally: manifest sha256s match the release's SHA256SUMS, and the `bin` path (`kx/kx`) extracts and runs (`kx 0.0.7`).

About the name: `kx` is short for "kubectl, indexed" — the plugin's whole purpose is minimizing keystrokes, so a compact name mirrors existing short plugins like `ctx` and `ns`.