### PR TITLE
Add multi-get plugin

### DIFF
--- a/plugins/multi-get.yaml
+++ b/plugins/multi-get.yaml
@@ -1,0 +1,60 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: multi-get
+spec:
+  version: v0.1.3
+  homepage: https://github.com/squatboy/multi-get
+  shortDescription: Query resources across namespaces
+  description: |
+    Query the same namespaced Kubernetes resource across multiple namespaces
+    and combine the results with namespace information.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/squatboy/multi-get/releases/download/v0.1.3/kubectl-multi-get_darwin_amd64.tar.gz
+    sha256: a0502f06038c5cf8c31239a8e6174ed488b919a8a4cab7931ef1990604aca1e8
+    bin: kubectl-multi-get
+    files:
+    - from: kubectl-multi-get
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/squatboy/multi-get/releases/download/v0.1.3/kubectl-multi-get_darwin_arm64.tar.gz
+    sha256: 2c9c853bbadb15d154dedb1ba39136a974a0ad1de529a15a6eff28609abfd1e6
+    bin: kubectl-multi-get
+    files:
+    - from: kubectl-multi-get
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/squatboy/multi-get/releases/download/v0.1.3/kubectl-multi-get_linux_amd64.tar.gz
+    sha256: bf31f4a5bf3ca5dfd1938bea6b9eb1ca2cf8fa57dd0c791082c57c6b9f967f76
+    bin: kubectl-multi-get
+    files:
+    - from: kubectl-multi-get
+      to: .
+    - from: LICENSE
+      to: .
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/squatboy/multi-get/releases/download/v0.1.3/kubectl-multi-get_linux_arm64.tar.gz
+    sha256: 9150eac1ad730e08c6929fbe5a5e7c574c8240a119e9d7567a691695ca249edb
+    bin: kubectl-multi-get
+    files:
+    - from: kubectl-multi-get
+      to: .
+    - from: LICENSE
+      to: .


### PR DESCRIPTION
This PR adds the initial Krew index entry for `multi-get`.

`multi-get` queries one namespaced Kubernetes resource across explicitly selected
namespaces, namespace-name matches, or all namespaces, and combines the
results with namespace information. It is available as `kubectl multi-get`.

- Source: https://github.com/squatboy/multi-get
- Release: https://github.com/squatboy/multi-get/releases/tag/v0.1.3
- License: MIT; `LICENSE` is included in every archive
- Platforms: darwin/{amd64,arm64}, linux/{amd64,arm64}
- The initial submission is a manual manifest; the source repository includes
  a `.krew.yaml` template for future release automation.

Validation performed before submission:

- `validate-krew-manifest` v0.4.5 passed all four declared platforms
- `kubectl krew install --manifest=plugins/multi-get.yaml` succeeded using the
  published v0.1.3 release assets
- `kubectl multi-get --help` confirmed the installed command and `LICENSE` was
  extracted with the plugin
- `make test`, `make vet`, and `make build` passed in the source repository
