### PR TITLE
Add oskar plugin (Open Source Kubernetes Anomaly Radar)

### DIFF
--- a/plugins/oskar.yaml
+++ b/plugins/oskar.yaml
@@ -1,0 +1,103 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: oskar
+spec:
+  version: v0.2.1
+  homepage: https://github.com/alessandrocorsico/oskar
+  shortDescription: "Finds broken links: ghost endpoints, dead webhooks"
+  description: |
+    OSKAR (Open Source Kubernetes Anomaly Radar) performs a read-only scan of
+    the cluster and reports silent state inconsistencies: the broken links
+    between objects that raise no events and keep every dashboard green.
+
+    Checks: EndpointSlice entries pointing at pods that no longer exist or at
+    IPs the pod does not own (ghost endpoints); admission webhooks whose
+    backend Service is missing or has no ready endpoints; Ingresses and
+    OpenShift Routes referencing non-existent Services or ports; Services
+    whose selector matches no pods; TLS Secrets expired or about to expire;
+    Pods, Namespaces and PVCs stuck in Terminating; Released or Failed
+    PersistentVolumes; HorizontalPodAutoscalers whose scale target is gone.
+
+    Every finding carries a remediation hint. Output is a human-readable
+    table or JSON, and exit codes make it usable as a CI/CD gate. It needs
+    only list permissions; a check whose resources cannot be listed is
+    skipped with a notice, never run on empty data.
+  caveats: |
+    OSKAR is read-only and needs the "list" verb on the resources it
+    inspects. The certificate check lists Secrets of type kubernetes.io/tls
+    only; if your RBAC forbids access to Secrets, that single check can be
+    disabled and everything else keeps working.
+  platforms:
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    uri: https://github.com/alessandrocorsico/oskar/releases/download/v0.2.1/oskar_linux_amd64.tar.gz
+    sha256: 857d10b1d75bc6c2b843ca6250d89a4b8d8b0ab15bd880e37f7298c8d27eb416
+    files:
+    - from: oskar
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: oskar
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    uri: https://github.com/alessandrocorsico/oskar/releases/download/v0.2.1/oskar_linux_arm64.tar.gz
+    sha256: b1b34ac966b3d7aa85899a5d93bb682c024278bca10971a414fc23f86a1ce046
+    files:
+    - from: oskar
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: oskar
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    uri: https://github.com/alessandrocorsico/oskar/releases/download/v0.2.1/oskar_darwin_amd64.tar.gz
+    sha256: 0a39557ae7ef7a75e6df380e255f747460a05f94c5517baf08256ac2135638a6
+    files:
+    - from: oskar
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: oskar
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: arm64
+    uri: https://github.com/alessandrocorsico/oskar/releases/download/v0.2.1/oskar_darwin_arm64.tar.gz
+    sha256: b09144eb6a6d3935825732c241fd91f7566862fec32e45ab14c5b75e43c0830d
+    files:
+    - from: oskar
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: oskar
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    uri: https://github.com/alessandrocorsico/oskar/releases/download/v0.2.1/oskar_windows_amd64.zip
+    sha256: 28e88c093081f3f418b05055c45d096f780bd649b8169b93390abf49edd4ab94
+    files:
+    - from: oskar.exe
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: oskar.exe
+  - selector:
+      matchLabels:
+        os: windows
+        arch: arm64
+    uri: https://github.com/alessandrocorsico/oskar/releases/download/v0.2.1/oskar_windows_arm64.zip
+    sha256: 2f8c87e9a37b47f1cb4db7f3ef8ce394933ab69fa239f7a22421dae6dad55cf0
+    files:
+    - from: oskar.exe
+      to: "."
+    - from: LICENSE
+      to: "."
+    bin: oskar.exe


### PR DESCRIPTION
## New plugin: `oskar`

**Homepage:** https://github.com/alessandrocorsico/oskar
**Release:** https://github.com/alessandrocorsico/oskar/releases/tag/v0.2.1 (Apache-2.0, LICENSE extracted from every archive)

OSKAR (Open Source Kubernetes Anomaly Radar) is a read-only scanner for
*silent state inconsistencies*: the broken links between objects that raise
no events, trip no probes and keep every dashboard green. It lists the
resources it needs once, runs nine checks over that snapshot and prints a
table or JSON with a remediation hint per finding; exit codes make it a
CI/CD gate.

This is the resubmission of #6283, which was opened by krew-release-bot and
closed with review feedback. Changes since then: the manifest is submitted
by a human, and `description`/`caveats` no longer contain usage commands.

### Validation

- `kubectl krew install --manifest=plugins/oskar.yaml` on darwin/arm64 and
  linux/amd64, then `kubectl oskar version` / `kubectl oskar checks`.
- All six platforms' `sha256` values match the release's `checksums.txt`,
  which is signed with cosign (keyless) and shipped with an SBOM per archive.

### How oskar differs from similar plugins in the index

I tried the four plugins mentioned in the review. Summary:

| Plugin | What it does | Overlap with oskar |
|---|---|---|
| `doctor` | Control-plane component health, NotReady nodes, unclaimed PVs, lost PVCs, Deployments/ReplicaSets with zero available replicas, stale CronJobs, and "orphan endpoints" (legacy `Endpoints` objects with no addresses). YAML report. | Different angle on endpoints: `doctor` flags *empty* Endpoints; oskar cross-references each `EndpointSlice` address with the live Pod it targets and flags entries pointing at Pods that no longer exist or at IPs the Pod does not own (the traffic-blackholing case). No overlap on the other checks. |
| `popeye` | Best-practice linter/sanitizer with a score: resource limits, probes, RBAC, deprecations. | Complementary: `popeye` says whether objects are *well configured*; oskar says whether the *references between objects are intact right now*. |
| `tripwire` | Deep failure-chain analysis of admission webhooks: config → Service → EndpointSlice → Pods → TLS `caBundle`, plus PDBs and node spread. | Real overlap on one check: oskar's `dead-webhook` only reports webhooks whose backend Service is missing or has no ready endpoints. For a webhook-only deep dive `tripwire` goes further (certificates, PDBs, topology); oskar's value is breadth across nine object relationships and the CI-gate semantics. |
| `janitor` | Lists objects in a problematic state per type (unscheduled/unhealthy pods, failed Jobs, unclaimed PVs, pending PVCs). | `janitor` does not correlate objects with each other; every oskar check is a cross-object reference: slice → pod, webhook → Service → endpoints, Ingress/Route → Service → port, Service selector → pods, HPA → workload. |

Checks that, to my knowledge, none of the four covers: ghost endpoints by IP
mismatch, Ingress backends referencing missing Services or ports, OpenShift
Routes referencing missing Services, Services whose selector matches no
pods, orphaned HorizontalPodAutoscalers, TLS Secrets expired or expiring
within a window, Pods/Namespaces/PVCs stuck in Terminating beyond a
threshold.

Two design points that are also different from the plugins above:

- **Missing permissions never produce a false "all clear"**: each check
  declares the resources it reads; when a resource cannot be listed (RBAC,
  API group not served) the dependent checks are reported as *skipped*
  instead of running on empty data, and any other API failure aborts with a
  non-zero exit code.
- **Stable JSON contract** (`schemaVersion`, per-check status, a fingerprint
  per finding) meant for CI gates and dashboards, plus signed multi-arch
  releases and images.

### Naming

I read the naming guide and the suggestion in the review. I am keeping
`oskar` as the plugin name: it is the project's established name (repository,
image, documentation), the index already lists brand-named plugins in this
space (`popeye`, `janitor`, `tripwire`, `doctor`), and the short description
now states what it does ("Finds broken links: ghost endpoints, dead
webhooks"). Happy to reconsider if the maintainers prefer a descriptive
name.

