### PR TITLE
atlas: upgrade to v1.5.2

### DIFF
--- a/plugins/atlas.yaml
+++ b/plugins/atlas.yaml
@@ -12,7 +12,7 @@ kind: Plugin
 metadata:
   name: atlas
 spec:
-  version: v1.5.1
+  version: v1.5.2
   homepage: https://github.com/lithastra/kubeatlas
   shortDescription: Visualize Kubernetes resource dependencies
   description: |
@@ -45,31 +45,31 @@ spec:
   platforms:
     - selector:
         matchLabels: { os: linux, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_linux_amd64.tar.gz
-      sha256: "0459a28f025a9371cadf9d4a43b41c48ed7429b8d578639062ea2a9c094a6f5e"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.2/kubectl-atlas_1.5.2_linux_amd64.tar.gz
+      sha256: "353ff48ae7a8dd09a6fb3833934befcab5a9e771f422da88b1d6cb30e7513494"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: linux, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_linux_arm64.tar.gz
-      sha256: "a7151808c54a27ca2d6edc363bf7fb7af829e8def17763133c3644c3b9153164"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.2/kubectl-atlas_1.5.2_linux_arm64.tar.gz
+      sha256: "99cd01dee1ace85ead109bf6d4f3402c7138f6d7bc0b819b89b7174ce8197f33"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_darwin_amd64.tar.gz
-      sha256: "a361da5cbc0978e5471a572b969642b7e618e84f91949979639dad7b8af47bdf"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.2/kubectl-atlas_1.5.2_darwin_amd64.tar.gz
+      sha256: "ea2fac6c89bd75e031be5aa5b8320411ad95ed98b1b0d19bbfede6a9d1846164"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: darwin, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_darwin_arm64.tar.gz
-      sha256: "fea7272228157860b5647bbb6858d00482cf3205194bffe5f466572461a1ffbb"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.2/kubectl-atlas_1.5.2_darwin_arm64.tar.gz
+      sha256: "68f59142d819a7728fd2cdc6d8ffbee20544987797a6c9403a6a55e77bb65c13"
       bin: kubectl-atlas
     - selector:
         matchLabels: { os: windows, arch: amd64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_windows_amd64.tar.gz
-      sha256: "777ca6f3564415e1ec4c70c93e048acee856870f44c605a372f8a6c21adb2261"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.2/kubectl-atlas_1.5.2_windows_amd64.tar.gz
+      sha256: "24b38105f0f3750ee252aab314adb4fcbe8bc91f0e48e1383473fe09d6a63c4b"
       bin: kubectl-atlas.exe
     - selector:
         matchLabels: { os: windows, arch: arm64 }
-      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.1/kubectl-atlas_1.5.1_windows_arm64.tar.gz
-      sha256: "c567c5175123179ab831b632cde31301b867df4659355255f6f6e1e9da99d613"
+      uri: https://github.com/lithastra/kubeatlas/releases/download/v1.5.2/kubectl-atlas_1.5.2_windows_arm64.tar.gz
+      sha256: "75be73faa8e5b8001cbb9399e6fcd272f23cee84222c8b42cb153f892e1c3617"
       bin: kubectl-atlas.exe


### PR DESCRIPTION
## Summary

- upgrade the `atlas` plugin from `v1.5.1` to `v1.5.2`
- update all six platform archive URLs
- update SHA-256 checksums from the published `v1.5.2` release

Release: https://github.com/lithastra/kubeatlas/releases/tag/v1.5.2

## Validation

- `validate-krew-manifest@v0.4.5`: structural validation passed, all selectors are used, no selectors overlap, and the first platform install completed
- anonymously downloaded all six release archives and verified every SHA-256 against the published `checksums.txt`
- confirmed every archive contains the manifest-declared `kubectl-atlas` / `kubectl-atlas.exe` entry
- ran the darwin/arm64 binary and confirmed `1.5.2` at commit `acb0ced4479f2d4ac3f0509ace1d5717ab4111b1`

The remaining validator platform installs are left to the upstream CI because the local GitHub CDN connection was exceptionally slow; the same archive bytes and entry paths were verified directly.