### PR TITLE
Add new plugin: mole

### DIFF
--- a/plugins/mole.yaml
+++ b/plugins/mole.yaml
@@ -6,7 +6,7 @@ kind: Plugin
 metadata:
   name: mole
 spec:
-  version: v0.3.0
+  version: v0.4.0
   homepage: https://github.com/justin-tahara/kubectl-mole
   shortDescription: Watch workloads settle and explain what broke
   description: |
@@ -26,41 +26,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_linux_amd64.tar.gz
-    sha256: 888266bf04d0b782e2a02e27bbf03f1244987962906ac5e1a5c6f16ebb2a4c29
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_linux_amd64.tar.gz
+    sha256: 91bb2d3591ed176036f40975cb4c40c054ac98bc0eb5a43514a1201073630d51
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_linux_arm64.tar.gz
-    sha256: ed9914014ef7c2ec37cf70a64de79f3dd7e6def734886f1773eb9ecd44a9ca8b
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_linux_arm64.tar.gz
+    sha256: 8ad4f2f39c7f2a55f10e769b0534da10aff254569b06d5638dbfadcca5b18581
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_darwin_amd64.tar.gz
-    sha256: 1e45a8cc87e049bcdaa4e50c4790153207c2d729f4627ac137b722f0e78e1b2c
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_darwin_amd64.tar.gz
+    sha256: 3fa7216b878f90456836cf5ad3834da4cd1f08ee8f46d3c511c2567630ac818d
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_darwin_arm64.tar.gz
-    sha256: e4bb87b5d2960cebd2eb30bad9239946bacdb5f25bce60eb7937098994ea1741
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_darwin_arm64.tar.gz
+    sha256: 8486506f4437bcbfca9c4006c65c86218f2748f90b6006dc1737aab82dfdec4b
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_windows_amd64.zip
-    sha256: 63a8026de033dcf89e33c785eb81991645d35e9e7e545657f8ac99fc1faeaab4
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_windows_amd64.zip
+    sha256: 374e35a4e82d52786fcd1138e0f9f18b3e457749682841de7eb5c90088cd9e96
     bin: kubectl-mole.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_windows_arm64.zip
-    sha256: 665bfcaf440e7c299c3a352820207a03b369618be94dbb54a5a2f1fb10bf27bc
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_windows_arm64.zip
+    sha256: a27833d8b8ec0375af9676f3eb4b353249098a23840dab35a11083708a64bcac
     bin: kubectl-mole.exe

--- a/plugins/mole.yaml
+++ b/plugins/mole.yaml
@@ -6,7 +6,7 @@ kind: Plugin
 metadata:
   name: mole
 spec:
-  version: v0.2.2
+  version: v0.3.0
   homepage: https://github.com/justin-tahara/kubectl-mole
   shortDescription: Watch workloads settle and explain what broke
   description: |
@@ -26,41 +26,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_linux_amd64.tar.gz
-    sha256: 0353dfa08c028c5c28fac14a5c34862ad6a868f7ac8d8d3d72714fecfc6f7e56
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_linux_amd64.tar.gz
+    sha256: 888266bf04d0b782e2a02e27bbf03f1244987962906ac5e1a5c6f16ebb2a4c29
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_linux_arm64.tar.gz
-    sha256: 508308c8c9ac655b4fcf0cb276bbe5eea8fb36c8ee82b407fdca7210f772b9d3
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_linux_arm64.tar.gz
+    sha256: ed9914014ef7c2ec37cf70a64de79f3dd7e6def734886f1773eb9ecd44a9ca8b
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_darwin_amd64.tar.gz
-    sha256: 55d30796ae8128b05b761620f8b18f4307f5e5c9d03e7166f3ff53a5c8f86b37
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_darwin_amd64.tar.gz
+    sha256: 1e45a8cc87e049bcdaa4e50c4790153207c2d729f4627ac137b722f0e78e1b2c
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_darwin_arm64.tar.gz
-    sha256: 906c377e4b1f82498eef30944cb70460f0fa933e3c50c90a53b8cb78d259f8b5
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_darwin_arm64.tar.gz
+    sha256: e4bb87b5d2960cebd2eb30bad9239946bacdb5f25bce60eb7937098994ea1741
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_windows_amd64.zip
-    sha256: a7797c1573a7506e8298d822ad7094ca0d768e0ab760d8fb4ec3530f314896e4
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_windows_amd64.zip
+    sha256: 63a8026de033dcf89e33c785eb81991645d35e9e7e545657f8ac99fc1faeaab4
     bin: kubectl-mole.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_windows_arm64.zip
-    sha256: eb7bc58c52320250fff6d36d55e23001407ed2381498d96f7917ee69e72b0d09
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.3.0/kubectl-mole_v0.3.0_windows_arm64.zip
+    sha256: 665bfcaf440e7c299c3a352820207a03b369618be94dbb54a5a2f1fb10bf27bc
     bin: kubectl-mole.exe

--- a/plugins/mole.yaml
+++ b/plugins/mole.yaml
@@ -6,7 +6,7 @@ kind: Plugin
 metadata:
   name: mole
 spec:
-  version: v0.4.0
+  version: v0.5.0
   homepage: https://github.com/justin-tahara/kubectl-mole
   shortDescription: Watch workloads settle and explain what broke
   description: |
@@ -26,41 +26,41 @@ spec:
       matchLabels:
         os: linux
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_linux_amd64.tar.gz
-    sha256: 91bb2d3591ed176036f40975cb4c40c054ac98bc0eb5a43514a1201073630d51
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.5.0/kubectl-mole_v0.5.0_linux_amd64.tar.gz
+    sha256: 396cd08fc7b3ec4a7185a0b0bace2573b1867f9f5783779d372a2ab4dc913068
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: linux
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_linux_arm64.tar.gz
-    sha256: 8ad4f2f39c7f2a55f10e769b0534da10aff254569b06d5638dbfadcca5b18581
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.5.0/kubectl-mole_v0.5.0_linux_arm64.tar.gz
+    sha256: 5b39a62d54ad0562f65cfcbb6090211514266317d79b1bd7c495cff72fdbeec1
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: darwin
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_darwin_amd64.tar.gz
-    sha256: 3fa7216b878f90456836cf5ad3834da4cd1f08ee8f46d3c511c2567630ac818d
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.5.0/kubectl-mole_v0.5.0_darwin_amd64.tar.gz
+    sha256: 4d91d1125c8f43a65ea5a456bf2de2b87c9b97560a60e2ec57ff0742d89b3b08
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: darwin
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_darwin_arm64.tar.gz
-    sha256: 8486506f4437bcbfca9c4006c65c86218f2748f90b6006dc1737aab82dfdec4b
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.5.0/kubectl-mole_v0.5.0_darwin_arm64.tar.gz
+    sha256: 25a120559de3318b9f9481ae36d7c9aecc71cc7334afa7362cb620ce3f1780d5
     bin: kubectl-mole
   - selector:
       matchLabels:
         os: windows
         arch: amd64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_windows_amd64.zip
-    sha256: 374e35a4e82d52786fcd1138e0f9f18b3e457749682841de7eb5c90088cd9e96
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.5.0/kubectl-mole_v0.5.0_windows_amd64.zip
+    sha256: fe55dda84edad2a2fa94e7210e1177903677c87fa072c5b15a91059696bb4cd2
     bin: kubectl-mole.exe
   - selector:
       matchLabels:
         os: windows
         arch: arm64
-    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.4.0/kubectl-mole_v0.4.0_windows_arm64.zip
-    sha256: a27833d8b8ec0375af9676f3eb4b353249098a23840dab35a11083708a64bcac
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.5.0/kubectl-mole_v0.5.0_windows_arm64.zip
+    sha256: a52e909626319ac0ed5500156500207687f6d9bbfc95d960d72089868bde46cd
     bin: kubectl-mole.exe

--- a/plugins/mole.yaml
+++ b/plugins/mole.yaml
@@ -1,0 +1,66 @@
+# The krew manifest for the initial krew-index submission (copy to
+# plugins/mole.yaml in a krew-index fork). After the plugin is accepted,
+# krew-release-bot keeps the index current from .krew.yaml on each release.
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: mole
+spec:
+  version: v0.2.2
+  homepage: https://github.com/justin-tahara/kubectl-mole
+  shortDescription: Watch workloads settle and explain what broke
+  description: |
+    mole watches Kubernetes workloads until they settle, then emits one
+    deterministic structured verdict: what happened, why it failed
+    (signature, cause, ownership chain, evidence), and a meaningful exit
+    code (0 settled, 1 failed, 2 still progressing, 3 permission denied,
+    4 nothing matched). With no TYPE/NAME argument it fans out over every
+    Deployment, StatefulSet, and DaemonSet in scope and returns one verdict
+    for the whole fleet. Read-only, no LLM, informer-based.
+  caveats: |
+    mole needs read access to workloads, pods, and events. A minimal
+    ClusterRole ships with the repo:
+    https://github.com/justin-tahara/kubectl-mole/blob/main/deploy/rbac.yaml
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_linux_amd64.tar.gz
+    sha256: 0353dfa08c028c5c28fac14a5c34862ad6a868f7ac8d8d3d72714fecfc6f7e56
+    bin: kubectl-mole
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_linux_arm64.tar.gz
+    sha256: 508308c8c9ac655b4fcf0cb276bbe5eea8fb36c8ee82b407fdca7210f772b9d3
+    bin: kubectl-mole
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_darwin_amd64.tar.gz
+    sha256: 55d30796ae8128b05b761620f8b18f4307f5e5c9d03e7166f3ff53a5c8f86b37
+    bin: kubectl-mole
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_darwin_arm64.tar.gz
+    sha256: 906c377e4b1f82498eef30944cb70460f0fa933e3c50c90a53b8cb78d259f8b5
+    bin: kubectl-mole
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_windows_amd64.zip
+    sha256: a7797c1573a7506e8298d822ad7094ca0d768e0ab760d8fb4ec3530f314896e4
+    bin: kubectl-mole.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/justin-tahara/kubectl-mole/releases/download/v0.2.2/kubectl-mole_v0.2.2_windows_arm64.zip
+    sha256: eb7bc58c52320250fff6d36d55e23001407ed2381498d96f7917ee69e72b0d09
+    bin: kubectl-mole.exe


### PR DESCRIPTION
Adds **mole** — a read-only plugin that watches a workload (Deployment, StatefulSet, DaemonSet, Job, CronJob, Pod, or any namespaced custom resource) until it settles, then emits one deterministic structured verdict: what happened, the diagnosed cause with an ownership chain and evidence, and a meaningful exit code (settled / failed / still progressing / permission denied / nothing matched). No-argument mode fans out over every workload in scope and collapses identical causes into one entry.

- Repo: https://github.com/justin-tahara/kubectl-mole (Apache-2.0)
- Manifest validated with `kubectl krew install --manifest=plugins/mole.yaml` against the published v0.2.2 release assets (sha256s verified by krew)
- Name checked against the naming guide; `mole` is unused in the index
- Future version bumps are automated via krew-release-bot