### PR TITLE
Update atlas to v1.5.1

### DIFF
--- a/plugins/atlas.yaml
+++ b/plugins/atlas.yaml
@@ -12,7 +12,7 @@ kind: Plugin
 metadata:
   name: atlas
 spec:
-  version: v1.5.0
+  version: v1.5.1
   homepage: https://github.com/lithastra/kubeatlas
   shortDescription: Visualize Kubernetes resource dependencies
   description: |
@@ -45,31 +45,31 @@ spec:
   platforms:
     - selector:
         matchLabels: { os: linux, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_linux_amd64.tar.gz
-      sha256: "28223c407d8691419d02350e8df0a0278e82664416d8232750d4d1292b5382ea"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_linux_amd64.tar.gz
+      sha256: "0459a28f025a9371cadf9d4a43b41c48ed7429b8d578639062ea2a9c094a6f5e"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: linux, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_linux_arm64.tar.gz
-      sha256: "0fe4b2b356f6601e1c4a7aa75505ac8f963be3f5ad69935e4bca4f6b14ecb230"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_linux_arm64.tar.gz
+      sha256: "a7151808c54a27ca2d6edc363bf7fb7af829e8def17763133c3644c3b9153164"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_darwin_amd64.tar.gz
-      sha256: "c12cc96922de521b2fb832a20b58e01ac3148bcb4fb47e59fd2a11515a91b75f"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_darwin_amd64.tar.gz
+      sha256: "a361da5cbc0978e5471a572b969642b7e618e84f91949979639dad7b8af47bdf"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_darwin_arm64.tar.gz
-      sha256: "19e6e10052f6120af2349b05f3c690058b5c616c74cba55c33403e3c1a0e7e0e"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_darwin_arm64.tar.gz
+      sha256: "fea7272228157860b5647bbb6858d00482cf3205194bffe5f466572461a1ffbb"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: windows, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_windows_amd64.tar.gz
-      sha256: "7cefae3789a7e3c73d0750c2366aa10ba623885893f27caf0933d35f7190474f"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_windows_amd64.tar.gz
+      sha256: "777ca6f3564415e1ec4c70c93e048acee856870f44c605a372f8a6c21adb2261"
       bin: kubectl-atlas.exe
     - selector:
         matchLabels: { os: windows, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.0/kubectl-atlas_1.5.0_windows_arm64.tar.gz
-      sha256: "65b2c71e4af678fcc8a2c8aeea1e3a66f293187794f19bcb2da8d434a643a7a6"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_windows_arm64.tar.gz
+      sha256: "c567c5175123179ab831b632cde31301b867df4659355255f6f6e1e9da99d613"
       bin: kubectl-atlas.exe


### PR DESCRIPTION
Updates the atlas plugin manifest to the public KubeAtlas v1.5.1 release.

Validation:
- validate-krew-manifest v0.4.5 structural checks passed
- all six platform archives installed successfully through a temporary Krew v0.4.5 environment
- checksums match the published v1.5.1 checksums.txt

Signed-off-by: dev lithastra <dev@lithastra.com>