### PR TITLE
Add safe-rollout plugin

### DIFF
--- a/plugins/safe-rollout.yaml
+++ b/plugins/safe-rollout.yaml
@@ -1,0 +1,50 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: safe-rollout
+spec:
+  version: v0.2.0
+  homepage: https://github.com/HarnageaGabriel/kubectl-safe-rollout
+  shortDescription: Explain why a rollout failed or stalled
+  description: |
+    Use check for pre-flight analysis of a live workload and its namespace.
+    Use watch to observe a rollout and classify its failure cause. The tool
+    never modifies cluster state. Classification is deterministic; ambiguous
+    evidence is reported as an explicit *-undetermined cause with the observed
+    evidence, rather than as a guess presented as certain.
+  platforms:
+    - selector:
+        matchLabels:
+          os: linux
+          arch: amd64
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_linux_amd64.tar.gz
+      sha256: 1813299a28b771fae5daf5ffc8e15195336b8de3ee3ae47c6a800df950cd4d5f
+      bin: kubectl-safe_rollout
+    - selector:
+        matchLabels:
+          os: linux
+          arch: arm64
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_linux_arm64.tar.gz
+      sha256: 34c5ae5ddd41896cc06f74ea1fc24e99609c13d91ebe5b26634af17039166adf
+      bin: kubectl-safe_rollout
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: amd64
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_darwin_amd64.tar.gz
+      sha256: 87c4daa03aa429ada8e40a64e75b3816bf832c32e3372287ad06c350ebd0e6d1
+      bin: kubectl-safe_rollout
+    - selector:
+        matchLabels:
+          os: darwin
+          arch: arm64
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_darwin_arm64.tar.gz
+      sha256: fb3beb4f06d8f22dddcbafa28040a8130b5da3ecdaf133fec5dc7d1ad9af245b
+      bin: kubectl-safe_rollout
+    - selector:
+        matchLabels:
+          os: windows
+          arch: amd64
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_windows_amd64.zip
+      sha256: 094545a64b7647cfe8dcbc24a164daeb8a7b7f714c1adadad99fd6069b63427e
+      bin: kubectl-safe_rollout.exe

--- a/plugins/safe-rollout.yaml
+++ b/plugins/safe-rollout.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe-rollout
 spec:
-  version: v0.2.0
+  version: v0.3.0
   homepage: https://github.com/HarnageaGabriel/kubectl-safe-rollout
   shortDescription: Explain why a rollout failed or stalled
   description: |
@@ -17,34 +17,34 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_linux_amd64.tar.gz
-      sha256: 1813299a28b771fae5daf5ffc8e15195336b8de3ee3ae47c6a800df950cd4d5f
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_linux_amd64.tar.gz
+      sha256: bb3ae2fcb27b3d114f0ad8823a2674892b475043d64bdba1a18a229c39ff8519
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_linux_arm64.tar.gz
-      sha256: 34c5ae5ddd41896cc06f74ea1fc24e99609c13d91ebe5b26634af17039166adf
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_linux_arm64.tar.gz
+      sha256: 0ed8308863a15f5929c02f588f985aba51d1dcc727b04ee501668d0ddce3bd74
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_darwin_amd64.tar.gz
-      sha256: 87c4daa03aa429ada8e40a64e75b3816bf832c32e3372287ad06c350ebd0e6d1
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_darwin_amd64.tar.gz
+      sha256: af1b4aaa55b0962e8e5b3e8807740d5f398a1b4ad12c3f3b5957ed507cf66d27
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_darwin_arm64.tar.gz
-      sha256: fb3beb4f06d8f22dddcbafa28040a8130b5da3ecdaf133fec5dc7d1ad9af245b
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_darwin_arm64.tar.gz
+      sha256: 29fd512864d1e2f3d4f6ae9e20fc8121ede0f63197541ffaad9c5c081c70733c
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.2.0/kubectl-safe_rollout_v0.2.0_windows_amd64.zip
-      sha256: 094545a64b7647cfe8dcbc24a164daeb8a7b7f714c1adadad99fd6069b63427e
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_windows_amd64.zip
+      sha256: b3f704f8a640150512cb9cd5261f8160914bc3bf065e0fb60dba4081820fb6fc
       bin: kubectl-safe_rollout.exe

--- a/plugins/safe-rollout.yaml
+++ b/plugins/safe-rollout.yaml
@@ -3,7 +3,7 @@ kind: Plugin
 metadata:
   name: safe-rollout
 spec:
-  version: v0.3.0
+  version: v0.4.0
   homepage: https://github.com/HarnageaGabriel/kubectl-safe-rollout
   shortDescription: Explain why a rollout failed or stalled
   description: |
@@ -17,34 +17,34 @@ spec:
         matchLabels:
           os: linux
           arch: amd64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_linux_amd64.tar.gz
-      sha256: bb3ae2fcb27b3d114f0ad8823a2674892b475043d64bdba1a18a229c39ff8519
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.4.0/kubectl-safe_rollout_v0.4.0_linux_amd64.tar.gz
+      sha256: 6661eed47e22c0d065501361ea46b95fe4c6b7de4f5e2481db0a219fbeed5a72
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: linux
           arch: arm64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_linux_arm64.tar.gz
-      sha256: 0ed8308863a15f5929c02f588f985aba51d1dcc727b04ee501668d0ddce3bd74
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.4.0/kubectl-safe_rollout_v0.4.0_linux_arm64.tar.gz
+      sha256: 7178cee2950f69714fcf09f274320292fd6f1fedee04ddb2576e3a78e49d29fb
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: darwin
           arch: amd64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_darwin_amd64.tar.gz
-      sha256: af1b4aaa55b0962e8e5b3e8807740d5f398a1b4ad12c3f3b5957ed507cf66d27
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.4.0/kubectl-safe_rollout_v0.4.0_darwin_amd64.tar.gz
+      sha256: 30459ebc7b1777b2f835a2c112510e133bfa09302dcb98b2ecbd02c8a17e4d85
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: darwin
           arch: arm64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_darwin_arm64.tar.gz
-      sha256: 29fd512864d1e2f3d4f6ae9e20fc8121ede0f63197541ffaad9c5c081c70733c
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.4.0/kubectl-safe_rollout_v0.4.0_darwin_arm64.tar.gz
+      sha256: d43dfdf35406a6668bd7358a115dcff6efe2120897fc7500cf6dce3bee5cd541
       bin: kubectl-safe_rollout
     - selector:
         matchLabels:
           os: windows
           arch: amd64
-      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.3.0/kubectl-safe_rollout_v0.3.0_windows_amd64.zip
-      sha256: b3f704f8a640150512cb9cd5261f8160914bc3bf065e0fb60dba4081820fb6fc
+      uri: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/download/v0.4.0/kubectl-safe_rollout_v0.4.0_windows_amd64.zip
+      sha256: 546f0db49314608887244fb161870ce7504238e0b9d73895bdae8690f7c2db66
       bin: kubectl-safe_rollout.exe


### PR DESCRIPTION
Submitting `safe-rollout`, a plugin that explains why a rollout failed or stalled.

- `kubectl safe-rollout check <kind>/<name>` — pre-flight analysis of a live workload and the state of its namespace.
- `kubectl safe-rollout watch <kind>/<name>` — observes a rollout through the Watch API and, when it fails or stalls, classifies the cause from the evidence collected and proposes remediation.

The plugin only reads from the cluster; it has no mutating operation and no `--apply-fix`. Classification is deterministic and uses no language model: when the evidence confirms a rollout is stuck but cannot distinguish between the known causes of a category, the finding is reported with an explicit `*-undetermined` cause listing what was observed, rather than the most likely cause presented as certain.

Repository: https://github.com/HarnageaGabriel/kubectl-safe-rollout
Release: https://github.com/HarnageaGabriel/kubectl-safe-rollout/releases/tag/v0.2.0
License: Apache 2.0

### Naming

`safe-rollout` follows the naming guide: lowercase, hyphen-separated, no `kube-` prefix, and specific rather than a bare verb. It does not collide with an existing plugin name in the index.

### Verification performed

- `validate-krew-manifest` reports all 5 `spec.platforms` install cleanly.
- Installed locally from this manifest and run: `kubectl krew install --manifest=safe-rollout.yaml` followed by `kubectl safe-rollout version`, which reports `0.2.0` with the release commit.
- Each release archive contains the binary plus `LICENSE` and `README.md`.
- The published `sha256` values were taken from the release `checksums.txt` and verified against the downloaded archives.

The tool itself is exercised by 17 end-to-end scenarios against a kind cluster (Kubernetes v1.36.1, containerd 2.2), one per classified cause, plus one that asserts a slow-starting application completes with no finding at all.