### PR TITLE
Update vigil to v1.5.0

### DIFF
--- a/plugins/vigil.yaml
+++ b/plugins/vigil.yaml
@@ -3,48 +3,52 @@ kind: Plugin
 metadata:
   name: vigil
 spec:
-  version: v0.5.0
+  version: v1.5.0
   homepage: https://github.com/stribog-cloud/KubeVigil
   shortDescription: Scan clusters for misconfigurations
   description: |
     KubeVigil scans Kubernetes clusters and YAML manifests for security
-    misconfigurations. It runs 110 security checks across 12 categories,
+    misconfigurations. It runs 150 security checks across 12 categories,
     maps findings to compliance frameworks (CIS, MITRE ATT&CK, NSA/CISA),
     and outputs reports in 8 formats. Includes auto-remediation with a
     five-ring safety model.
+  caveats: |
+    Scanning a live cluster uses your current kubeconfig context. Run
+    `kubectl vigil scan --help` for manifest-only (offline) usage.
   platforms:
-    - selector:
-        matchLabels:
-          os: linux
-          arch: amd64
-      uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v0.5.0/kubevigil_0.5.0_linux_amd64.tar.gz
-      sha256: e704fa6e82637c0d02fd57d32791b242567b7219f1f6db10657763924d97a55e
-      bin: kubevigil
-    - selector:
-        matchLabels:
-          os: linux
-          arch: arm64
-      uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v0.5.0/kubevigil_0.5.0_linux_arm64.tar.gz
-      sha256: 2d6bc7dbc9ca8d692546f9515a98cf18030cf8908e27f133e77946c36f08d537
-      bin: kubevigil
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: amd64
-      uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v0.5.0/kubevigil_0.5.0_darwin_amd64.tar.gz
-      sha256: f4486b27a94a0002960fd5dcfa6c88912cf8dea5a539b0635f641064d469755d
-      bin: kubevigil
-    - selector:
-        matchLabels:
-          os: darwin
-          arch: arm64
-      uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v0.5.0/kubevigil_0.5.0_darwin_arm64.tar.gz
-      sha256: ea3027df448e62f4734a8f8b73a4b031ea3841f0344d611dc23eedd7ce7f85bb
-      bin: kubevigil
-    - selector:
-        matchLabels:
-          os: windows
-          arch: amd64
-      uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v0.5.0/kubevigil_0.5.0_windows_amd64.zip
-      sha256: e5c0a7b03633482e7ade59cf2c227b8de547bb13530233985a23b8ee29d3a217
-      bin: kubevigil.exe
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v1.5.0/kubevigil_1.5.0_linux_amd64.tar.gz
+    sha256: 0c36a9dd7c7a913fea8b85d8d19222c8553f254c65712dc2c448f315f4f5f6e2
+    bin: kubevigil
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v1.5.0/kubevigil_1.5.0_linux_arm64.tar.gz
+    sha256: 8bfdd866217dc3bf1bb45d468a6b327a99f585897cce7aeb5f2b036e308d6885
+    bin: kubevigil
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v1.5.0/kubevigil_1.5.0_darwin_amd64.tar.gz
+    sha256: 861c773207c14eb3e8fdeb96532e6de0058ee6d56bbaaf468d0c7d7031be4888
+    bin: kubevigil
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v1.5.0/kubevigil_1.5.0_darwin_arm64.tar.gz
+    sha256: d0635ba3d6acfdd215a4b6afc62ba5b55357aaecaa414175049f48d701d22931
+    bin: kubevigil
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/stribog-cloud/KubeVigil/releases/download/v1.5.0/kubevigil_1.5.0_windows_amd64.zip
+    sha256: 5298d553d64f161406dec336dd66412cf83382377a170887f805549103e13421
+    bin: kubevigil.exe
+


### PR DESCRIPTION
Updates the `vigil` plugin ([KubeVigil](https://github.com/stribog-cloud/KubeVigil)) from **v0.5.0 to v1.5.0**.

The entry has been pinned at v0.5.0 for five months and seven releases — the manifest was only ever updated by hand, once. The repository is now wired to `rajatjindal/krew-release-bot`, so subsequent updates will be opened automatically on release; this one-off PR closes the existing gap.

### Checksums

All five platform `sha256` values were produced by krew-release-bot's own renderer from the published release assets, then **independently verified against `kubevigil_checksums.txt` in the v1.5.0 release** — all five match exactly.

### Other changes

- **Description: 110 → 150 checks.** The tool now ships 150 checks across 12 categories; the published description understated it.
- **`caveats` added**, noting that a live-cluster scan uses the current kubeconfig context and pointing at manifest-only (offline) usage.
- **Platform entries re-indented to two spaces**, matching the output krew-release-bot generates. This is why the diff looks larger than a version bump — doing it now means every future automated PR is a version-only diff rather than a reformat.

No change to the plugin name, homepage, `shortDescription`, binary names, or the set of supported platforms (linux/darwin amd64+arm64, windows amd64).