### PR TITLE
Add node-df plugin

### DIFF
--- a/plugins/node-df.yaml
+++ b/plugins/node-df.yaml
@@ -1,0 +1,34 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: node-df
+spec:
+  version: v0.1.1
+  homepage: https://github.com/loktionovam/kubectl-node-df
+  shortDescription: Show node filesystem usage
+  description: |
+    Displays node filesystem and inode usage from the kubelet Summary API,
+    including eviction threshold headroom when kubelet configuration is
+    accessible.
+  caveats: |
+    Requires kubectl and jq.
+
+    The active Kubernetes credentials must allow proxy access to the kubelet
+    Summary API. Access to kubelet configz is optional and is used to display
+    eviction threshold headroom.
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: os
+        operator: In
+        values:
+        - darwin
+        - linux
+    uri: https://github.com/loktionovam/kubectl-node-df/archive/v0.1.1.tar.gz
+    sha256: 5523b70f8776202e157df5ca6add56435e9af79f446e42155857920cc58cbbd1
+    files:
+    - from: kubectl-node-df-*/kubectl-node_df
+      to: .
+    - from: kubectl-node-df-*/LICENSE
+      to: .
+    bin: kubectl-node_df


### PR DESCRIPTION
Adds node-df v0.1.1, a POSIX shell plugin that reports node filesystem and inode usage with optional eviction headroom.

Validated with validate-krew-manifest v0.4.5 and installed successfully from the published archive.